### PR TITLE
enhance: Add `consume` cmd to read data from provided topic

### DIFF
--- a/mq/factory.go
+++ b/mq/factory.go
@@ -11,11 +11,11 @@ import (
 	"github.com/milvus-io/birdwatcher/mq/pulsar"
 )
 
-func NewConsumer(mqType, address, channel string) (ifc.Consumer, error) {
+func NewConsumer(mqType, address, channel string, config ifc.MqOption) (ifc.Consumer, error) {
 	groupID := fmt.Sprintf("group-id-%d", time.Now().UnixNano())
 	switch mqType {
 	case "pulsar":
-		return pulsar.NewPulsarConsumer(address, channel, groupID)
+		return pulsar.NewPulsarConsumer(address, channel, groupID, config)
 	default:
 		panic("unknown mq type:" + mqType)
 	}

--- a/mq/factory_wkafka.go
+++ b/mq/factory_wkafka.go
@@ -12,13 +12,13 @@ import (
 	"github.com/milvus-io/birdwatcher/mq/pulsar"
 )
 
-func NewConsumer(mqType, address, channel string) (ifc.Consumer, error) {
+func NewConsumer(mqType, address, channel string, config ifc.MqOption) (ifc.Consumer, error) {
 	groupID := fmt.Sprintf("group-id-%d", time.Now().UnixNano())
 	switch mqType {
 	case "kafka":
 		return kafka.NewKafkaConsumer(address, channel, groupID)
 	case "pulsar":
-		return pulsar.NewPulsarConsumer(address, channel, groupID)
+		return pulsar.NewPulsarConsumer(address, channel, groupID, config)
 	default:
 		panic("unknown mq type:" + mqType)
 	}

--- a/mq/ifc/msgstream.go
+++ b/mq/ifc/msgstream.go
@@ -7,6 +7,7 @@ import (
 type Consumer interface {
 	GetLastMessageID() (MessageID, error)
 	GetLastMessage() (Message, error)
+	Consume() (Message, error)
 	Close() error
 }
 

--- a/mq/ifc/options.go
+++ b/mq/ifc/options.go
@@ -1,0 +1,19 @@
+package ifc
+
+// SubscriptionInitialPosition is the type of a subscription initial position
+type SubscriptionInitialPosition int
+
+const (
+	// SubscriptionPositionUnkown indicates we don't care about the consumer location, since we are doing another seek or only some meta api over that
+	SubscriptionPositionUnknown SubscriptionInitialPosition = iota
+
+	// SubscriptionPositionLatest is latest position which means the start consuming position will be the last message
+	SubscriptionPositionLatest
+
+	// SubscriptionPositionEarliest is earliest position which means the start consuming position will be the first message
+	SubscriptionPositionEarliest
+)
+
+type MqOption struct {
+	SubscriptionInitPos SubscriptionInitialPosition
+}

--- a/mq/pulsar/pulsar_test.go
+++ b/mq/pulsar/pulsar_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/milvus-io/birdwatcher/mq/ifc"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,7 +45,9 @@ func TestConsumer(t *testing.T) {
 		}
 	}
 
-	c, err := NewPulsarConsumer(address, topic, "gid")
+	c, err := NewPulsarConsumer(address, topic, "gid", ifc.MqOption{
+		SubscriptionInitPos: ifc.SubscriptionPositionLatest,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/states/consume.go
+++ b/states/consume.go
@@ -1,0 +1,94 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/mq"
+	"github.com/milvus-io/birdwatcher/mq/ifc"
+	"github.com/milvus-io/birdwatcher/proto/v2.2/commonpb"
+	"github.com/milvus-io/birdwatcher/proto/v2.2/msgpb"
+)
+
+type ConsumeParam struct {
+	framework.ParamBase `use:"consume" desc:"consume msgs from provided topic"`
+	MqType              string `name:"mq_type" default:"pulsar" desc:"message queue type to consume"`
+	MqAddress           string `name:"mq_addr" default:"pulsar://127.0.0.1:6650" desc:"message queue service address"`
+	Topic               string `name:"topic" default:"" desc:"topic to consume"`
+	ShardName           string `name:"shard_name" default:"" desc:"shard name(vchannel name) to filter with"`
+	Detail              bool   `name:"detail" default:"false" desc:"print msg detail"`
+}
+
+func (s *InstanceState) ConsumeCommand(ctx context.Context, p *ConsumeParam) error {
+	c, err := mq.NewConsumer(p.MqType, p.MqAddress, p.Topic, ifc.MqOption{
+		SubscriptionInitPos: ifc.SubscriptionPositionEarliest,
+	})
+	if err != nil {
+		return err
+	}
+
+	latestID, err := c.GetLastMessageID()
+	if err != nil {
+		return err
+	}
+	if latestID.AtEarliestPosition() {
+		fmt.Println("empty topic")
+		return nil
+	}
+
+	for {
+		msg, err := c.Consume()
+		if err != nil {
+			return err
+		}
+		header := commonpb.MsgHeader{}
+		proto.Unmarshal(msg.Payload(), &header)
+		msgType := header.GetBase().GetMsgType()
+		if msgType != commonpb.MsgType_TimeTick {
+			fmt.Printf("%s ", msgType)
+			switch msgType {
+			case commonpb.MsgType_Insert, commonpb.MsgType_Delete:
+				v, err := ParseMsg(header.GetBase().GetMsgType(), msg.Payload())
+				if err != nil {
+					fmt.Println(err.Error())
+				}
+				if p.ShardName == "" || v.GetShardName() == p.ShardName {
+					if p.Detail {
+						fmt.Print(v)
+					} else {
+						fmt.Print(v.GetShardName())
+					}
+				}
+			default:
+			}
+			fmt.Println()
+		}
+		if eq, _ := msg.ID().Equal(latestID.Serialize()); eq {
+			break
+		}
+	}
+	return nil
+}
+
+func ParseMsg(msgType commonpb.MsgType, payload []byte) (interface {
+	fmt.Stringer
+	GetShardName() string
+}, error) {
+	var msg interface {
+		proto.Message
+		GetShardName() string
+	}
+	switch msgType {
+	case commonpb.MsgType_Insert:
+		msg = &msgpb.InsertRequest{}
+	case commonpb.MsgType_Delete:
+		msg = &msgpb.DeleteRequest{}
+	}
+	err := proto.Unmarshal(payload, msg)
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}

--- a/states/etcd/repair/checkpoint.go
+++ b/states/etcd/repair/checkpoint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/mq"
+	"github.com/milvus-io/birdwatcher/mq/ifc"
 	"github.com/milvus-io/birdwatcher/proto/v2.0/commonpb"
 	"github.com/milvus-io/birdwatcher/proto/v2.0/datapb"
 	"github.com/milvus-io/birdwatcher/proto/v2.0/internalpb"
@@ -199,7 +200,9 @@ func getLatestCheckpointFromPChannel(cli clientv3.KV, basePath string) (map[stri
 
 func getLatestFromPChannel(mqType, address, vchannel string) (*internalpb.MsgPosition, error) {
 	topic := ToPhysicalChannel(vchannel)
-	consumer, err := mq.NewConsumer(mqType, address, topic)
+	consumer, err := mq.NewConsumer(mqType, address, topic, ifc.MqOption{
+		SubscriptionInitPos: ifc.SubscriptionPositionLatest,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add `consume` command. It subscribe top provided topic and consume until the latestID. If `detail` flag is false, this command prints only the message type. Otherwise, the Insert/Delete msg body will be printed.