### PR TITLE
fix: Fix panicking in `remove collection-drop` when collection not exist

### DIFF
--- a/states/etcd/remove/collection_dropping.go
+++ b/states/etcd/remove/collection_dropping.go
@@ -34,6 +34,7 @@ func CollectionDropCommand(cli clientv3.KV, basePath string) *cobra.Command {
 				collection, err := common.GetCollectionByIDVersion(context.Background(), cli, basePath, etcdversion.GetVersion(), collectionID)
 				if err != nil {
 					fmt.Printf("failed to get collection by id(%d): %s\n", collectionID, err.Error())
+					return
 				}
 				// skip healthy collection
 				if collection.State != models.CollectionStateCollectionDropping && collection.State != models.CollectionStateCollectionDropped {
@@ -45,6 +46,10 @@ func CollectionDropCommand(cli clientv3.KV, basePath string) *cobra.Command {
 				collections, err = common.ListCollectionsVersion(context.Background(), cli, basePath, etcdversion.GetVersion(), func(coll *models.Collection) bool {
 					return coll.State == models.CollectionStateCollectionDropping || coll.State == models.CollectionStateCollectionDropped
 				})
+				if err != nil {
+					fmt.Println("failed to list collection", err.Error())
+					return
+				}
 			}
 
 			for _, collection := range collections {


### PR DESCRIPTION
When collection with provided id not exist, birdwatcher will have NPE panic

Also add log and return fast when list collection fails in same command