### PR TITLE
fix: Make `remove channel` works when collection meta gone

### DIFF
--- a/states/etcd/remove/channel.go
+++ b/states/etcd/remove/channel.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/milvus-io/birdwatcher/proto/v2.0/etcdpb"
 	datapbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/datapb"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
 	"github.com/spf13/cobra"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -29,26 +29,16 @@ func ChannelCommand(cli clientv3.KV, basePath string) *cobra.Command {
 				return
 			}
 
-			var collections []etcdpb.CollectionInfo
-
-			colls, err := common.ListCollections(cli, basePath, func(info *etcdpb.CollectionInfo) bool {
-				return true
-			})
+			collections, err := common.ListCollectionsVersion(context.Background(), cli, basePath, etcdversion.GetVersion())
 			if err != nil {
 				fmt.Println(err.Error())
-				return
-			}
-			collections = append(collections, colls...)
-
-			if len(collections) == 0 {
-				fmt.Println("no collection found")
 				return
 			}
 
 			validChannels := make(map[string]struct{})
 			for _, collection := range collections {
-				for _, vchan := range collection.GetVirtualChannelNames() {
-					validChannels[vchan] = struct{}{}
+				for _, channel := range collection.Channels {
+					validChannels[channel.VirtualName] = struct{}{}
 				}
 			}
 


### PR DESCRIPTION
- List collection with lastest logic
- If all collections are gone, make `remove channel` workable