### PR TITLE
enhance: Rectify entry offset when scanning binlog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/stathat/consistent v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -27,6 +27,7 @@ import (
 type ScanBinlogParams struct {
 	framework.ParamBase `use:"scan-binlog" desc:"scan binlog to check data"`
 	CollectionID        int64    `name:"collection" default:"0"`
+	PartitionID         int64    `name:"partition" default:"0"`
 	SegmentID           int64    `name:"segment" default:"0"`
 	Fields              []string `name:"fields"`
 	Expr                string   `name:"expr"`
@@ -78,6 +79,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	segments, err := common.ListSegments(ctx, s.client, s.basePath, func(s *models.Segment) bool {
 		return (p.SegmentID == 0 || p.SegmentID == s.ID) &&
 			p.CollectionID == s.CollectionID &&
+			(p.PartitionID == 0 || p.PartitionID == s.PartitionID) &&
 			(p.IncludeUnhealthy || s.State != commonpb.SegmentState_Dropped)
 	})
 	if err != nil {


### PR DESCRIPTION
This previous used `i` is the offset in record batch not the design entry offset in file batch.

This PR make the offset represent the correct value by iterating it outside of recordBatch loop.

Also add `partitionID` filter and fix go.mod missing dep.