### PR TITLE
fix: Use correct index prefix in metastore

### DIFF
--- a/states/etcd/common/consts.go
+++ b/states/etcd/common/consts.go
@@ -33,6 +33,6 @@ const (
 )
 
 const (
-	IndexPrefix        = `indexes`
+	IndexPrefix        = `field-index`
 	SegmentIndexPrefix = `segment-index`
 )


### PR DESCRIPTION
This index prefix shall be `field-index` instead of `indexes`