### PR TITLE
enhance: Accelerate scan-binlog command

### DIFF
--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/expr-lang/expr"
 	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -31,6 +33,7 @@ type ScanBinlogParams struct {
 	Action              string   `name:"action" default:"count"`
 	IgnoreDelete        bool     `name:"ignoreDelete" default:"false" desc:"ignore delete logic"`
 	IncludeUnhealthy    bool     `name:"includeUnhealthy" default:"false" desc:"also check dropped segments"`
+	WorkerNum           int64    `name:"workerNum" default:"4" desc:"worker num"`
 }
 
 func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogParams) error {
@@ -85,14 +88,15 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	}
 
 	fmt.Printf("=== start to execute \"%s\" task with filter expresion: \"%s\" ===\n", p.Action, p.Expr)
+	fmt.Printf("=== worker num: %d, skip delete: %t ===\n", p.WorkerNum, p.IgnoreDelete)
 
 	// prepare action dataset
 	// count
-	var count int64
+	var count atomic.Int64
 	// locate do nothing
 	// dedup
-	ids := make(map[any]struct{})
-	dedupResult := make(map[any]int64)
+	ids := sync.Map{}         // pk set
+	dedupResult := sync.Map{} // id => duplicated count
 
 	getObject := func(binlogPath string) (*minio.Object, error) {
 		logPath := strings.ReplaceAll(binlogPath, "ROOT_PATH", rootPath)
@@ -138,7 +142,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 		addDeltaRecords(segment, l0DeleteRecords)
 	}
 
-	for _, segment := range normalSegments {
+	workFn := func(segment *models.Segment) error {
 		deletedRecords := make(map[any]uint64) // pk => ts
 		addDeltaRecords(segment, deletedRecords)
 
@@ -156,7 +160,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 
 		if pkBinlog == nil {
 			fmt.Printf("PK Binlog not found, segment %d\n", segment.ID)
-			continue
+			return nil
 		}
 
 		for idx, binlog := range pkBinlog.Binlogs {
@@ -213,16 +217,17 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 
 				switch strings.ToLower(p.Action) {
 				case "count":
-					count++
+					count.Inc()
 				case "locate":
 					fmt.Printf("entry found, segment %d offset %d, pk: %v, ts: %d\n", segment.ID, offset, pk.GetValue(), ts)
 					fmt.Printf("binlog batch %d, pk binlog %s\n", idx, binlog.LogPath)
 				case "dedup":
-					_, ok := ids[pkv]
+					_, ok := ids.LoadOrStore(pkv, struct{}{})
 					if ok {
-						dedupResult[pkv]++
+						count.Inc()
+						v, _ := dedupResult.LoadOrStore(pkv, atomic.NewInt64(0))
+						v.(*atomic.Int64).Inc()
 					}
-					ids[pkv] = struct{}{}
 				}
 				return nil
 			})
@@ -230,22 +235,53 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 				return err
 			}
 		}
+		return err
 	}
+
+	var wg sync.WaitGroup
+	wg.Add(int(p.WorkerNum))
+	taskCh := make(chan *models.Segment)
+
+	num := atomic.NewInt64(0)
+
+	for i := 0; i < int(p.WorkerNum); i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				segment, ok := <-taskCh
+				if !ok {
+					return
+				}
+				err := workFn(segment)
+				if err != nil {
+					fmt.Println(err)
+				}
+				fmt.Printf("%d/%d done, current counter: %d\n", num.Inc(), len(normalSegments), count.Load())
+			}
+		}()
+	}
+
+	for _, segment := range normalSegments {
+		taskCh <- segment
+	}
+	close(taskCh)
+	wg.Wait()
 
 	switch strings.ToLower(p.Action) {
 	case "count":
-		fmt.Printf("Total %d entries found\n", count)
+		fmt.Printf("Total %d entries found\n", count.Load())
 	case "dedup":
-		total := len(dedupResult)
+		total := count.Load()
 		fmt.Printf("%d duplicated entries found\n", total)
 		var i int64
-		for pk, cnt := range dedupResult {
+		dedupResult.Range(func(pk, cnt any) bool {
 			if i > 10 {
-				break
+				return false
 			}
-			fmt.Printf("PK[%s] %v duplicated %d times\n", pkField.Name, pk, cnt+1)
+			fmt.Printf("PK[%s] %v duplicated %d times\n", pkField.Name, pk, cnt.(*atomic.Int64).Load()+1)
 			i++
-		}
+			return true
+		})
 	default:
 	}
 


### PR DESCRIPTION
`scan-binlog` command might be too slow when target cluster is huge. This patch add worker num param to accelerate scan speed.