### PR TITLE
Update the installation comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ go 1.18 or higher
 
 ### Install birdwatcher
 
-install with go command
-```shell
-go install github.com/milvus-io/birdwatcher
-```
+download source and run with go command
 
-or download source and run with go command
 ```shell
 git clone https://github.com/milvus-io/birdwatcher
 cd birdwatcher
-go build -o birdwatcher main.go
+go install
 ```
+
+tips: [As JimB notice in comments](https://stackoverflow.com/questions/69807151/go-install-github-com-dmacvicar-terraform-provider-libvirtlatest-shows-error):
+
+> If there are replace or exclude directives in the module, the correct installation method is to clone the source and install it.
 
 ## How to use
 


### PR DESCRIPTION
/kind improvement

fail to install by `go install xxx`
![image](https://github.com/milvus-io/birdwatcher/assets/21985684/23f9a93c-e14d-486f-849b-ac9a5a022936)

reason:  
> If there are replace or exclude directives in the module, the correct installation method is to clone the source and install it, there's no reason to recommend otherwise.

detail: https://stackoverflow.com/questions/69807151/go-install-github-com-dmacvicar-terraform-provider-libvirtlatest-shows-error