### PR TITLE
enhance: Add setup workspace step to enable history by default

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -3,7 +3,7 @@ package configs
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -40,7 +40,7 @@ func (c *Config) load() error {
 		return err
 	}
 	defer f.Close()
-	bs, err := ioutil.ReadAll(f)
+	bs, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
@@ -96,6 +96,14 @@ func (c *Config) createDefault() error {
 	return nil
 }
 
+func (c *Config) setupWorkspaceFolder() {
+	// try best to setup
+	err := os.MkdirAll(c.WorkspacePath, os.ModePerm)
+	if err != nil {
+		fmt.Println("failed to set workspace folder", err.Error())
+	}
+}
+
 func NewConfig(configPath string) (*Config, error) {
 	config := &Config{
 		ConfigPath: configPath,
@@ -103,8 +111,10 @@ func NewConfig(configPath string) (*Config, error) {
 	err := config.load()
 	// config path not exist, may first time to run
 	if errors.Is(err, errConfigPathNotExist) {
-		return config, config.createDefault()
+		err = config.createDefault()
 	}
+
+	config.setupWorkspaceFolder()
 
 	return config, err
 }


### PR DESCRIPTION
Birdwatcher shall put history log in workspace folder. If the folder does not exist, history logging will fail. This PR make birdwatcher to try to create folder by default and try it best to enable history logging