### PR TITLE
fix: Get growing segment id when growing info is in GrowingSegments

### DIFF
--- a/states/distribution.go
+++ b/states/distribution.go
@@ -8,6 +8,7 @@ import (
 	commonpbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/commonpb"
 	querypbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/querypb"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
@@ -72,7 +73,7 @@ func GetDistributionCommand(cli clientv3.KV, basePath string) *cobra.Command {
 							continue
 						}
 						fmt.Printf("Leader view for channel: %s\n", lv.GetChannel())
-						growings := lv.GetGrowingSegmentIDs()
+						growings := lo.Uniq(lo.Union(lv.GetGrowingSegmentIDs(), lo.Keys(lv.GetGrowingSegments())))
 						fmt.Printf("Growing segments number: %d , ids: %v\n", len(growings), growings)
 					}
 


### PR DESCRIPTION
Growing segment could be in `GrowingSegments` or `GrowingSegmentIDs` field in LeaderView
This handles either case when get segment distribution