### PR TITLE
Fix ApplicationState sub state transfer

### DIFF
--- a/states/current_version.go
+++ b/states/current_version.go
@@ -8,18 +8,15 @@ import (
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
-	"github.com/spf13/cobra"
 )
 
-// CurrentVersionCommand returns command for show current-version.
-func CurrentVersionCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "current-version",
-		Run: func(_ *cobra.Command, args []string) {
-			fmt.Println("Current Version:", etcdversion.GetVersion())
-		},
-	}
-	return cmd
+type ShowCurrentVersionParam struct {
+	framework.ParamBase `use:"show current-version" desc:"display current Milvus Meta data version"`
+}
+
+// ShowCurrentVersionCommand returns command for show current-version.
+func (app *ApplicationState) ShowCurrentVersionCommand(ctx context.Context, p *ShowCurrentVersionParam) {
+	fmt.Println("Current Version:", etcdversion.GetVersion())
 }
 
 type setCurrentVersionParam struct {
@@ -35,7 +32,7 @@ func (p *setCurrentVersionParam) ParseArgs(args []string) error {
 	return nil
 }
 
-func (s *InstanceState) SetCurrentVersionCommand(ctx context.Context, param setCurrentVersionParam) {
+func (app *ApplicationState) SetCurrentVersionCommand(ctx context.Context, param setCurrentVersionParam) {
 	switch param.newVersion {
 	case models.LTEVersion2_1:
 		fallthrough
@@ -48,39 +45,4 @@ func (s *InstanceState) SetCurrentVersionCommand(ctx context.Context, param setC
 	default:
 		fmt.Println("Invalid version string:", param.newVersion)
 	}
-}
-
-// SetCurrentVersionCommand returns command for set current-version.
-func SetCurrentVersionCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "set",
-	}
-
-	subCmd := &cobra.Command{
-		Use: "current-version",
-		Run: func(_ *cobra.Command, args []string) {
-			if len(args) != 1 {
-				fmt.Println("invalid parameter numbers")
-				return
-			}
-
-			newVersion := args[0]
-			switch newVersion {
-			case models.LTEVersion2_1:
-				fallthrough
-			case "LTEVersion2_1":
-				etcdversion.SetVersion(models.LTEVersion2_1)
-			case models.GTEVersion2_2:
-				fallthrough
-			case "GTEVersion2_2":
-				etcdversion.SetVersion(models.GTEVersion2_2)
-			default:
-				fmt.Println("Invalid version string:", newVersion)
-			}
-		},
-	}
-
-	cmd.AddCommand(subCmd)
-
-	return cmd
 }


### PR DESCRIPTION
Change list:
- Fix sub state transfer might not work for multiple sub state attached
- Change `dry-mode`, `backup` and `current-version` commands to framework format
- Remove all deprecated `WithInsecure` grpc dial option
- Add `debug commands` utility command for debug current command tree

/kind improvement