### PR TITLE
enhance: Add check-partition-key command to export partition key error data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.30
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/samber/lo v1.28.2
+	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/streamnative/pulsarctl v0.5.0
@@ -24,6 +25,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.4
 	go.etcd.io/etcd/client/v3 v3.5.4
 	go.etcd.io/etcd/server/v3 v3.5.4
+	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.46.0
 	google.golang.org/protobuf v1.30.0
@@ -67,6 +69,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
+	github.com/google/flatbuffers v2.0.5+incompatible // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
@@ -99,6 +102,7 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pierrec/lz4/v4 v4.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -110,7 +114,6 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
@@ -131,7 +134,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect

--- a/states/binlog.go
+++ b/states/binlog.go
@@ -1,0 +1,355 @@
+package states
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
+	"github.com/milvus-io/birdwatcher/storage"
+	"github.com/minio/minio-go/v7"
+	"github.com/samber/lo"
+)
+
+type ScanBinlogsParam struct {
+	framework.ParamBase `use:"test scan-binlogs"`
+	CollectionID        int64  `name:"collectionID"`
+	MinioAddress        string `name:"minioAddr" default:"" desc:"the minio address to override, leave empty to use milvus.yaml value"`
+	OutputFormat        string `name:"outputFmt" default:"stdout"`
+}
+
+func (s *InstanceState) TestScanBinlogsCommand(ctx context.Context, p *ScanBinlogsParam) error {
+	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, p.MinioAddress)
+	if err != nil {
+		return err
+	}
+
+	collection, err := common.GetCollectionByIDVersion(ctx, s.client, s.basePath, etcdversion.GetVersion(), p.CollectionID)
+	if err != nil {
+		return err
+	}
+	segments, err := common.ListSegmentsVersion(ctx, s.client, s.basePath, etcdversion.GetVersion(), func(segment *models.Segment) bool {
+		return segment.CollectionID == collection.ID
+	})
+	if err != nil {
+		return err
+	}
+	pkField, ok := collection.GetPKField()
+	if !ok {
+		return errors.New("collection does not has pk")
+	}
+	idField := lo.SliceToMap(collection.Schema.Fields, func(field models.FieldSchema) (int64, models.FieldSchema) {
+		return field.FieldID, field
+	})
+	var f *os.File
+	var pqWriter *storage.ParquetWriter
+	switch p.OutputFormat {
+	case "json":
+		f, err = os.Create(fmt.Sprintf("%d.json", collection.ID))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	case "parquet":
+		f, err = os.Create(fmt.Sprintf("%d.parquet", collection.ID))
+		if err != nil {
+			return err
+		}
+		pqWriter = storage.NewParquetWriter(collection)
+		defer pqWriter.Flush(f)
+	}
+	for _, segment := range segments {
+		deltalog, err := s.DownloadDeltalogs(ctx, minioClient, bucketName, rootPath, collection, segment)
+		if err != nil {
+			return err
+		}
+
+		s.ScanBinlogs(ctx, minioClient, bucketName, rootPath, collection, segment, func(readers map[int64]*storage.BinlogReader) {
+
+			iter, err := NewBinlogIterator(collection, readers)
+			if err != nil {
+				fmt.Println("failed to create iterator", err.Error())
+				return
+			}
+
+			err = iter.Range(func(rowID, ts int64, pk storage.PrimaryKey, data map[int64]any) error {
+				deleted := false
+				deltalog.Range(func(delPk storage.PrimaryKey, delTs uint64) bool {
+					if delPk.EQ(pk) && ts < int64(delTs) {
+						deleted = true
+						return false
+					}
+					return true
+				})
+				if deleted {
+					return nil
+				}
+				output := lo.MapKeys(data, func(v any, k int64) string {
+					return idField[k].Name
+				})
+				output[pkField.Name] = pk.GetValue()
+				switch p.OutputFormat {
+				case "stdout":
+					fmt.Println(output)
+				case "json":
+					bs, err := json.Marshal(output)
+					if err != nil {
+						fmt.Println(err.Error())
+						return err
+					}
+					f.Write(bs)
+					f.Write([]byte("\n"))
+				case "parquet":
+					data[0] = rowID
+					data[1] = ts
+					data[pkField.FieldID] = pk.GetValue()
+					writeParquetData(collection, pqWriter, rowID, ts, pk, output)
+				}
+				return nil
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+		})
+	}
+
+	return nil
+}
+
+// ScanBinlogs scans provided segment with delete record excluded.
+func (s *InstanceState) ScanBinlogs(ctx context.Context, minioClient *minio.Client, bucketName string, rootPath string, collection *models.Collection, segment *models.Segment, fn func(map[int64]*storage.BinlogReader)) {
+	pkField, has := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
+		return field.IsPrimaryKey
+	})
+	if !has {
+		return
+	}
+
+	pkFieldData, has := lo.Find(segment.GetBinlogs(), func(fieldBinlog *models.FieldBinlog) bool {
+		return fieldBinlog.FieldID == pkField.FieldID
+	})
+	if !has {
+		return
+	}
+
+	for idx := range pkFieldData.Binlogs {
+		field2Binlog := make(map[int64]*storage.BinlogReader)
+		for _, fieldBinlog := range segment.GetBinlogs() {
+			binlog := fieldBinlog.Binlogs[idx]
+			filePath := strings.Replace(binlog.LogPath, "ROOT_PATH", rootPath, -1)
+			object, err := minioClient.GetObject(ctx, bucketName, filePath, minio.GetObjectOptions{})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			reader, _, err := storage.NewBinlogReader(object)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			field2Binlog[fieldBinlog.FieldID] = reader
+		}
+
+		fn(field2Binlog)
+	}
+}
+
+type BinlogIterator struct {
+	schema  *models.CollectionSchema
+	readers map[int64]*storage.BinlogReader
+
+	rowIDs     []int64
+	timestamps []int64
+
+	pks  storage.PrimaryKeys
+	data map[int64][]any
+
+	rows int
+}
+
+func NewBinlogIterator(collection *models.Collection, readers map[int64]*storage.BinlogReader) (*BinlogIterator, error) {
+	rowIDReader := readers[0]
+	rowIDs, err := rowIDReader.NextInt64EventReader()
+	if err != nil {
+		return nil, err
+	}
+
+	tsReader := readers[1]
+	timestamps, err := tsReader.NextInt64EventReader()
+	if err != nil {
+		return nil, err
+	}
+
+	var pks storage.PrimaryKeys
+	pkField, _ := collection.GetPKField()
+	pkReader := readers[pkField.FieldID]
+	switch pkField.DataType {
+	case models.DataTypeInt64:
+		intPks, err := pkReader.NextInt64EventReader()
+		if err != nil {
+			return nil, err
+		}
+		iPks := storage.NewInt64PrimaryKeys(len(rowIDs))
+		iPks.AppendRaw(intPks...)
+		pks = iPks
+	case models.DataTypeVarChar:
+		strPks, err := pkReader.NextVarcharEventReader()
+		if err != nil {
+			return nil, err
+		}
+		sPks := storage.NewVarcharPrimaryKeys(len(rowIDs))
+		sPks.AppendRaw(strPks...)
+		pks = sPks
+	}
+
+	idField := lo.SliceToMap(collection.Schema.Fields, func(field models.FieldSchema) (int64, models.FieldSchema) {
+		return field.FieldID, field
+	})
+	data := make(map[int64][]any)
+	for fieldID, reader := range readers {
+		if fieldID < 100 || fieldID == pkField.FieldID {
+			continue
+		}
+		field := idField[fieldID]
+		column, err := readerToSlice(reader, field)
+		if err != nil {
+			return nil, err
+		}
+		data[fieldID] = column
+	}
+
+	return &BinlogIterator{
+		schema:  &collection.Schema,
+		readers: readers,
+
+		rowIDs:     rowIDs,
+		timestamps: timestamps,
+
+		pks:  pks,
+		data: data,
+
+		rows: len(rowIDs),
+	}, nil
+}
+
+func (iter *BinlogIterator) Range(fn func(rowID int64, ts int64, pk storage.PrimaryKey, data map[int64]any) error) error {
+	for i := 0; i < iter.rows; i++ {
+		row := make(map[int64]any)
+		for field, columns := range iter.data {
+			row[field] = columns[i]
+		}
+		err := fn(iter.rowIDs[i], iter.timestamps[i], iter.pks.Get(i), row)
+		if err != nil {
+			fmt.Println(err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func toAny[T any](v T, _ int) any { return v }
+
+func readerToSlice(reader *storage.BinlogReader, field models.FieldSchema) ([]any, error) {
+	switch field.DataType {
+	case models.DataTypeBool:
+		val, err := reader.NextBoolEventReader()
+		return lo.Map(val, toAny[bool]), err
+	case models.DataTypeInt8:
+		val, err := reader.NextInt8EventReader()
+		return lo.Map(val, toAny[int8]), err
+	case models.DataTypeInt16:
+		val, err := reader.NextInt16EventReader()
+		return lo.Map(val, toAny[int16]), err
+	case models.DataTypeInt32:
+		val, err := reader.NextInt32EventReader()
+		return lo.Map(val, toAny[int32]), err
+	case models.DataTypeInt64:
+		val, err := reader.NextInt64EventReader()
+		return lo.Map(val, toAny[int64]), err
+	case models.DataTypeFloat:
+		val, err := reader.NextFloat32EventReader()
+		return lo.Map(val, toAny[float32]), err
+	case models.DataTypeDouble:
+		val, err := reader.NextFloat64EventReader()
+		return lo.Map(val, toAny[float64]), err
+	case models.DataTypeVarChar, models.DataTypeString:
+		val, err := reader.NextVarcharEventReader()
+		return lo.Map(val, toAny[string]), err
+	case models.DataTypeJSON:
+		val, err := reader.NextByteSliceEventReader()
+		return lo.Map(val, toAny[[]byte]), err
+	case models.DataTypeFloatVector:
+		val, err := reader.NextFloatVectorEventReader()
+		return lo.Map(val, toAny[[]float32]), err
+	case models.DataTypeBinaryVector:
+		val, err := reader.NextBinaryVectorEventReader()
+		return lo.Map(val, toAny[[]byte]), err
+	default:
+		return nil, errors.Newf("data type %s not supported yet", field.DataType.String())
+	}
+}
+
+func writeParquetData(collection *models.Collection, pqWriter *storage.ParquetWriter, rowID, ts int64, pk storage.PrimaryKey, output map[string]any) error {
+	pkField, _ := collection.GetPKField()
+	for _, field := range collection.Schema.Fields {
+		var err error
+		switch field.FieldID {
+		case 0: // RowID
+			err = pqWriter.AppendInt64("RowID", rowID)
+		case 1: // Timestamp
+			err = pqWriter.AppendInt64("Timestamp", ts)
+		case pkField.FieldID:
+			switch pkField.DataType {
+			case models.DataTypeInt64:
+				err = pqWriter.AppendInt64(pkField.Name, pk.GetValue().(int64))
+			case models.DataTypeVarChar:
+				err = pqWriter.AppendString(pkField.Name, pk.GetValue().(string))
+			}
+		default:
+			err = writeParquetField(pqWriter, field, output[field.Name])
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeParquetField(pqWriter *storage.ParquetWriter, field models.FieldSchema, v any) error {
+	var err error
+	switch field.DataType {
+	case models.DataTypeBool:
+		pqWriter.AppendBool(field.Name, v.(bool))
+	case models.DataTypeInt8:
+		pqWriter.AppendInt8(field.Name, v.(int8))
+	case models.DataTypeInt16:
+		pqWriter.AppendInt16(field.Name, v.(int16))
+	case models.DataTypeInt32:
+		pqWriter.AppendInt32(field.Name, v.(int32))
+	case models.DataTypeInt64:
+		pqWriter.AppendInt64(field.Name, v.(int64))
+	case models.DataTypeFloat:
+		pqWriter.AppendFloat32(field.Name, v.(float32))
+	case models.DataTypeDouble:
+		pqWriter.AppendFloat64(field.Name, v.(float64))
+	case models.DataTypeVarChar, models.DataTypeString:
+		pqWriter.AppendString(field.Name, v.(string))
+	case models.DataTypeJSON:
+		pqWriter.AppendBytes(field.Name, v.([]byte))
+	case models.DataTypeFloatVector:
+		pqWriter.AppendFloatVector(field.Name, v.([]float32))
+	case models.DataTypeBinaryVector:
+		pqWriter.AppendBinaryVector(field.Name, v.([]byte))
+	default:
+		return errors.Newf("data type %v not supported", field.DataType)
+	}
+	return err
+}

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -195,9 +195,8 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 						case "stdout":
 							if p.StopIfErr {
 								return errQuickExit
-							} else {
-								fmt.Printf("PK %v partition does not follow partition key rule\n", pk)
 							}
+							fmt.Printf("PK %v partition does not follow partition key rule\n", pk)
 						case "json":
 							bs, err := json.Marshal(output)
 							if err != nil {

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -119,6 +119,9 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 		var collectionErrs int
 
 		for _, segment := range segments {
+			if segment.State == models.SegmentStateDropped || segment.State == models.SegmentStateSegmentStateNone {
+				continue
+			}
 			var errCnt int
 			err := func() error {
 				var f *os.File

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -1,0 +1,128 @@
+package states
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
+	"github.com/milvus-io/birdwatcher/storage"
+	"github.com/minio/minio-go/v7"
+	"github.com/samber/lo"
+)
+
+type CheckPartitionKeyParam struct {
+	framework.ParamBase `use:"check-partiton-key" desc:"check partition key field file"`
+	StopIfErr           bool   `name:"stopIfErr" default:"true"`
+	RootPath            string `name:"rootPath" default:"files"`
+}
+
+func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPartitionKeyParam) error {
+	collections, err := common.ListCollectionsVersion(ctx, s.client, s.basePath, etcdversion.GetVersion())
+	if err != nil {
+		return err
+	}
+
+	client, bucketName, err := getMinioAccess()
+	if err != nil {
+		return err
+	}
+
+	for _, collection := range collections {
+		partKeyField, enablePartKey := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
+			return field.IsPartitionKey
+		})
+		if !enablePartKey {
+			continue
+		}
+
+		partitions, err := common.ListCollectionPartitions(ctx, s.client, s.basePath, collection.ID)
+		if err != nil {
+			continue
+		}
+
+		partIdx := lo.SliceToMap(partitions, func(partition *models.Partition) (int64, uint32) {
+			splits := strings.Split(partition.Name, "_")
+			if len(splits) < 2 {
+				// continue
+			}
+			index, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
+			if err != nil {
+				return -1, 0
+			}
+			if (index >= int64(len(partitions))) || (index < 0) {
+				return -1, 0
+			}
+			return partition.ID, uint32(index)
+		})
+		idName := lo.SliceToMap(partitions, func(partition *models.Partition) (int64, string) {
+			return partition.ID, partition.Name
+		})
+
+		segments, err := common.ListSegmentsVersion(ctx, s.client, s.basePath, etcdversion.GetVersion(), func(segment *models.Segment) bool {
+			return segment.CollectionID == collection.ID
+		})
+
+		if err != nil {
+			return err
+		}
+
+		for _, segment := range segments {
+			binlogs := segment.GetBinlogs()
+			partKeyBinlog, ok := lo.Find(binlogs, func(binlog *models.FieldBinlog) bool {
+				return binlog.FieldID == partKeyField.FieldID
+			})
+			if !ok {
+				continue
+			}
+			targetIdx := partIdx[segment.PartitionID]
+			fmt.Printf("Segment: %d, Partition: %s, Target Index: %d\n", segment.ID, idName[segment.PartitionID], targetIdx)
+			for _, binlog := range partKeyBinlog.Binlogs {
+
+				filePath := strings.Replace(binlog.LogPath, "ROOT_PATH", p.RootPath, -1)
+				func(filePath string) {
+					result, err := client.GetObject(ctx, bucketName, filePath, minio.GetObjectOptions{})
+					if err != nil {
+						fmt.Println(err.Error())
+					}
+
+					bReader, _, err := storage.NewBinlogReader(result)
+					defer bReader.Close()
+					var target int64
+					switch partKeyField.DataType {
+					case models.DataTypeInt64:
+						var data []int64
+						for ; err == nil; data, err = bReader.NextInt64EventReader(result) {
+							for _, val := range data {
+								h, _ := Hash32Int64(val)
+								if (h % uint32(len(partitions))) != targetIdx {
+									target++
+								}
+							}
+						}
+
+					case models.DataTypeVarChar:
+						var data []string
+						for ; err == nil; data, err = bReader.NextVarcharEventReader(result) {
+							for _, val := range data {
+								h := HashString2Uint32(val)
+								if (h % uint32(len(partitions))) != targetIdx {
+									target++
+								}
+							}
+						}
+					}
+					if target > 0 {
+						fmt.Printf("Segment: %d, Path: %s, mismatch found: %d\n", segment.ID, filePath, target)
+					}
+				}(filePath)
+
+			}
+		}
+	}
+	return nil
+}

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -288,7 +288,7 @@ func (s *InstanceState) DownloadDeltalogs(ctx context.Context, client *minio.Cli
 
 			var deltaData *storage.DeltaData
 			for err == nil {
-				deltaData, err = reader.NextEventReader(schemapb.DataType_Int64)
+				deltaData, err = reader.NextEventReader(schemapb.DataType(pkField.DataType))
 				if err == nil {
 					err = data.Merge(deltaData)
 					if err != nil {

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -2,12 +2,17 @@ package states
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
 	"github.com/milvus-io/birdwatcher/storage"
@@ -18,7 +23,8 @@ import (
 type CheckPartitionKeyParam struct {
 	framework.ParamBase `use:"check-partiton-key" desc:"check partition key field file"`
 	StopIfErr           bool   `name:"stopIfErr" default:"true"`
-	RootPath            string `name:"rootPath" default:"files"`
+	MinioAddress        string `name:"minioAddr" default:"" desc:"the minio address to override, leave empty to use milvus.yaml value"`
+	OutputFormat        string `name:"outputFmt" default:"stdout"`
 }
 
 func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPartitionKeyParam) error {
@@ -27,10 +33,22 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 		return err
 	}
 
-	client, bucketName, err := getMinioAccess()
+	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, p.MinioAddress)
 	if err != nil {
 		return err
 	}
+
+	type suspectCollection struct {
+		collection   *models.Collection
+		partitions   []*models.Partition
+		partIndex    map[int64]uint32 // partition id to hash index
+		idName       map[int64]string
+		partKeyField models.FieldSchema
+		pkField      models.FieldSchema
+		tsField      models.FieldSchema
+	}
+
+	var suspectCollections []*suspectCollection
 
 	for _, collection := range collections {
 		partKeyField, enablePartKey := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
@@ -39,6 +57,12 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 		if !enablePartKey {
 			continue
 		}
+		pkField, _ := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
+			return field.IsPrimaryKey
+		})
+		tsField, _ := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
+			return field.FieldID == 1
+		})
 
 		partitions, err := common.ListCollectionPartitions(ctx, s.client, s.basePath, collection.ID)
 		if err != nil {
@@ -48,7 +72,7 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 		partIdx := lo.SliceToMap(partitions, func(partition *models.Partition) (int64, uint32) {
 			splits := strings.Split(partition.Name, "_")
 			if len(splits) < 2 {
-				// continue
+				return -1, 0
 			}
 			index, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
 			if err != nil {
@@ -63,6 +87,27 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 			return partition.ID, partition.Name
 		})
 
+		suspectCollections = append(suspectCollections, &suspectCollection{
+			collection:   collection,
+			partitions:   partitions,
+			partIndex:    partIdx,
+			idName:       idName,
+			partKeyField: partKeyField,
+			pkField:      pkField,
+			tsField:      tsField,
+		})
+	}
+
+	for _, susCol := range suspectCollections {
+		collection := susCol.collection
+		partitions := susCol.partitions
+		partKeyField := susCol.partKeyField
+		partIdx := susCol.partIndex
+		pkField, _ := collection.GetPKField()
+		idField := lo.SliceToMap(collection.Schema.Fields, func(field models.FieldSchema) (int64, models.FieldSchema) {
+			return field.FieldID, field
+		})
+
 		segments, err := common.ListSegmentsVersion(ctx, s.client, s.basePath, etcdversion.GetVersion(), func(segment *models.Segment) bool {
 			return segment.CollectionID == collection.ID
 		})
@@ -71,58 +116,168 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 			return err
 		}
 
-		for _, segment := range segments {
-			binlogs := segment.GetBinlogs()
-			partKeyBinlog, ok := lo.Find(binlogs, func(binlog *models.FieldBinlog) bool {
-				return binlog.FieldID == partKeyField.FieldID
-			})
-			if !ok {
-				continue
-			}
-			targetIdx := partIdx[segment.PartitionID]
-			fmt.Printf("Segment: %d, Partition: %s, Target Index: %d\n", segment.ID, idName[segment.PartitionID], targetIdx)
-			for _, binlog := range partKeyBinlog.Binlogs {
+		var collectionErrs int
 
-				filePath := strings.Replace(binlog.LogPath, "ROOT_PATH", p.RootPath, -1)
-				func(filePath string) {
-					result, err := client.GetObject(ctx, bucketName, filePath, minio.GetObjectOptions{})
+		for _, segment := range segments {
+			var errCnt int
+			err := func() error {
+				var f *os.File
+				var pqWriter *storage.ParquetWriter
+				switch p.OutputFormat {
+				case "json":
+					f, err = os.Create(fmt.Sprintf("%d-%d.json", collection.ID, segment.ID))
+					if err != nil {
+						return err
+					}
+				case "parquet":
+					f, err = os.Create(fmt.Sprintf("%d-%d.parquet", collection.ID, segment.ID))
+					if err != nil {
+						return err
+					}
+					pqWriter = storage.NewParquetWriter(collection)
+
+				}
+				deltalog, err := s.DownloadDeltalogs(ctx, minioClient, bucketName, rootPath, collection, segment)
+				if err != nil {
+					return err
+				}
+
+				s.ScanBinlogs(ctx, minioClient, bucketName, rootPath, collection, segment, func(readers map[int64]*storage.BinlogReader) {
+					targetIndex := partIdx[segment.PartitionID]
+					iter, err := NewBinlogIterator(collection, readers)
+					if err != nil {
+						fmt.Println("failed to create iterator", err.Error())
+						return
+					}
+
+					err = iter.Range(func(rowID, ts int64, pk storage.PrimaryKey, data map[int64]any) error {
+						deleted := false
+						deltalog.Range(func(delPk storage.PrimaryKey, delTs uint64) bool {
+							if delPk.EQ(pk) && ts < int64(delTs) {
+								deleted = true
+								return false
+							}
+							return true
+						})
+						if deleted {
+							return nil
+						}
+
+						partKeyValue := data[partKeyField.FieldID]
+						var hashVal uint32
+						switch partKeyField.DataType {
+						case models.DataTypeInt64:
+							hashVal, _ = Hash32Int64(partKeyValue.(int64))
+						case models.DataTypeVarChar, models.DataTypeString:
+							hashVal = HashString2Uint32(partKeyValue.(string))
+						default:
+							return errors.Newf("unexpected partition key field type %v", partKeyField.DataType)
+						}
+						if (hashVal % uint32(len(partitions))) == targetIndex {
+							return nil
+						}
+						errCnt++
+
+						output := lo.MapKeys(data, func(v any, k int64) string {
+							return idField[k].Name
+						})
+						output[pkField.Name] = pk.GetValue()
+						switch p.OutputFormat {
+						case "stdout":
+							fmt.Printf("PK %v partition does not follow partition key rule\n", pk)
+						case "json":
+							bs, err := json.Marshal(output)
+							if err != nil {
+								fmt.Println(err.Error())
+								return err
+							}
+							f.Write(bs)
+							f.Write([]byte("\n"))
+						case "parquet":
+							data[0] = rowID
+							data[1] = ts
+							data[pkField.FieldID] = pk.GetValue()
+							writeParquetData(collection, pqWriter, rowID, ts, pk, output)
+						}
+						return nil
+					})
 					if err != nil {
 						fmt.Println(err.Error())
 					}
+				})
+				return nil
+			}()
+			if err != nil {
+				return err
+			}
+			if errCnt > 0 {
+				fmt.Printf("Segment %d of collection %s find %d partition-key error\n", segment.ID, collection.Schema.Name, errCnt)
+				collectionErrs += errCnt
+			}
+		}
 
-					bReader, _, err := storage.NewBinlogReader(result)
-					defer bReader.Close()
-					var target int64
-					switch partKeyField.DataType {
-					case models.DataTypeInt64:
-						var data []int64
-						for ; err == nil; data, err = bReader.NextInt64EventReader(result) {
-							for _, val := range data {
-								h, _ := Hash32Int64(val)
-								if (h % uint32(len(partitions))) != targetIdx {
-									target++
-								}
-							}
-						}
+		fmt.Printf("Collection %s found %d partition key error\n", collection.Schema.Name, collectionErrs)
+	}
+	return nil
+}
 
-					case models.DataTypeVarChar:
-						var data []string
-						for ; err == nil; data, err = bReader.NextVarcharEventReader(result) {
-							for _, val := range data {
-								h := HashString2Uint32(val)
-								if (h % uint32(len(partitions))) != targetIdx {
-									target++
-								}
-							}
-						}
+// type TestDownloadDeltalogParam struct {
+// 	framework.ParamBase `use:"test download-deltalogs"`
+// 	RootPath            string `name:"rootPath" default:"files"`
+// }
+
+// func (s *InstanceState) TestDownloadDeltalogCommand(ctx context.Context, p *TestDownloadDeltalogParam) error {
+// 	// client, bucketName, _, err := s.GetMinioClientFromCfg(ctx) //getMinioAccess()
+// 	// if err != nil {
+// 	// 	return err
+// 	// }
+// 	// segments, err := common.ListSegmentsVersion(ctx, s.client, s.basePath, etcdversion.GetVersion())
+// 	// if err != nil {
+// 	// 	return err
+// 	// }
+// 	// for _, segment := range segments {
+// 	// 	// s.DownloadDeltalogs(ctx, client, bucketName, p.RootPath, collection, segment)
+// 	// }
+// 	return nil
+// }
+
+func (s *InstanceState) DownloadDeltalogs(ctx context.Context, client *minio.Client, bucket, rootPath string, collection *models.Collection, segment *models.Segment) (*storage.DeltaData, error) {
+	pkField, has := lo.Find(collection.Schema.Fields, func(field models.FieldSchema) bool {
+		return field.IsPrimaryKey
+	})
+	if !has {
+		return nil, errors.New("pk not found")
+	}
+	data := storage.NewDeltaData(schemapb.DataType(pkField.DataType), 0)
+	for _, delFieldBinlog := range segment.GetDeltalogs() {
+		for _, binlog := range delFieldBinlog.Binlogs {
+			filePath := strings.Replace(binlog.LogPath, "ROOT_PATH", rootPath, -1)
+			result, err := client.GetObject(ctx, bucket, filePath, minio.GetObjectOptions{})
+			if err != nil {
+				fmt.Println(err.Error())
+				continue
+			}
+
+			reader, err := storage.NewDeltalogReader(result)
+			if err != nil {
+				fmt.Println(err.Error())
+				continue
+			}
+
+			var deltaData *storage.DeltaData
+			for err == nil {
+				deltaData, err = reader.NextEventReader(schemapb.DataType_Int64)
+				if err == nil {
+					err = data.Merge(deltaData)
+					if err != nil {
+						return nil, err
 					}
-					if target > 0 {
-						fmt.Printf("Segment: %d, Path: %s, mismatch found: %d\n", segment.ID, filePath, target)
-					}
-				}(filePath)
-
+				}
+			}
+			if err != io.EOF {
+				return nil, err
 			}
 		}
 	}
-	return nil
+	return data, nil
 }

--- a/states/download_segment.go
+++ b/states/download_segment.go
@@ -67,11 +67,34 @@ func getDownloadSegmentCmd(cli clientv3.KV, basePath string) *cobra.Command {
 	return cmd
 }
 
-func getMinioWithInfo(addr string, ak, sk string, bucketName string) (*minio.Client, string, error) {
+func getMinioWithInfo(addr string, ak, sk string, bucketName string, secure bool) (*minio.Client, string, error) {
 	cred := credentials.NewStaticV4(ak, sk, "")
 	minioClient, err := minio.New(addr, &minio.Options{
 		Creds:  cred,
-		Secure: false,
+		Secure: secure,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	exists, err := minioClient.BucketExists(context.Background(), bucketName)
+	if !exists {
+		fmt.Printf("bucket %s not exists\n", bucketName)
+		return nil, "", err
+	}
+
+	if !exists {
+		fmt.Printf("Bucket not exist\n")
+		return nil, "", errors.New("bucket not exists")
+	}
+
+	return minioClient, bucketName, nil
+}
+
+func getMinioWithIAM(addr string, bucketName string, secure bool) (*minio.Client, string, error) {
+	cred := credentials.NewIAM("")
+	minioClient, err := minio.New(addr, &minio.Options{
+		Creds:  cred,
+		Secure: secure,
 	})
 	if err != nil {
 		return nil, "", err

--- a/states/etcd/common/segment.go
+++ b/states/etcd/common/segment.go
@@ -78,7 +78,7 @@ func getSegmentLazyFunc(cli clientv3.KV, basePath string, segment datapbv2.Segme
 		}
 
 		binlogs, err := f(func(segment datapbv2.SegmentInfo, fieldID int64, logID int64) string {
-			return fmt.Sprintf("files/insert_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
+			return fmt.Sprintf("ROOT_PATH/insert_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
 		})
 		if err != nil {
 			return nil, nil, nil, err
@@ -86,7 +86,7 @@ func getSegmentLazyFunc(cli clientv3.KV, basePath string, segment datapbv2.Segme
 
 		prefix = path.Join(basePath, "datacoord-meta", fmt.Sprintf("statslog/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID))
 		statslogs, err := f(func(segment datapbv2.SegmentInfo, fieldID int64, logID int64) string {
-			return fmt.Sprintf("files/stats_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
+			return fmt.Sprintf("ROOT_PATH/stats_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
 		})
 		if err != nil {
 			return nil, nil, nil, err
@@ -94,7 +94,7 @@ func getSegmentLazyFunc(cli clientv3.KV, basePath string, segment datapbv2.Segme
 
 		prefix = path.Join(basePath, "datacoord-meta", fmt.Sprintf("deltalog/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID))
 		deltalogs, err := f(func(segment datapbv2.SegmentInfo, fieldID int64, logID int64) string {
-			return fmt.Sprintf("files/delta_log/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, logID)
+			return fmt.Sprintf("ROOT_PATH/delta_log/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, logID)
 		})
 		if err != nil {
 			return nil, nil, nil, err

--- a/states/hash.go
+++ b/states/hash.go
@@ -1,0 +1,58 @@
+package states
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"unsafe"
+
+	"github.com/spaolacci/murmur3"
+)
+
+// Endian is type alias of binary.LittleEndian.
+// Milvus uses little endian by default.
+var Endian = binary.LittleEndian
+
+const substringLengthForCRC = 100
+
+// Hash32Bytes hashing a byte array to uint32
+func Hash32Bytes(b []byte) (uint32, error) {
+	h := murmur3.New32()
+	if _, err := h.Write(b); err != nil {
+		return 0, err
+	}
+	return h.Sum32() & 0x7fffffff, nil
+}
+
+// Hash32Uint64 hashing an uint64 nubmer to uint32
+func Hash32Uint64(v uint64) (uint32, error) {
+	// need unsafe package to get element byte size
+	/* #nosec G103 */
+	b := make([]byte, unsafe.Sizeof(v))
+	Endian.PutUint64(b, v)
+	return Hash32Bytes(b)
+}
+
+// Hash32Int64 hashing an int64 number to uint32
+func Hash32Int64(v int64) (uint32, error) {
+	return Hash32Uint64(uint64(v))
+}
+
+// Hash32String hashing a string to int64
+func Hash32String(s string) (int64, error) {
+	b := []byte(s)
+	v, err := Hash32Bytes(b)
+	if err != nil {
+		return 0, err
+	}
+	return int64(v), nil
+}
+
+// HashString2Uint32 hashing a string to uint32
+func HashString2Uint32(v string) uint32 {
+	subString := v
+	if len(v) > substringLengthForCRC {
+		subString = v[:substringLengthForCRC]
+	}
+
+	return crc32.ChecksumIEEE([]byte(subString))
+}

--- a/states/inspect_primary_key.go
+++ b/states/inspect_primary_key.go
@@ -93,7 +93,7 @@ func getInspectPKCmd(cli clientv3.KV, basePath string) *cobra.Command {
 							fmt.Println("fail to create binlog reader:", err.Error())
 							continue
 						}
-						ids, err := r.NextInt64EventReader(f)
+						ids, err := r.NextInt64EventReader()
 						if err != nil {
 							fmt.Println("faild to read next event:", err.Error())
 							continue

--- a/states/inspect_primary_key.go
+++ b/states/inspect_primary_key.go
@@ -93,7 +93,7 @@ func getInspectPKCmd(cli clientv3.KV, basePath string) *cobra.Command {
 							fmt.Println("fail to create binlog reader:", err.Error())
 							continue
 						}
-						ids, err := r.NextEventReader(f)
+						ids, err := r.NextInt64EventReader(f)
 						if err != nil {
 							fmt.Println("faild to read next event:", err.Error())
 							continue

--- a/states/minio.go
+++ b/states/minio.go
@@ -1,0 +1,95 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	rootcoordpbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/rootcoordpb"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/minio/minio-go/v7"
+	"github.com/samber/lo"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type TestMinioCfgParam struct {
+	framework.ParamBase `use:"test-minio-cfg"`
+	// *MinioConnectParam
+	MinioAddress  string `name:"minioAddress"`
+	MinioPasswd   string `name:"minioPassword"`
+	MinioUserName string `name:"minioUsername"`
+}
+
+type MinioConnectParam struct {
+	MinioAddress  string `name:"minioAddress"`
+	MinioPasswd   string `name:"minioPassword"`
+	MinioUserName string `name:"minioUsername"`
+}
+
+func (s *InstanceState) TestMinioCfgCommand(ctx context.Context, p *TestMinioCfgParam) error {
+	fmt.Println(p)
+	_, _, _, err := s.GetMinioClientFromCfg(ctx, "")
+	return err
+}
+
+func (s *InstanceState) GetMinioClientFromCfg(ctx context.Context, minioAddr string) (client *minio.Client, bucketName, rootPath string, err error) {
+	sessions, err := common.ListSessions(s.client, s.basePath)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	session, found := lo.Find(sessions, func(session *models.Session) bool {
+		return session.ServerName == "rootcoord"
+	})
+
+	if !found {
+		return nil, "", "", errors.New("rootcoord session not found")
+	}
+
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	}
+
+	conn, err := grpc.DialContext(ctx, session.Address, opts...)
+	if err != nil {
+		return nil, "", "", errors.New("find to connect to rootcoord")
+	}
+	source := rootcoordpbv2.NewRootCoordClient(conn)
+
+	configurations, err := getConfiguration(ctx, source, session.ServerID)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	var addr string
+	var port string
+	var ak, sk string
+
+	for _, config := range configurations {
+		switch config.GetKey() {
+		case "minio.address":
+			addr = config.GetValue()
+		case "minio.port":
+			port = config.GetValue()
+		case "minio.bucketname":
+			bucketName = config.GetValue()
+		case "minio.rootpath":
+			rootPath = config.GetValue()
+		case "minio.secretaccesskey":
+			sk = config.GetValue()
+		case "minio.accesskeyid":
+			ak = config.GetValue()
+		}
+	}
+
+	client, _, err = getMinioWithInfo(fmt.Sprintf("%s:%s", addr, port), ak, sk, bucketName)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	return client, bucketName, rootPath, nil
+}

--- a/states/minio.go
+++ b/states/minio.go
@@ -94,7 +94,7 @@ func (s *InstanceState) GetMinioClientFromCfg(ctx context.Context, minioAddr str
 		}
 	}
 
-	if useSSL == "tre" {
+	if useSSL == "true" {
 		secure = true
 	}
 

--- a/storage/binlog_reader.go
+++ b/storage/binlog_reader.go
@@ -1,11 +1,15 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 
-	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/parquet"
+	"github.com/apache/arrow/go/v8/parquet/file"
+	"github.com/samber/lo"
 )
 
 const (
@@ -13,8 +17,15 @@ const (
 	MagicNumber int32 = 0xfffabc
 )
 
+type ReadSeeker interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}
+
 // BinlogReader from Milvus.
 type BinlogReader struct {
+	reader io.Reader
 }
 
 type descriptorEvent struct {
@@ -22,8 +33,10 @@ type descriptorEvent struct {
 	descriptorEventData
 }
 
-func NewBinlogReader(f io.Reader) (*BinlogReader, descriptorEvent, error) {
-	reader := &BinlogReader{}
+func NewBinlogReader(f ReadSeeker) (*BinlogReader, descriptorEvent, error) {
+	reader := &BinlogReader{
+		reader: f,
+	}
 	var de descriptorEvent
 	var err error
 
@@ -38,57 +51,67 @@ func NewBinlogReader(f io.Reader) (*BinlogReader, descriptorEvent, error) {
 	return reader, de, nil
 }
 
+// NextInt16EventReader returns next reader for the events.
+func (reader *BinlogReader) NextBoolEventReader() ([]bool, error) {
+	return readData[bool, *file.BooleanColumnChunkReader](reader.reader, 0)
+}
+
+// NextInt16EventReader returns next reader for the events.
+func (reader *BinlogReader) NextInt8EventReader() ([]int8, error) {
+	return readDataTrans[int32, int8, *file.Int32ColumnChunkReader](reader.reader, 0, func(v int32) int8 { return int8(v) })
+}
+
+// NextInt16EventReader returns next reader for the events.
+func (reader *BinlogReader) NextInt16EventReader() ([]int16, error) {
+	return readDataTrans[int32, int16, *file.Int32ColumnChunkReader](reader.reader, 0, func(v int32) int16 { return int16(v) })
+}
+
+// NextInt32EventReader returns next reader for the events.
+func (reader *BinlogReader) NextInt32EventReader() ([]int32, error) {
+	return readData[int32, *file.Int32ColumnChunkReader](reader.reader, 0)
+}
+
 // NextInt64EventReader returns next reader for the events.
-func (reader *BinlogReader) NextInt64EventReader(f io.Reader) ([]int64, error) {
-	eventReader := newEventReader()
-	header, err := eventReader.readHeader(f)
-	if err != nil {
-		return nil, err
-	}
-	insertEventData, err := readInsertEventData(f)
-	if err != nil {
-		return nil, err
-	}
-
-	next := int(header.EventLength - header.GetMemoryUsageInBytes() - insertEventData.GetEventDataFixPartSize())
-
-	data := make([]byte, next)
-	io.ReadFull(f, data)
-
-	pr, err := NewParquetPayloadReader(schemapb.DataType_Int64, data)
-	if err != nil {
-		return nil, err
-	}
-
-	return pr.GetInt64sFromPayload()
+func (reader *BinlogReader) NextInt64EventReader() ([]int64, error) {
+	return readData[int64, *file.Int64ColumnChunkReader](reader.reader, 0)
 }
 
-func (reader *BinlogReader) NextVarcharEventReader(f io.Reader) ([]string, error) {
-	eventReader := newEventReader()
-	header, err := eventReader.readHeader(f)
-	if err != nil {
-		return nil, err
-	}
-	insertEventData, err := readInsertEventData(f)
-	if err != nil {
-		return nil, err
-	}
-
-	next := int(header.EventLength - header.GetMemoryUsageInBytes() - insertEventData.GetEventDataFixPartSize())
-
-	data := make([]byte, next)
-	io.ReadFull(f, data)
-
-	pr, err := NewParquetPayloadReader(schemapb.DataType_Int64, data)
-	if err != nil {
-		return nil, err
-	}
-
-	return pr.GetStringFromPayload()
-
+func (reader *BinlogReader) NextFloat32EventReader() ([]float32, error) {
+	return readData[float32, *file.Float32ColumnChunkReader](reader.reader, 0)
 }
 
-func (reader *BinlogReader) readMagicNumber(f io.Reader) (int32, error) {
+func (reader *BinlogReader) NextFloat64EventReader() ([]float64, error) {
+	return readData[float64, *file.Float64ColumnChunkReader](reader.reader, 0)
+}
+
+func (reader *BinlogReader) NextVarcharEventReader() ([]string, error) {
+	return readDataTrans[parquet.ByteArray, string, *file.ByteArrayColumnChunkReader](reader.reader, 0, func(v parquet.ByteArray) string {
+		return v.String()
+	})
+}
+
+func (reader *BinlogReader) NextByteSliceEventReader() ([][]byte, error) {
+	return readDataTrans[parquet.ByteArray, []byte, *file.ByteArrayColumnChunkReader](reader.reader, 0, func(v parquet.ByteArray) []byte {
+		return v
+	})
+}
+
+func (reader *BinlogReader) NextBinaryVectorEventReader() ([][]byte, error) {
+	return readDataTrans[parquet.FixedLenByteArray, []byte, *file.FixedLenByteArrayColumnChunkReader](reader.reader, 0, func(v parquet.FixedLenByteArray) []byte {
+		return v
+	})
+}
+
+func (reader *BinlogReader) NextFloatVectorEventReader() ([][]float32, error) {
+	return readDataTrans[parquet.FixedLenByteArray, []float32, *file.FixedLenByteArrayColumnChunkReader](reader.reader, 0, func(v parquet.FixedLenByteArray) []float32 {
+		dim := v.Len() / 4
+		vector := make([]float32, dim)
+		copy(arrow.Float32Traits.CastToBytes(vector), v)
+		return vector
+	})
+}
+
+func (reader *BinlogReader) readMagicNumber(f ReadSeeker) (int32, error) {
 	var err error
 	var magicNumber int32
 	magicNumber, err = readMagicNumber(f)
@@ -96,7 +119,7 @@ func (reader *BinlogReader) readMagicNumber(f io.Reader) (int32, error) {
 	return magicNumber, err
 }
 
-func (reader *BinlogReader) readDescriptorEvent(f io.Reader) (descriptorEvent, error) {
+func (reader *BinlogReader) readDescriptorEvent(f ReadSeeker) (descriptorEvent, error) {
 	event, err := ReadDescriptorEvent(f)
 	if err != nil {
 		return event, err
@@ -104,7 +127,7 @@ func (reader *BinlogReader) readDescriptorEvent(f io.Reader) (descriptorEvent, e
 	return event, nil
 }
 
-func readMagicNumber(buffer io.Reader) (int32, error) {
+func readMagicNumber(buffer ReadSeeker) (int32, error) {
 	var magicNumber int32
 	if err := binary.Read(buffer, commonEndian, &magicNumber); err != nil {
 		return -1, err
@@ -117,7 +140,7 @@ func readMagicNumber(buffer io.Reader) (int32, error) {
 }
 
 // ReadDescriptorEvent reads a descriptorEvent from buffer
-func ReadDescriptorEvent(buffer io.Reader) (descriptorEvent, error) {
+func ReadDescriptorEvent(buffer ReadSeeker) (descriptorEvent, error) {
 	de := descriptorEvent{}
 	header, err := readDescriptorEventHeader(buffer)
 	if err != nil {
@@ -136,4 +159,45 @@ func ReadDescriptorEvent(buffer io.Reader) (descriptorEvent, error) {
 // Close closes the BinlogReader object.
 // It mainly calls the Close method of the internal events, reclaims resources, and marks itself as closed.
 func (reader *BinlogReader) Close() {
+}
+
+func readDataTrans[T any, U any, Reader interface {
+	file.ColumnChunkReader
+	ReadBatch(int64, []T, []int16, []int16) (int64, int, error)
+}](f io.Reader, colIdx int, trans func(T) U) ([]U, error) {
+	data, err := readData[T, Reader](f, colIdx)
+	if err != nil {
+		return nil, err
+	}
+	return lo.Map(data, func(v T, _ int) U {
+		return trans(v)
+	}), nil
+}
+
+func readData[T any, Reader interface {
+	file.ColumnChunkReader
+	ReadBatch(int64, []T, []int16, []int16) (int64, int, error)
+}](f io.Reader, colIdx int) ([]T, error) {
+
+	eventReader := newEventReader()
+	header, err := eventReader.readHeader(f)
+	if err != nil {
+		return nil, err
+	}
+	insertEventData, err := readInsertEventData(f)
+	if err != nil {
+		return nil, err
+	}
+
+	next := int(header.EventLength - header.GetMemoryUsageInBytes() - insertEventData.GetEventDataFixPartSize())
+
+	data := make([]byte, next)
+	io.ReadFull(f, data)
+
+	pqReader, err := file.NewParquetReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	return readPayloadAll[T, Reader](pqReader, colIdx)
 }

--- a/storage/binlog_reader_test.go
+++ b/storage/binlog_reader_test.go
@@ -15,7 +15,7 @@ func TestBinlogReader(t *testing.T) {
 	r, de, err := NewBinlogReader(f)
 	require.NoError(t, err)
 	fmt.Printf("%#v\n", de)
-	ids, err := r.NextEventReader(f)
+	ids, err := r.NextInt64EventReader(f)
 	require.NoError(t, err)
 
 	t.Log(len(ids))

--- a/storage/binlog_reader_test.go
+++ b/storage/binlog_reader_test.go
@@ -15,7 +15,7 @@ func TestBinlogReader(t *testing.T) {
 	r, de, err := NewBinlogReader(f)
 	require.NoError(t, err)
 	fmt.Printf("%#v\n", de)
-	ids, err := r.NextInt64EventReader(f)
+	ids, err := r.NextInt64EventReader()
 	require.NoError(t, err)
 
 	t.Log(len(ids))

--- a/storage/delta_data.go
+++ b/storage/delta_data.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
+)
+
+type DeltaData struct {
+	pks      PrimaryKeys
+	tss      []uint64
+	dataType schemapb.DataType
+
+	// stats
+	delRowCount int64
+	memSize     int64
+}
+
+func NewDeltaData(dataType schemapb.DataType, cap int) *DeltaData {
+	var pks PrimaryKeys
+	switch dataType {
+	case schemapb.DataType_Int64:
+		pks = NewInt64PrimaryKeys(cap)
+	case schemapb.DataType_VarChar:
+		pks = NewVarcharPrimaryKeys(cap)
+	default:
+		fmt.Println("data type", dataType.String(), "not supported")
+	}
+	return &DeltaData{
+		pks:      pks,
+		tss:      make([]uint64, 0, cap),
+		dataType: dataType,
+	}
+}
+
+func (dd *DeltaData) Append(pk PrimaryKey, ts uint64) {
+	dd.pks.MustAppend(pk)
+	dd.tss = append(dd.tss, ts)
+	dd.delRowCount++
+}
+
+func (dd *DeltaData) Range(f func(pk PrimaryKey, ts uint64) bool) {
+	for i := 0; i < int(dd.delRowCount); i++ {
+		if !f(dd.pks.Get(i), dd.tss[i]) {
+			return
+		}
+	}
+}
+
+func (dd *DeltaData) Merge(add *DeltaData) error {
+	if dd.dataType != add.dataType {
+		return errors.New("data type not match")
+	}
+	dd.pks.MustMerge(add.pks)
+	dd.tss = append(dd.tss, add.tss...)
+	dd.delRowCount += add.delRowCount
+	return nil
+}

--- a/storage/deltalog_reader.go
+++ b/storage/deltalog_reader.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
+)
+
+type DeltalogReader struct {
+	reader io.Reader
+}
+
+func NewDeltalogReader(f ReadSeeker) (*DeltalogReader, error) {
+	reader := &DeltalogReader{}
+
+	// var de descriptorEvent
+	var err error
+
+	_, err = readMagicNumber(f)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ReadDescriptorEvent(f)
+	if err != nil {
+		return nil, err
+	}
+	reader.reader = f
+	return reader, nil
+}
+
+type DeleteLog struct {
+	Pk     PrimaryKey `json:"pk"`
+	Ts     uint64     `json:"ts"`
+	PkType int64      `json:"pkType"`
+}
+
+func (dl *DeleteLog) UnmarshalJSON(data []byte) error {
+	var messageMap map[string]*json.RawMessage
+	err := json.Unmarshal(data, &messageMap)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(*messageMap["pkType"], &dl.PkType)
+	if err != nil {
+		return err
+	}
+
+	switch schemapb.DataType(dl.PkType) {
+	case schemapb.DataType_Int64:
+		dl.Pk = &Int64PrimaryKey{}
+	case schemapb.DataType_VarChar:
+		dl.Pk = &VarCharPrimaryKey{}
+	}
+
+	err = json.Unmarshal(*messageMap["pk"], dl.Pk)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(*messageMap["ts"], &dl.Ts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (dr *DeltalogReader) NextEventReader(dataType schemapb.DataType) (*DeltaData, error) {
+	eventReader := newEventReader()
+	header, err := eventReader.readHeader(dr.reader)
+	if err != nil {
+		return nil, err
+	}
+	ifed, err := readIndexFileEventData(dr.reader)
+	if err != nil {
+		return nil, err
+	}
+
+	next := header.EventLength - header.GetMemoryUsageInBytes() - ifed.GetEventDataFixPartSize()
+	data := make([]byte, next)
+	_, err = io.ReadFull(dr.reader, data)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, err := NewParquetPayloadReader(schemapb.DataType_String, data)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := pr.GetBytesSliceFromPayload(0)
+	if err != nil {
+		return nil, err
+	}
+	deltaData := NewDeltaData(dataType, len(entries))
+	var log DeleteLog
+	for _, entry := range entries {
+		err := json.Unmarshal(entry, &log)
+		if err != nil {
+			return nil, err
+		}
+		deltaData.Append(log.Pk, log.Ts)
+	}
+	return deltaData, nil
+}

--- a/storage/index_reader.go
+++ b/storage/index_reader.go
@@ -34,7 +34,6 @@ func (reader *IndexReader) NextEventReader(f *os.File, dataType schemapb.DataTyp
 	eventReader := newEventReader()
 	header, err := eventReader.readHeader(f)
 	if err != nil {
-		//return nil, err
 		return nil, err
 	}
 	ifed, err := readIndexFileEventData(f)
@@ -53,7 +52,7 @@ func (reader *IndexReader) NextEventReader(f *os.File, dataType schemapb.DataTyp
 	}
 	switch dataType {
 	case schemapb.DataType_String:
-		result, err := pr.GetStringFromPayload()
+		result, err := pr.GetStringFromPayload(0)
 		if err != nil {
 			fmt.Println(err.Error())
 			return nil, err
@@ -62,7 +61,7 @@ func (reader *IndexReader) NextEventReader(f *os.File, dataType schemapb.DataTyp
 			return []byte(data)
 		}), nil
 	case schemapb.DataType_Int8:
-		result, err := pr.GetBytesFromPayload()
+		result, err := pr.GetBytesFromPayload(0)
 		if err != nil {
 			fmt.Println(err.Error())
 			return nil, err

--- a/storage/parquet_reader.go
+++ b/storage/parquet_reader.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"github.com/apache/arrow/go/v8/parquet/file"
+	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
+)
+
+type ParquetReader struct {
+	reader *file.Reader
+}
+
+func NewParquetReader(colType schemapb.DataType, r ReadSeeker) (*ParquetReader, error) {
+	reader, err := file.NewParquetReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return &ParquetReader{
+		reader: reader,
+	}, nil
+}
+
+func (r *ParquetReader) Next() {
+	// r.reader.RowGroup(0).Column(0)
+}

--- a/storage/parquet_writer.go
+++ b/storage/parquet_writer.go
@@ -1,0 +1,192 @@
+package storage
+
+import (
+	"encoding/binary"
+	"io"
+	"math"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/apache/arrow/go/v8/parquet"
+	"github.com/apache/arrow/go/v8/parquet/compress"
+	"github.com/apache/arrow/go/v8/parquet/pqarrow"
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/samber/lo"
+)
+
+func ToArrowDataType(dataType models.DataType, dim int) arrow.DataType {
+	switch dataType {
+	case models.DataTypeBool:
+		return &arrow.BooleanType{}
+	case models.DataTypeInt8:
+		return &arrow.Int8Type{}
+	case models.DataTypeInt16:
+		return &arrow.Int16Type{}
+	case models.DataTypeInt32:
+		return &arrow.Int32Type{}
+	case models.DataTypeInt64:
+		return &arrow.Int64Type{}
+	case models.DataTypeFloat:
+		return &arrow.Float32Type{}
+	case models.DataTypeDouble:
+		return &arrow.Float64Type{}
+	case models.DataTypeString, models.DataTypeVarChar:
+		return &arrow.StringType{}
+	case models.DataTypeArray:
+		return &arrow.BinaryType{}
+	case models.DataTypeJSON:
+		return &arrow.BinaryType{}
+	case models.DataTypeBinaryVector:
+		return &arrow.FixedSizeBinaryType{
+			ByteWidth: dim / 8,
+		}
+	case models.DataTypeFloatVector:
+		return &arrow.FixedSizeBinaryType{
+			ByteWidth: dim * 4,
+		}
+	}
+	return nil
+}
+
+type ParquetWriter struct {
+	schema   *arrow.Schema
+	builders map[string]array.Builder
+	fields   map[string]arrow.Field
+}
+
+func NewParquetWriter(collection *models.Collection) *ParquetWriter {
+
+	fields := lo.Map(collection.Schema.Fields, func(field models.FieldSchema, _ int) arrow.Field {
+		dim, _ := field.GetDim()
+		return arrow.Field{
+			Name: field.Name,
+			Type: ToArrowDataType(field.DataType, int(dim)),
+		}
+	})
+
+	builders := lo.SliceToMap(fields, func(field arrow.Field) (string, array.Builder) {
+		return field.Name, array.NewBuilder(memory.DefaultAllocator, field.Type)
+	})
+	fieldMap := lo.SliceToMap(fields, func(field arrow.Field) (string, arrow.Field) {
+		return field.Name, field
+	})
+
+	schema := arrow.NewSchema(fields, nil)
+
+	return &ParquetWriter{
+		schema:   schema,
+		builders: builders,
+		fields:   fieldMap,
+	}
+}
+
+func (w *ParquetWriter) AppendBool(field string, v bool) error {
+	return AppendBuilder[bool, *array.BooleanBuilder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendInt8(field string, v int8) error {
+	return AppendBuilder[int8, *array.Int8Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendInt16(field string, v int16) error {
+	return AppendBuilder[int16, *array.Int16Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendInt32(field string, v int32) error {
+	return AppendBuilder[int32, *array.Int32Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendInt64(field string, v int64) error {
+	return AppendBuilder[int64, *array.Int64Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendFloat32(field string, v float32) error {
+	return AppendBuilder[float32, *array.Float32Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendFloat64(field string, v float64) error {
+	return AppendBuilder[float64, *array.Float64Builder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendString(field string, v string) error {
+	return AppendBuilder[string, *array.StringBuilder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendBytes(field string, v []byte) error {
+	return AppendBuilder[[]byte, *array.BinaryBuilder](field, w.builders, v)
+}
+
+func (w *ParquetWriter) AppendFloatVector(field string, vec []float32) error {
+	length := len(vec)
+	bytesLength := length * 4
+	bytesData := make([]byte, bytesLength)
+
+	for i := 0; i < length; i++ {
+		bytes := math.Float32bits(vec[i])
+		binary.LittleEndian.PutUint32(bytesData[i*4:], bytes)
+	}
+
+	return AppendBuilder[[]byte, *array.FixedSizeBinaryBuilder](field, w.builders, bytesData)
+}
+
+func (w *ParquetWriter) AppendBinaryVector(field string, vec []byte) error {
+	return AppendBuilder[[]byte, *array.FixedSizeBinaryBuilder](field, w.builders, vec)
+}
+
+func (w *ParquetWriter) Flush(writer io.Writer) error {
+
+	columns := make([]arrow.Column, 0, len(w.builders))
+	arrs := make([]arrow.Array, 0, len(w.builders))
+
+	rows := int64(0)
+	for field, builder := range w.builders {
+		rowCount := builder.Len()
+		if rows != 0 && rows != int64(rowCount) {
+			return errors.New("columns row count differs")
+		}
+		rows = int64(rowCount)
+		arr := builder.NewArray()
+		column := arrow.NewColumnFromArr(w.fields[field], arr)
+
+		arrs = append(arrs, arr)
+		columns = append(columns, column)
+	}
+
+	defer func() {
+		for _, arr := range arrs {
+			arr.Release()
+		}
+		for _, column := range columns {
+			column.Release()
+		}
+	}()
+
+	table := array.NewTable(w.schema, columns, rows)
+	defer table.Release()
+
+	props := parquet.NewWriterProperties(
+		parquet.WithCompression(compress.Codecs.Zstd),
+		parquet.WithCompressionLevel(3),
+	)
+	pqarrow.NewArrowWriterProperties()
+
+	return pqarrow.WriteTable(table, writer, 1024*1024*1024, props, pqarrow.NewArrowWriterProperties())
+}
+
+func AppendBuilder[T any, Builder interface {
+	AppendValues([]T, []bool)
+}](field string, builders map[string]array.Builder, v T) error {
+	b, ok := builders[field]
+	if !ok {
+		return errors.Newf("field %s builder not found", field)
+	}
+	builder, ok := b.(Builder)
+	if !ok {
+		return errors.Newf("field %s builder type not match", field)
+	}
+
+	builder.AppendValues([]T{v}, nil)
+	return nil
+}

--- a/storage/payload_reader.go
+++ b/storage/payload_reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 
+	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/parquet"
 	"github.com/apache/arrow/go/v8/parquet/file"
 	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
@@ -28,68 +29,115 @@ func NewParquetPayloadReader(colType schemapb.DataType, buf []byte) (*ParquetPay
 	return &ParquetPayloadReader{reader: reader, colType: colType}, nil
 }
 
-func (r *ParquetPayloadReader) GetInt64sFromPayload() ([]int64, error) {
-	if r.colType != schemapb.DataType_Int64 {
-		return nil, errors.New("data type not matched")
-	}
-
-	// looks weird
-	reader, ok := r.reader.RowGroup(0).Column(0).(*file.Int64ColumnChunkReader)
-	if !ok {
-		return nil, errors.New("parquet reader type not match")
-	}
-	numRows := r.reader.NumRows()
-
-	values := make([]int64, numRows)
-	total, valuesRead, err := reader.ReadBatch(numRows, values, nil, nil)
+func (r *ParquetPayloadReader) GetInt8FromPayLoad(colIdx int) ([]int8, error) {
+	data, err := readPayloadAll[int32, *file.Int32ColumnChunkReader](r.reader, colIdx)
 	if err != nil {
 		return nil, err
 	}
-
-	if total != numRows || valuesRead != int(numRows) {
-		return nil, errors.New("numRows not match")
-	}
-	return values, nil
-}
-
-func (r *ParquetPayloadReader) GetStringFromPayload() ([]string, error) {
-	reader, ok := r.reader.RowGroup(0).Column(0).(*file.ByteArrayColumnChunkReader)
-	if !ok {
-		return nil, errors.New("parquet reader type not match")
-	}
-
-	numRows := r.reader.NumRows()
-	values := make([]parquet.ByteArray, numRows)
-	total, valuesRead, err := reader.ReadBatch(numRows, values, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	if total != numRows || valuesRead != int(numRows) {
-		return nil, errors.New("numRows not match")
-	}
-
-	return lo.Map(values, func(ba parquet.ByteArray, _ int) string {
-		return ba.String()
+	return lo.Map(data, func(v int32, _ int) int8 {
+		return int8(v)
 	}), nil
 }
 
-func (r *ParquetPayloadReader) GetBytesFromPayload() ([]byte, error) {
-	reader, ok := r.reader.RowGroup(0).Column(0).(*file.Int32ColumnChunkReader)
-	if !ok {
-		return nil, errors.New("parquet reader type not match")
-	}
-
-	numRows := r.reader.NumRows()
-	values := make([]int32, numRows)
-	total, valuesRead, err := reader.ReadBatch(numRows, values, nil, nil)
+func (r *ParquetPayloadReader) GetInt16FromPayLoad(colIdx int) ([]int16, error) {
+	data, err := readPayloadAll[int32, *file.Int32ColumnChunkReader](r.reader, colIdx)
 	if err != nil {
 		return nil, err
 	}
-	if total != numRows || valuesRead != int(numRows) {
-		return nil, errors.New("numRows not match")
+	return lo.Map(data, func(v int32, _ int) int16 {
+		return int16(v)
+	}), nil
+}
+
+func (r *ParquetPayloadReader) GetInt32FromPayLoad(colIdx int) ([]int32, error) {
+	return readPayloadAll[int32, *file.Int32ColumnChunkReader](r.reader, colIdx)
+}
+
+func (r *ParquetPayloadReader) GetInt64sFromPayload(colIdx int) ([]int64, error) {
+	return readPayloadAll[int64, *file.Int64ColumnChunkReader](r.reader, colIdx)
+}
+
+func (r *ParquetPayloadReader) GetStringFromPayload(colIdx int) ([]string, error) {
+	byteArr, err := readPayloadAll[parquet.ByteArray, *file.ByteArrayColumnChunkReader](r.reader, colIdx)
+	if err != nil {
+		return nil, err
+	}
+	return lo.Map(byteArr, func(arr parquet.ByteArray, _ int) string {
+		return arr.String()
+	}), nil
+}
+
+func (r *ParquetPayloadReader) GetBytesFromPayload(colIdx int) ([]byte, error) {
+	data, err := readPayloadAll[int32, *file.Int32ColumnChunkReader](r.reader, colIdx)
+	if err != nil {
+		return nil, err
+	}
+	return lo.Map(data, func(v int32, _ int) byte {
+		return byte(v)
+	}), nil
+}
+
+func (r *ParquetPayloadReader) GetFloat32FromPayload(colIdx int) ([]float32, error) {
+	return readPayloadAll[float32, *file.Float32ColumnChunkReader](r.reader, colIdx)
+}
+
+func (r *ParquetPayloadReader) GetFloat64FromPayload(colIdx int) ([]float64, error) {
+	return readPayloadAll[float64, *file.Float64ColumnChunkReader](r.reader, colIdx)
+}
+
+func (r *ParquetPayloadReader) GetBytesSliceFromPayload(colIdx int) ([][]byte, error) {
+	byteArr, err := readPayloadAll[parquet.ByteArray, *file.ByteArrayColumnChunkReader](r.reader, colIdx)
+	if err != nil {
+		return nil, err
+	}
+	return lo.Map(byteArr, func(arr parquet.ByteArray, _ int) []byte {
+		return arr
+	}), nil
+}
+
+func (r *ParquetPayloadReader) GetFloatVectorFromPayload(colIdx int, dim int) ([][]float32, error) {
+	data, err := readPayloadAll[parquet.FixedLenByteArray, *file.FixedLenByteArrayColumnChunkReader](r.reader, colIdx)
+	if err != nil {
+		return nil, err
 	}
 
-	return lo.Map(values, func(ba int32, _ int) byte {
-		return byte(ba)
+	return lo.Map(data, func(v parquet.FixedLenByteArray, _ int) []float32 {
+		dim := v.Len() / 4
+		vector := make([]float32, dim)
+		copy(arrow.Float32Traits.CastToBytes(vector), v)
+		return vector
 	}), nil
+}
+
+func readPayloadAll[T any, Reader interface {
+	file.ColumnChunkReader
+	ReadBatch(int64, []T, []int16, []int16) (int64, int, error)
+}](r *file.Reader, colIdx int) ([]T, error) {
+
+	var rowCount int64
+	for i := 0; i < r.NumRowGroups(); i++ {
+		rowCount += r.RowGroup(i).NumRows()
+	}
+
+	result := make([]T, rowCount)
+
+	var offset int64
+	for i := 0; i < r.NumRowGroups(); i++ {
+		rowGroup := r.RowGroup(i)
+		groupCount := rowGroup.NumRows()
+
+		reader, ok := rowGroup.Column(colIdx).(Reader)
+		if !ok {
+			return nil, errors.New("column chunk reader conversion failed")
+		}
+		total, read, err := reader.ReadBatch(groupCount, result[offset:rowCount], nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if total != groupCount || int64(read) != groupCount {
+			return nil, errors.New("row count not matched")
+		}
+	}
+
+	return result, nil
 }

--- a/storage/primary_key.go
+++ b/storage/primary_key.go
@@ -1,0 +1,401 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/milvus-io/birdwatcher/proto/v2.2/schemapb"
+)
+
+type PrimaryKey interface {
+	GT(key PrimaryKey) bool
+	GE(key PrimaryKey) bool
+	LT(key PrimaryKey) bool
+	LE(key PrimaryKey) bool
+	EQ(key PrimaryKey) bool
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(data []byte) error
+	SetValue(interface{}) error
+	GetValue() interface{}
+	Type() schemapb.DataType
+	Size() int64
+}
+
+type Int64PrimaryKey struct {
+	Value int64 `json:"pkValue"`
+}
+
+func NewInt64PrimaryKey(v int64) *Int64PrimaryKey {
+	return &Int64PrimaryKey{
+		Value: v,
+	}
+}
+
+func (ip *Int64PrimaryKey) GT(key PrimaryKey) bool {
+	pk, ok := key.(*Int64PrimaryKey)
+	if !ok {
+		return false
+	}
+	if ip.Value > pk.Value {
+		return true
+	}
+
+	return false
+}
+
+func (ip *Int64PrimaryKey) GE(key PrimaryKey) bool {
+	pk, ok := key.(*Int64PrimaryKey)
+	if !ok {
+		return false
+	}
+	if ip.Value >= pk.Value {
+		return true
+	}
+
+	return false
+}
+
+func (ip *Int64PrimaryKey) LT(key PrimaryKey) bool {
+	pk, ok := key.(*Int64PrimaryKey)
+	if !ok {
+		return false
+	}
+
+	if ip.Value < pk.Value {
+		return true
+	}
+
+	return false
+}
+
+func (ip *Int64PrimaryKey) LE(key PrimaryKey) bool {
+	pk, ok := key.(*Int64PrimaryKey)
+	if !ok {
+		return false
+	}
+
+	if ip.Value <= pk.Value {
+		return true
+	}
+
+	return false
+}
+
+func (ip *Int64PrimaryKey) EQ(key PrimaryKey) bool {
+	pk, ok := key.(*Int64PrimaryKey)
+	if !ok {
+		return false
+	}
+
+	if ip.Value == pk.Value {
+		return true
+	}
+
+	return false
+}
+
+func (ip *Int64PrimaryKey) MarshalJSON() ([]byte, error) {
+	ret, err := json.Marshal(ip.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (ip *Int64PrimaryKey) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &ip.Value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ip *Int64PrimaryKey) SetValue(data interface{}) error {
+	value, ok := data.(int64)
+	if !ok {
+		return fmt.Errorf("wrong type value when setValue for Int64PrimaryKey")
+	}
+
+	ip.Value = value
+	return nil
+}
+
+func (ip *Int64PrimaryKey) Type() schemapb.DataType {
+	return schemapb.DataType_Int64
+}
+
+func (ip *Int64PrimaryKey) GetValue() interface{} {
+	return ip.Value
+}
+
+func (ip *Int64PrimaryKey) Size() int64 {
+	// 8 + reflect.ValueOf(Int64PrimaryKey).Type().Size()
+	return 16
+}
+
+type BaseStringPrimaryKey struct {
+	Value string
+}
+
+func (sp *BaseStringPrimaryKey) GT(key BaseStringPrimaryKey) bool {
+	return strings.Compare(sp.Value, key.Value) > 0
+}
+
+func (sp *BaseStringPrimaryKey) GE(key BaseStringPrimaryKey) bool {
+	return strings.Compare(sp.Value, key.Value) >= 0
+}
+
+func (sp *BaseStringPrimaryKey) LT(key BaseStringPrimaryKey) bool {
+	return strings.Compare(sp.Value, key.Value) < 0
+}
+
+func (sp *BaseStringPrimaryKey) LE(key BaseStringPrimaryKey) bool {
+	return strings.Compare(sp.Value, key.Value) <= 0
+}
+
+func (sp *BaseStringPrimaryKey) EQ(key BaseStringPrimaryKey) bool {
+	return strings.Compare(sp.Value, key.Value) == 0
+}
+
+func (sp *BaseStringPrimaryKey) MarshalJSON() ([]byte, error) {
+	ret, err := json.Marshal(sp.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (sp *BaseStringPrimaryKey) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &sp.Value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sp *BaseStringPrimaryKey) SetValue(data interface{}) error {
+	value, ok := data.(string)
+	if !ok {
+		return fmt.Errorf("wrong type value when setValue for StringPrimaryKey")
+	}
+
+	sp.Value = value
+	return nil
+}
+
+func (sp *BaseStringPrimaryKey) GetValue() interface{} {
+	return sp.Value
+}
+
+type VarCharPrimaryKey struct {
+	BaseStringPrimaryKey
+}
+
+func NewVarCharPrimaryKey(v string) *VarCharPrimaryKey {
+	return &VarCharPrimaryKey{
+		BaseStringPrimaryKey: BaseStringPrimaryKey{
+			Value: v,
+		},
+	}
+}
+
+func (vcp *VarCharPrimaryKey) GT(key PrimaryKey) bool {
+	pk, ok := key.(*VarCharPrimaryKey)
+	if !ok {
+		return false
+	}
+
+	return vcp.BaseStringPrimaryKey.GT(pk.BaseStringPrimaryKey)
+}
+
+func (vcp *VarCharPrimaryKey) GE(key PrimaryKey) bool {
+	pk, ok := key.(*VarCharPrimaryKey)
+	if !ok {
+		return false
+	}
+
+	return vcp.BaseStringPrimaryKey.GE(pk.BaseStringPrimaryKey)
+}
+
+func (vcp *VarCharPrimaryKey) LT(key PrimaryKey) bool {
+	pk, ok := key.(*VarCharPrimaryKey)
+	if !ok {
+		return false
+	}
+
+	return vcp.BaseStringPrimaryKey.LT(pk.BaseStringPrimaryKey)
+}
+
+func (vcp *VarCharPrimaryKey) LE(key PrimaryKey) bool {
+	pk, ok := key.(*VarCharPrimaryKey)
+	if !ok {
+		return false
+	}
+
+	return vcp.BaseStringPrimaryKey.LE(pk.BaseStringPrimaryKey)
+}
+
+func (vcp *VarCharPrimaryKey) EQ(key PrimaryKey) bool {
+	pk, ok := key.(*VarCharPrimaryKey)
+	if !ok {
+		return false
+	}
+
+	return vcp.BaseStringPrimaryKey.EQ(pk.BaseStringPrimaryKey)
+}
+
+func (vcp *VarCharPrimaryKey) Type() schemapb.DataType {
+	return schemapb.DataType_VarChar
+}
+
+func (vcp *VarCharPrimaryKey) Size() int64 {
+	return int64(8*len(vcp.Value) + 8)
+}
+
+func GenPrimaryKeyByRawData(data interface{}, pkType schemapb.DataType) (PrimaryKey, error) {
+	var result PrimaryKey
+	switch pkType {
+	case schemapb.DataType_Int64:
+		result = &Int64PrimaryKey{
+			Value: data.(int64),
+		}
+	case schemapb.DataType_VarChar:
+		result = &VarCharPrimaryKey{
+			BaseStringPrimaryKey: BaseStringPrimaryKey{
+				Value: data.(string),
+			},
+		}
+	default:
+		return nil, fmt.Errorf("not supported primary data type")
+	}
+
+	return result, nil
+}
+
+func GenInt64PrimaryKeys(data ...int64) ([]PrimaryKey, error) {
+	pks := make([]PrimaryKey, len(data))
+	var err error
+	for i := range data {
+		pks[i], err = GenPrimaryKeyByRawData(data[i], schemapb.DataType_Int64)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return pks, nil
+}
+
+func GenVarcharPrimaryKeys(data ...string) ([]PrimaryKey, error) {
+	pks := make([]PrimaryKey, len(data))
+	var err error
+	for i := range data {
+		pks[i], err = GenPrimaryKeyByRawData(data[i], schemapb.DataType_VarChar)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return pks, nil
+}
+
+func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) {
+	ret := make([]PrimaryKey, 0)
+	if data == nil {
+		return ret, fmt.Errorf("failed to parse pks from nil field data")
+	}
+	scalarData := data.GetScalars()
+	if scalarData == nil {
+		return ret, fmt.Errorf("failed to parse pks from nil scalar data")
+	}
+
+	switch data.Type {
+	case schemapb.DataType_Int64:
+		for _, value := range scalarData.GetLongData().GetData() {
+			pk := NewInt64PrimaryKey(value)
+			ret = append(ret, pk)
+		}
+	case schemapb.DataType_VarChar:
+		for _, value := range scalarData.GetStringData().GetData() {
+			pk := NewVarCharPrimaryKey(value)
+			ret = append(ret, pk)
+		}
+	default:
+		return ret, fmt.Errorf("not supported primary data type")
+	}
+
+	return ret, nil
+}
+
+func ParseIDs2PrimaryKeys(ids *schemapb.IDs) []PrimaryKey {
+	ret := make([]PrimaryKey, 0)
+	switch ids.IdField.(type) {
+	case *schemapb.IDs_IntId:
+		int64Pks := ids.GetIntId().GetData()
+		for _, v := range int64Pks {
+			pk := NewInt64PrimaryKey(v)
+			ret = append(ret, pk)
+		}
+	case *schemapb.IDs_StrId:
+		stringPks := ids.GetStrId().GetData()
+		for _, v := range stringPks {
+			pk := NewVarCharPrimaryKey(v)
+			ret = append(ret, pk)
+		}
+	default:
+		// TODO::
+	}
+
+	return ret
+}
+
+func ParsePrimaryKeys2IDs(pks []PrimaryKey) *schemapb.IDs {
+	ret := &schemapb.IDs{}
+	if len(pks) == 0 {
+		return ret
+	}
+	switch pks[0].Type() {
+	case schemapb.DataType_Int64:
+		int64Pks := make([]int64, 0)
+		for _, pk := range pks {
+			int64Pks = append(int64Pks, pk.(*Int64PrimaryKey).Value)
+		}
+		ret.IdField = &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{
+				Data: int64Pks,
+			},
+		}
+	case schemapb.DataType_VarChar:
+		stringPks := make([]string, 0)
+		for _, pk := range pks {
+			stringPks = append(stringPks, pk.(*VarCharPrimaryKey).Value)
+		}
+		ret.IdField = &schemapb.IDs_StrId{
+			StrId: &schemapb.StringArray{
+				Data: stringPks,
+			},
+		}
+	default:
+		// TODO::
+	}
+
+	return ret
+}

--- a/storage/primary_keys.go
+++ b/storage/primary_keys.go
@@ -1,0 +1,157 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/birdwatcher/proto/v2.0/schemapb"
+	"github.com/samber/lo"
+)
+
+// PrimaryKeys is the interface holding a slice of PrimaryKey
+type PrimaryKeys interface {
+	Append(pks ...PrimaryKey) error
+	MustAppend(pks ...PrimaryKey)
+	Get(idx int) PrimaryKey
+	Type() schemapb.DataType
+	Size() int64
+	Len() int
+	MustMerge(pks PrimaryKeys)
+}
+
+type Int64PrimaryKeys struct {
+	values []int64
+}
+
+func NewInt64PrimaryKeys(cap int) *Int64PrimaryKeys {
+	return &Int64PrimaryKeys{values: make([]int64, 0, cap)}
+}
+
+func (pks *Int64PrimaryKeys) AppendRaw(values ...int64) {
+	pks.values = append(pks.values, values...)
+}
+
+func (pks *Int64PrimaryKeys) Append(values ...PrimaryKey) error {
+	iValues := make([]int64, 0, len(values))
+	for _, pk := range values {
+		iPk, ok := pk.(*Int64PrimaryKey)
+		if !ok {
+			return errors.New("pk type not match") //merr.WrapErrParameterInvalid("Int64PrimaryKey", "non-int64 pk")
+		}
+		iValues = append(iValues, iPk.Value)
+	}
+
+	pks.AppendRaw(iValues...)
+	return nil
+}
+
+func (pks *Int64PrimaryKeys) MustAppend(values ...PrimaryKey) {
+	err := pks.Append(values...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (pks *Int64PrimaryKeys) Get(idx int) PrimaryKey {
+	return NewInt64PrimaryKey(pks.values[idx])
+}
+
+func (pks *Int64PrimaryKeys) Type() schemapb.DataType {
+	return schemapb.DataType_Int64
+}
+
+func (pks *Int64PrimaryKeys) Len() int {
+	return len(pks.values)
+}
+
+func (pks *Int64PrimaryKeys) Size() int64 {
+	return int64(pks.Len()) * 8
+}
+
+func (pks *Int64PrimaryKeys) MustMerge(another PrimaryKeys) {
+	aPks, ok := another.(*Int64PrimaryKeys)
+	if !ok {
+		panic("cannot merge different kind of pks")
+	}
+
+	pks.values = append(pks.values, aPks.values...)
+}
+
+type VarcharPrimaryKeys struct {
+	values []string
+	size   int64
+}
+
+func NewVarcharPrimaryKeys(cap int) *VarcharPrimaryKeys {
+	return &VarcharPrimaryKeys{
+		values: make([]string, 0, cap),
+	}
+}
+
+func (pks *VarcharPrimaryKeys) AppendRaw(values ...string) {
+	pks.values = append(pks.values, values...)
+	lo.ForEach(values, func(str string, _ int) {
+		pks.size += int64(len(str)) + 16
+	})
+}
+
+func (pks *VarcharPrimaryKeys) Append(values ...PrimaryKey) error {
+	sValues := make([]string, 0, len(values))
+	for _, pk := range values {
+		iPk, ok := pk.(*VarCharPrimaryKey)
+		if !ok {
+			return errors.New("pk type not match")
+		}
+		sValues = append(sValues, iPk.Value)
+	}
+
+	pks.AppendRaw(sValues...)
+	return nil
+}
+
+func (pks *VarcharPrimaryKeys) MustAppend(values ...PrimaryKey) {
+	err := pks.Append(values...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (pks *VarcharPrimaryKeys) Get(idx int) PrimaryKey {
+	return NewVarCharPrimaryKey(pks.values[idx])
+}
+
+func (pks *VarcharPrimaryKeys) Type() schemapb.DataType {
+	return schemapb.DataType_VarChar
+}
+
+func (pks *VarcharPrimaryKeys) Len() int {
+	return len(pks.values)
+}
+
+func (pks *VarcharPrimaryKeys) Size() int64 {
+	return pks.size
+}
+
+func (pks *VarcharPrimaryKeys) MustMerge(another PrimaryKeys) {
+	aPks, ok := another.(*VarcharPrimaryKeys)
+	if !ok {
+		panic("cannot merge different kind of pks")
+	}
+
+	pks.values = append(pks.values, aPks.values...)
+	pks.size += aPks.size
+}


### PR DESCRIPTION
See also milvus-io/milvus#30607

This command could scan binlogs for milvus instance and check partition key data is located in wrong partition due to previously mentioned issue