### PR TITLE
enhance: Pass ctx for `common.ListSegmentIndex` instead

### DIFF
--- a/states/etcd/common/index.go
+++ b/states/etcd/common/index.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"path"
-	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -19,10 +18,7 @@ func ListIndex(ctx context.Context, cli clientv3.KV, basePath string, filters ..
 }
 
 // ListSegmentIndex list segment index info.
-func ListSegmentIndex(cli clientv3.KV, basePath string, filters ...func(segIdx *etcdpb.SegmentIndexInfo) bool) ([]etcdpb.SegmentIndexInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-	defer cancel()
-
+func ListSegmentIndex(ctx context.Context, cli clientv3.KV, basePath string, filters ...func(segIdx *etcdpb.SegmentIndexInfo) bool) ([]etcdpb.SegmentIndexInfo, error) {
 	prefix := path.Join(basePath, "root-coord/segment-index") + "/"
 	result, _, err := ListProtoObjects(ctx, cli, prefix, filters...)
 	return result, err

--- a/states/etcd/repair/segment.go
+++ b/states/etcd/repair/segment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
@@ -56,8 +57,11 @@ func SegmentCommand(cli clientv3.KV, basePath string) *cobra.Command {
 				return
 			}
 
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			defer cancel()
+
 			// use v1 meta for now
-			segmentIndexes, err := common.ListSegmentIndex(cli, basePath)
+			segmentIndexes, err := common.ListSegmentIndex(ctx, cli, basePath)
 			if err != nil {
 				fmt.Println(err.Error())
 				return

--- a/states/etcd/show/segment_index.go
+++ b/states/etcd/show/segment_index.go
@@ -31,7 +31,7 @@ func (c *ComponentShow) SegmentIndexCommand(ctx context.Context, p *SegmentIndex
 		return err
 	}
 
-	segmentIndexes, err := common.ListSegmentIndex(c.client, c.metaPath)
+	segmentIndexes, err := common.ListSegmentIndex(ctx, c.client, c.metaPath)
 	if err != nil {
 		return err
 	}
@@ -111,6 +111,7 @@ func (c *ComponentShow) SegmentIndexCommand(ctx context.Context, p *SegmentIndex
 				fmt.Printf("\t Index Type:%v on Field ID: %d", common.GetKVPair(idx.GetIndexInfo().GetIndexParams(), "index_type"), idx.GetIndexInfo().GetFieldID())
 				fmt.Printf("\tSerialized Size: %d\n", segIdx.GetSerializeSize())
 				fmt.Printf("\tCurrent Index Version: %d\n", segIdx.GetCurrentIndexVersion())
+				fmt.Printf("\t Index Files: %v\n", segIdx.IndexFileKeys)
 			}
 		} else {
 			// use v1 info


### PR DESCRIPTION
Previously common.ListSegmentIndex has default timeout of 3 seconds, which could cause command fail when segment index number is large