### PR TITLE
enhance: Add `partition-loaded` and make `force-release` selectable

### DIFF
--- a/models/collection_loaded.go
+++ b/models/collection_loaded.go
@@ -22,8 +22,8 @@ type CollectionLoaded struct {
 	Status       LoadStatus
 	FieldIndexID map[int64]int64
 
-	// orignial etcd key
-	key     string
+	// orignial etcd Key
+	Key     string
 	Version string
 }
 
@@ -46,7 +46,7 @@ func NewCollectionLoadedV2_1(info *querypb.CollectionInfo, key string) *Collecti
 	c.InMemoryPercentage = info.GetInMemoryPercentage()
 	c.ReplicaIDs = info.GetReplicaIds()
 	c.Version = LTEVersion2_1
-	c.key = key
+	c.Key = key
 
 	return c
 }
@@ -57,7 +57,7 @@ func NewCollectionLoadedV2_2(info *querypbv2.CollectionLoadInfo, key string) *Co
 	c.Status = LoadStatus(info.GetStatus())
 	c.FieldIndexID = info.GetFieldIndexID()
 	c.Version = GTEVersion2_2
-	c.key = key
+	c.Key = key
 	return c
 }
 

--- a/models/partition_loaded.go
+++ b/models/partition_loaded.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	querypbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/querypb"
+)
+
+type PartitionLoaded struct {
+	CollectionID  int64
+	PartitionID   int64
+	ReplicaNumber int32
+
+	Status LoadStatus
+
+	Key     string
+	Version string
+}
+
+func NewPartitionLoaded(info *querypbv2.PartitionLoadInfo, key string) *PartitionLoaded {
+	return &PartitionLoaded{
+		CollectionID:  info.GetCollectionID(),
+		PartitionID:   info.GetPartitionID(),
+		ReplicaNumber: info.GetReplicaNumber(),
+		Status:        LoadStatus(info.GetStatus()),
+		Version:       GTEVersion2_2,
+		Key:           key,
+	}
+}

