### PR TITLE
enhance: Upgrade goreleaser go version to 1.21

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.21
           cache: true
 
       - uses: goreleaser/goreleaser-action@v4
@@ -48,7 +48,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.21
           cache: true
 
       - uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
generic deduction does not work well in 1.18
upgrading go tool version to 1.21 releasing new code