### PR TITLE
Keep tailing slash for kv operations

### DIFF
--- a/states/kv/utils.go
+++ b/states/kv/utils.go
@@ -1,0 +1,14 @@
+package kv
+
+import (
+	"path"
+	"strings"
+)
+
+func joinPath(parts ...string) string {
+	r := path.Join(parts...)
+	if len(parts) > 0 && strings.HasSuffix(parts[len(parts)-1], "/") {
+		r += "/"
+	}
+	return r
+}


### PR DESCRIPTION
Since `path.Join` will remove tailing slash, the newly added kv implementation will return some other kv values when prefix need this tailing slash.

Add a util function to keep this tailing slash and replace all `path.Join` in kv impl with it

Fix #213