### PR TITLE
enhance: Adapt 2.6 minio session check to include mixcoord

### DIFF
--- a/states/minio.go
+++ b/states/minio.go
@@ -44,7 +44,7 @@ func (s *InstanceState) GetMinioClientFromCfg(ctx context.Context, params ...oss
 	}
 
 	session, found := lo.Find(sessions, func(session *models.Session) bool {
-		return session.ServerName == "rootcoord"
+		return session.ServerName == "rootcoord" || session.ServerName == "mixcoord"
 	})
 
 	if !found {


### PR DESCRIPTION
Milvus 2.6 merged coordinator sessions into one. Adapt 2.6 minio session check to include mixcoord