### PR TITLE
enhance: Add auto detect rootPath for connect command

### DIFF
--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -119,6 +119,11 @@ func (s *disconnectState) ConnectCommand(ctx context.Context, cp *ConnectParams)
 		}
 		if len(candidates) == 1 {
 			cp.RootPath = candidates[0]
+		} else if len(candidates) > 1 {
+			fmt.Println("multiple possible rootPath find, cannot use auto mode")
+		} else {
+			fmt.Println("failed to find rootPath candidate")
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Find instance rootPath is painful, this PR add auto flag to find milvus rootPath in etcd. 
If there is only one candidate, connect command will use it automatically