### PR TITLE
enhance: Output ts when locate pks

### DIFF
--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -214,7 +214,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 				case "count":
 					count++
 				case "locate":
-					fmt.Printf("entry found, segment %d offset %d, pk: %v\n", segment.ID, offset, pk.GetValue())
+					fmt.Printf("entry found, segment %d offset %d, pk: %v, ts: %d\n", segment.ID, offset, pk.GetValue(), ts)
 					fmt.Printf("binlog batch %d, pk binlog %s\n", idx, binlog.LogPath)
 				case "dedup":
 					_, ok := ids[pkv]


### PR DESCRIPTION
Output example
```
=== start to execute "locate" task with filter expresion: "id==556505" ===
entry found, segment 456391498725960756 offset 138210, pk: 556505, ts: 456391398954631189
binlog batch 1, pk binlog ROOT_PATH/insert_log/456390691419325481/456390691419325482/456391498725960756/100/456391498725962722

```