### PR TITLE
enhance: accelerate `load-backup` command speed

### DIFF
--- a/states/etcd_restore.go
+++ b/states/etcd_restore.go
@@ -219,7 +219,7 @@ func restoreEtcdFromBackV2(cli clientv3.KV, rd io.Reader, ph models.PartHeader) 
 	var wg sync.WaitGroup
 	workerNum := 3
 	wg.Add(workerNum)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < workerNum; i++ {
 		go func() {
 			defer wg.Done()
 			for batch := range ch {

--- a/states/load_backup.go
+++ b/states/load_backup.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/birdwatcher/configs"
@@ -71,8 +72,9 @@ func (s *disconnectState) LoadBackupCommand(ctx context.Context, p *LoadBackupPa
 		return err
 	}
 	fmt.Println("using data dir:", server.Config().Dir)
-	// TODO
+
 	nextState := getEmbedEtcdInstanceV2(server, s.config)
+	start := time.Now()
 	switch header.Version {
 	case 1:
 		fmt.Printf("Found backup version: %d, instance name :%s\n", header.Version, header.Instance)
@@ -95,6 +97,7 @@ func (s *disconnectState) LoadBackupCommand(ctx context.Context, p *LoadBackupPa
 		nextState.Close()
 		return err
 	}
+	fmt.Println("load backup cost", time.Since(start))
 	err = nextState.setupWorkDir(server.Config().Dir)
 	if err != nil {
 		fmt.Println("failed to setup workspace for backup file", err.Error())


### PR DESCRIPTION
Previously the `load-backup` command cost lots of time if there are numerous kv pairs in backup file.

This PR accelerate this procedure with
- Batching the KV entries before writing into embed etcd
- Use multiple workers to execute the put transaction

For 110k kv backup file, this could improve load time from about 5.5 minutes to around 15 seconds.

are numerous