### PR TITLE
enhance: Select v2binlog reader column index

### DIFF
--- a/storage/binlog/reader.go
+++ b/storage/binlog/reader.go
@@ -14,6 +14,7 @@ import (
 type BinlogReader interface {
 	NextRecordReader(context.Context) (pqarrow.RecordReader, error)
 	GetMapping() map[int64]int
+	SelectFields([]int64)
 	Close()
 }
 

--- a/storage/binlog/v1/binlog_reader.go
+++ b/storage/binlog/v1/binlog_reader.go
@@ -171,6 +171,8 @@ func (reader *BinlogReader) GetMapping() map[int64]int {
 	return map[int64]int{reader.DescriptorEvent.FieldID: 0}
 }
 
+func (reader *BinlogReader) SelectFields(_ []int64) {}
+
 func (reader *BinlogReader) readMagicNumber(f common.ReadSeeker) (int32, error) {
 	var err error
 	var magicNumber int32

--- a/storage/binlog_reader.go
+++ b/storage/binlog_reader.go
@@ -71,6 +71,9 @@ func (crr *SegmentBinlogRecordReader) iterateNextBatch(ctx context.Context) erro
 			continue
 		}
 
+		// select columns if possible
+		reader.SelectFields(crr.outputFields)
+
 		rr, err := reader.NextRecordReader(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
Since storage v2 merge narrow columns into one binlog file, parsing them all without any selection logic may impact scan-binlog performance.

This PR add select fields logic for storage v2 binlog reader to reduce the performance downgrading.