--- a/states/backup_mock_connect.go
+++ b/states/backup_mock_connect.go
@@ -72,9 +72,6 @@ func (s *embedEtcdMockState) SetupCommands() {
 		// inspect-pk
 		getInspectPKCmd(s.client, rootPath),
 
-		// force-release
-		getForceReleaseCmd(s.client, rootPath),
-
 		// for testing
 		etcd.RepairCommand(s.client, rootPath),
 

--- a/states/etcd/audit/audit.go
+++ b/states/etcd/audit/audit.go
@@ -53,9 +53,12 @@ func (c *FileAuditKV) Get(ctx context.Context, key string, opts ...clientv3.OpOp
 
 // Delete deletes a key, or optionally using WithRange(end), [key, end).
 func (c *FileAuditKV) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
-	fmt.Println("audio delete", key)
+	fmt.Println("audit delete", key)
 	opts = append(opts, clientv3.WithPrevKV())
 	resp, err := c.cli.Delete(ctx, key, opts...)
+	if err != nil {
+		return resp, err
+	}
 	c.writeHeader(models.OpDel, int32(len(resp.PrevKvs)))
 	for _, kv := range resp.PrevKvs {
 		c.writeLogKV(kv)

--- a/states/etcd/common/collection.go
+++ b/states/etcd/common/collection.go
@@ -32,7 +32,9 @@ const (
 	// CollectionLoadPrefix is prefix for querycoord collection loaded in milvus v2.1.x
 	CollectionLoadPrefix = "queryCoord-collectionMeta"
 	// CollectionLoadPrefixV2 is prefix for querycoord collection loaded in milvus v2.2.x
-	CollectionLoadPrefixV2 = "querycoord-collection-loadinfo"
+	CollectionLoadPrefixV2      = "querycoord-collection-loadinfo"
+	PartitionLoadedPrefixLegacy = "queryCoord-partitionMeta"
+	PartitionLoadedPrefix       = "querycoord-partition-loadinfo"
 )
 
 var (

--- a/states/etcd/common/collection_loaded.go
+++ b/states/etcd/common/collection_loaded.go
@@ -13,13 +13,14 @@ import (
 )
 
 // ListCollectionLoadedInfo returns collection loaded info with provided version.
-func ListCollectionLoadedInfo(ctx context.Context, cli clientv3.KV, basePath string, version string, filters ...func(any) bool) ([]*models.CollectionLoaded, error) {
+func ListCollectionLoadedInfo(ctx context.Context, cli clientv3.KV, basePath string, version string, filters ...func(cl *models.CollectionLoaded) bool) ([]*models.CollectionLoaded, error) {
 	switch version {
 	case models.LTEVersion2_1:
 		prefix := path.Join(basePath, CollectionLoadPrefix)
 		infos, paths, err := ListProtoObjects(ctx, cli, prefix, func(info *querypb.CollectionInfo) bool {
+			cl := models.NewCollectionLoadedV2_1(info, "")
 			for _, filter := range filters {
-				if !filter(info) {
+				if !filter(cl) {
 					return false
 				}
 			}
@@ -34,8 +35,9 @@ func ListCollectionLoadedInfo(ctx context.Context, cli clientv3.KV, basePath str
 	case models.GTEVersion2_2:
 		prefix := path.Join(basePath, CollectionLoadPrefixV2)
 		infos, paths, err := ListProtoObjects(ctx, cli, prefix, func(info *querypbv2.CollectionLoadInfo) bool {
+			cl := models.NewCollectionLoadedV2_2(info, "")
 			for _, filter := range filters {
-				if !filter(info) {
+				if !filter(cl) {
 					return false
 				}
 			}

--- a/states/etcd/common/partition_loaded.go
+++ b/states/etcd/common/partition_loaded.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"path"
+
+	"github.com/milvus-io/birdwatcher/models"
+	querypbv2 "github.com/milvus-io/birdwatcher/proto/v2.2/querypb"
+	"github.com/samber/lo"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func ListPartitionLoadedInfo(ctx context.Context, cli clientv3.KV, basePath string, version string, filters ...func(*models.PartitionLoaded) bool) ([]*models.PartitionLoaded, error) {
+	switch version {
+	case models.GTEVersion2_2:
+		prefix := path.Join(basePath, PartitionLoadedPrefix)
+		infos, paths, err := ListProtoObjects(ctx, cli, prefix, func(info *querypbv2.PartitionLoadInfo) bool {
+			pl := models.NewPartitionLoaded(info, "")
+			for _, filter := range filters {
+				if !filter(pl) {
+					return false
+				}
+			}
+			return true
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return lo.Map(infos, func(info querypbv2.PartitionLoadInfo, idx int) *models.PartitionLoaded {
+			return models.NewPartitionLoaded(&info, paths[idx])
+		}), nil
+	default:
+		return nil, errors.New("version not supported")
+	}
+}

--- a/states/etcd/show/collection.go
+++ b/states/etcd/show/collection.go
@@ -42,9 +42,10 @@ func (c *ComponentShow) CollectionCommand(ctx context.Context, p *CollectionPara
 			if p.DatabaseID > -1 && coll.DBID != p.DatabaseID {
 				return false
 			}
-			if p.State != "" && strings.ToLower(p.State) != strings.ToLower(coll.State.String()) {
+			if p.State != "" && !strings.EqualFold(p.State, coll.State.String()) {
 				return false
 			}
+
 			total++
 			return true
 		})

--- a/states/etcd/show/collection_loaded.go
+++ b/states/etcd/show/collection_loaded.go
@@ -10,7 +10,6 @@ import (
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
-	"github.com/samber/lo"
 )
 
 const (
@@ -25,18 +24,12 @@ type CollectionLoadedParam struct {
 // CollectionLoadedCommand return show collection-loaded command.
 func (c *ComponentShow) CollectionLoadedCommand(ctx context.Context, p *CollectionLoadedParam) (*CollectionsLoaded, error) {
 	var total int
-	infos, err := common.ListCollectionLoadedInfo(ctx, c.client, c.basePath, etcdversion.GetVersion(), func(_ any) bool {
+	infos, err := common.ListCollectionLoadedInfo(ctx, c.client, c.basePath, etcdversion.GetVersion(), func(info *models.CollectionLoaded) bool {
 		total++
-		return true
+		return p.CollectionID == 0 || p.CollectionID == info.CollectionID
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list collection load info")
-	}
-
-	if p.CollectionID > 0 {
-		infos = lo.Filter(infos, func(info *models.CollectionLoaded, _ int) bool {
-			return info.CollectionID == p.CollectionID
-		})
 	}
 
 	return framework.NewListResult[CollectionsLoaded](infos), nil

--- a/states/etcd/show/index.go
+++ b/states/etcd/show/index.go
@@ -84,7 +84,7 @@ func printIndex(index IndexInfoV1) {
 	)
 	fmt.Printf("Index Params: %s\n", common.GetKVPair(index.info.GetIndexParams(), "params"))
 	for _, v := range indexParams {
-		fmt.Printf("%s:%s", v.GetKey(), v.GetValue())
+		fmt.Printf("%s:%s\n", v.GetKey(), v.GetValue())
 	}
 	fmt.Println("==================================================================")
 }
@@ -101,7 +101,7 @@ func printIndexV2(index indexpbv2.FieldIndex) {
 	)
 	fmt.Printf("Index Params: %s\n", common.GetKVPair(index.GetIndexInfo().GetUserIndexParams(), "params"))
 	for _, v := range indexParams {
-		fmt.Printf("%s:%s", v.GetKey(), v.GetValue())
+		fmt.Printf("%s:%s\n", v.GetKey(), v.GetValue())
 	}
 	fmt.Println("==================================================================")
 }

--- a/states/etcd/show/partition_loaded.go
+++ b/states/etcd/show/partition_loaded.go
@@ -1,0 +1,57 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	etcdversion "github.com/milvus-io/birdwatcher/states/etcd/version"
+)
+
+type PartitionLoadedParam struct {
+	framework.ParamBase `use:"show partition-loaded" desc:"display the information of loaded partition(s) from querycoord meta"`
+	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	PartitionID         int64 `name:"partition" default:"0" desc:"partition id to filter with"`
+}
+
+func (c *ComponentShow) PartitionLoadedCommand(ctx context.Context, p *PartitionLoadedParam) (*PartitionsLoaded, error) {
+	partitions, err := common.ListPartitionLoadedInfo(ctx, c.client, c.basePath, etcdversion.GetVersion(), func(pl *models.PartitionLoaded) bool {
+		return (p.CollectionID == 0 || p.CollectionID == pl.CollectionID) &&
+			(p.PartitionID == 0 || p.PartitionID == pl.PartitionID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return framework.NewListResult[PartitionsLoaded](partitions), nil
+}
+
+type PartitionsLoaded struct {
+	framework.ListResultSet[*models.PartitionLoaded]
+}
+
+func (rs *PartitionsLoaded) PrintAs(format framework.Format) string {
+	switch format {
+	case framework.FormatDefault, framework.FormatPlain:
+		sb := &strings.Builder{}
+		for _, info := range rs.Data {
+			rs.printPartitionLoaded(sb, info)
+		}
+		fmt.Fprintf(sb, "--- Partitions Loaded: %d\n", len(rs.Data))
+		return sb.String()
+	default:
+	}
+	return ""
+}
+
+func (rs *PartitionsLoaded) printPartitionLoaded(sb *strings.Builder, info *models.PartitionLoaded) {
+	fmt.Fprintf(sb, "CollectionID: %d\tPartitionID: %d\n", info.CollectionID, info.PartitionID)
+	fmt.Fprintf(sb, "ReplicaNumber: %d", info.ReplicaNumber)
+	switch info.Version {
+	case models.LTEVersion2_1:
+	case models.GTEVersion2_2:
+		fmt.Fprintf(sb, "\tLoadStatus: %s\n", info.Status.String())
+	}
+}

--- a/states/force_release.go
+++ b/states/force_release.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/proto/v2.0/querypb"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
@@ -14,41 +15,66 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+type ForceReleaseParam struct {
+	framework.ParamBase `use:"force-release"`
+	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to force release"`
+	All                 bool  `name:"all" default:"false" desc:"force release all collections loaded"`
+}
+
 // getForceReleaseCmd returns command for force-release
-// usage: force-release [flags]
-func getForceReleaseCmd(cli clientv3.KV, basePath string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "force-release",
-		Short: "Force release the collections from QueryCoord",
-		Run: func(cmd *cobra.Command, args []string) {
-			/*
-				// basePath = 'by-dev/meta/'
-				// queryCoord prefix = 'queryCoord-'
-				now := time.Now()
-				err := backupEtcd(cli, basePath, "queryCoord-", string(compQueryCoord), fmt.Sprintf("bw_etcd_querycoord.%s.bak.gz", now.Format("060102-150405")), false)
-				if err != nil {
-					fmt.Printf("backup etcd failed, error: %v, stop doing force-release\n", err)
-				}*/
-
-			// remove all keys start with [basePath]/queryCoord- qcv1 meta
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-			defer cancel()
-			_, err := cli.Delete(ctx, path.Join(basePath, "queryCoord-"), clientv3.WithPrefix())
-			if err != nil {
-				fmt.Printf("failed to remove queryCoord v1 etcd kv, err: %v\n", err)
-			}
-			// remove all keys start with [basePath]/querycoord- qcv2 meta
-			_, err = cli.Delete(ctx, path.Join(basePath, "querycoord-"), clientv3.WithPrefix())
-			if err != nil {
-				fmt.Printf("failed to remove queryCoord v2 etcd kv, err: %v\n", err)
-			}
-
-			// release all collections from online querynodes
-			// maybe? kill session of queryCoord?
-		},
+// usage: force-release --collection [collection id]
+// or force-release --all
+func (s *InstanceState) ForceReleaseCommand(ctx context.Context, p *ForceReleaseParam) error {
+	// release all collections / partitions
+	if p.All {
+		_, err := s.client.Delete(ctx, path.Join(s.basePath, "queryCoord-"), clientv3.WithPrefix())
+		if err != nil {
+			fmt.Printf("failed to remove queryCoord v1 etcd kv, err: %v\n", err)
+		}
+		// remove all keys start with [basePath]/querycoord- qcv2 meta
+		_, err = s.client.Delete(ctx, path.Join(s.basePath, "querycoord-"), clientv3.WithPrefix())
+		if err != nil {
+			fmt.Printf("failed to remove queryCoord v2 etcd kv, err: %v\n", err)
+		}
+		return nil
 	}
 
-	return cmd
+	collections, err := common.ListCollectionLoadedInfo(ctx, s.client, s.basePath, etcdversion.GetVersion(), func(cl *models.CollectionLoaded) bool {
+		return cl.CollectionID == p.CollectionID
+	})
+	if err != nil {
+		return err
+	}
+	partitions, err := common.ListPartitionLoadedInfo(ctx, s.client, s.basePath, etcdversion.GetVersion(), func(pl *models.PartitionLoaded) bool {
+		return p.CollectionID == pl.CollectionID
+	})
+	if err != nil {
+		return err
+	}
+	if len(collections) == 0 && len(partitions) == 0 {
+		fmt.Println("no collections/partitions selected")
+		return nil
+	}
+
+	for _, cl := range collections {
+		fmt.Printf("Force release collection %d, key: %s\n", cl.CollectionID, cl.Key)
+		_, err := s.client.Delete(ctx, cl.Key)
+		if err != nil {
+			fmt.Printf("failed to force release collection %d, err: %v\n", cl.CollectionID, err)
+			continue
+		}
+		fmt.Printf("Force release collection %d done", cl.CollectionID)
+	}
+	for _, pl := range partitions {
+		fmt.Printf("Force release partition %d, key: %s\n", pl.PartitionID, pl.Key)
+		_, err := s.client.Delete(ctx, pl.Key)
+		if err != nil {
+			fmt.Printf("failed to force release partition %d, err: %v\n", pl.PartitionID, err)
+			continue
+		}
+		fmt.Printf("Force release partition %d done", pl.PartitionID)
+	}
+	return nil
 }
 
 // getReleaseDroppedCollectionCmd returns command for release-dropped-collection

--- a/states/instance.go
+++ b/states/instance.go
@@ -71,8 +71,6 @@ func (s *InstanceState) SetupCommands() {
 		getBackupEtcdCmd(cli, basePath),
 		// kill --component [component] --id [id]
 		getEtcdKillCmd(cli, basePath),
-		// force-release
-		getForceReleaseCmd(cli, basePath),
 		// download-pk
 		getDownloadPKCmd(cli, basePath),
 		// visit [component] [id]


### PR DESCRIPTION
See also #255

This PR:
- Add `show partition-loaded` command to list partitions loaded
- Make `force-release` able to specify collection id
- Rewrite `force-release` command with new framework
- Some minor format/parameter usage fix