### PR TITLE
enhance: Rename duplicated compaction task command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/states/etcd/remove/compaction_task.go
+++ b/states/etcd/remove/compaction_task.go
@@ -20,8 +20,8 @@ type CompactionTaskParam struct {
 	Run                 bool   `name:"run" default:"false" desc:"flag to control actually run or dry"`
 }
 
-// CompactionTaskCommand is the command function to remove compaction task.
-func (c *ComponentRemove) CompactionTaskCommand(ctx context.Context, p *CompactionTaskParam) error {
+// RemoveCompactionTaskCommand is the command function to remove compaction task.
+func (c *ComponentRemove) RemoveCompactionTaskCommand(ctx context.Context, p *CompactionTaskParam) error {
 	compactionTasks, err := common.ListCompactionTask(ctx, c.client, c.basePath, func(task *models.CompactionTask) bool {
 		if p.CompactionType != task.GetType().String() {
 			return false


### PR DESCRIPTION
Duplicated method name from different embed struct causing command failed to work