### PR TITLE
Fix multi generation cmd logic error

### DIFF
--- a/framework/state.go
+++ b/framework/state.go
@@ -54,8 +54,12 @@ func (s *CmdState) SetLabel(label string) {
 
 // Spawn returns a child command connected to current state as parent.
 func (s *CmdState) Spawn(label string) *CmdState {
+	p := s
+	for p.parent != nil {
+		p = p.parent
+	}
 	return &CmdState{
-		parent: s,
+		parent: p,
 		label:  label,
 	}
 }


### PR DESCRIPTION
Use the root ancestor of `CmdState` to spawn in case of multiple generation caused missing commands
/kind improvement