### PR TITLE
Add Docker Build and Push Workflow for Tagged Commits

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,38 @@
+name: Docker Build and Push
+
+# This workflow is triggered on pushes(only tags) to the repository.
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            milvusdb/birdwatcher
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow designed to automate the Docker image building and pushing process for the MilvusDB/Birdwatcher project. The workflow triggers on new tags (formatted as 'v*') pushed to the repository and includes the following key steps:

1. Checkout the source code.
2. Generate Docker metadata including tags based on semantic versioning, and commit SHA.
3. Login to Docker Hub using secured credentials.
4. Build the Docker image from the current directory context and push it to Docker Hub, using the generated tags and labels.

This automation ensures that every tagged commit is accompanied by a corresponding Docker image, simplifying deployment and testing processes.