### PR TITLE
enhance: Return error when expr filter execution fails

### DIFF
--- a/storage/segment_iterator.go
+++ b/storage/segment_iterator.go
@@ -78,7 +78,11 @@ func (si *SegmentIterator) Range(ctx context.Context) error {
 
 func (si *SegmentIterator) scan(_ context.Context, pk common.PrimaryKey, batchInfo *common.BatchInfo, offset int, values map[int64]any) error {
 	for _, filter := range si.filters {
-		if !filter.Match(pk, values[1].(int64), values) {
+		match, err := filter.Match(pk, values[1].(int64), values)
+		if err != nil {
+			return err
+		}
+		if !match {
 			return nil
 		}
 	}


### PR DESCRIPTION
Previously, expr execution error only print error and skip this line, which is not an acceptable behavior. This PR make `EntityFilter` return error when execution meet non-continuable error and handles in the full calling chain.