### PR TITLE
fix: Replace "ROOT_PATH" when executing verify-segment

### DIFF
--- a/states/instance.go
+++ b/states/instance.go
@@ -75,9 +75,6 @@ func (s *InstanceState) SetupCommands() {
 		// balance-explain
 		ExplainBalanceCommand(cli, basePath),
 
-		//
-		getVerifySegmentCmd(cli, basePath),
-
 		// probe
 		GetProbeCmd(cli, basePath),
 

--- a/states/verify_segment.go
+++ b/states/verify_segment.go
@@ -7,171 +7,162 @@ import (
 	"strings"
 
 	"github.com/minio/minio-go/v7"
-	"github.com/spf13/cobra"
 
+	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
-	"github.com/milvus-io/birdwatcher/states/kv"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 )
 
-func getVerifySegmentCmd(cli kv.MetaKV, basePath string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "verify-segment",
-		Short: "Verify segment file matches storage",
-		Run: func(cmd *cobra.Command, args []string) {
-			collectionID, err := cmd.Flags().GetInt64("collection")
-			if err != nil {
-				fmt.Println(err.Error())
-				return
-			}
-			fix, err := cmd.Flags().GetBool("fix")
-			if err != nil {
-				fmt.Println(err.Error())
-				return
-			}
+type VerifySegmentParam struct {
+	framework.ParamBase `use:"verify-segment" desc:"Verify segment file matches storage"`
 
-			segments, err := common.ListSegments(context.Background(), cli, basePath, func(seg *models.Segment) bool {
-				return seg.CollectionID == collectionID && seg.State == commonpb.SegmentState_Flushed
-			})
-			if err != nil {
-				fmt.Println("failed to list segment info", err.Error())
-			}
+	CollectionID int64
+	RootPath     string
+	Fix          bool
+}
 
-			minioClient, bucketName, err := getMinioAccess()
-			if err != nil {
-				fmt.Println("failed to get minio access", err.Error())
-				return
-			}
+func (s *InstanceState) VerifySegmentCommnad(ctx context.Context, p *VerifySegmentParam) error {
+	fmt.Printf(`Using %s as storage rootPath, change by "--rootPath" flag if needed`, p.RootPath)
 
-			total := len(segments)
-			for idx, segment := range segments {
-				fmt.Printf("Start to verify segment(%d) --- (%d/%d)\n", segment.ID, idx, total)
-				type item struct {
-					tag          string
-					fieldBinlogs []*models.FieldBinlog
-				}
-				items := []item{
-					{tag: "binlog", fieldBinlogs: segment.GetBinlogs()},
-					{tag: "statslog", fieldBinlogs: segment.GetStatslogs()},
-					{tag: "deltalog", fieldBinlogs: segment.GetDeltalogs()},
-				}
-				for _, item := range items {
-					for _, statslog := range item.fieldBinlogs {
-						for _, l := range statslog.Binlogs {
-							_, err := minioClient.StatObject(context.Background(), bucketName, l.LogPath, minio.StatObjectOptions{})
-							if err != nil {
-								errResp := minio.ToErrorResponse(err)
-								fmt.Println("failed to check ", l.LogPath, err, errResp.Code)
-								if errResp.Code == "NoSuchKey" {
-									switch item.tag {
-									case "binlog":
-										fmt.Println("path", l.LogPath, fix)
-										splits := strings.Split(l.LogPath, "/")
-										logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse logID")
-										}
+	segments, err := common.ListSegments(ctx, s.client, s.basePath, func(seg *models.Segment) bool {
+		return seg.CollectionID == p.CollectionID && seg.State == commonpb.SegmentState_Flushed
+	})
+	if err != nil {
+		fmt.Println("failed to list segment info", err.Error())
+		return err
+	}
 
-										fieldID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse fieldID")
-										}
+	minioClient, bucketName, err := getMinioAccess()
+	if err != nil {
+		fmt.Println("failed to get minio access", err.Error())
+		return err
+	}
 
-										segmentID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse segmentID")
-										}
+	total := len(segments)
+	for idx, segment := range segments {
+		fmt.Printf("Start to verify segment(%d) --- (%d/%d)\n", segment.ID, idx, total)
+		type item struct {
+			tag          string
+			fieldBinlogs []*models.FieldBinlog
+		}
+		items := []item{
+			{tag: "binlog", fieldBinlogs: segment.GetBinlogs()},
+			{tag: "statslog", fieldBinlogs: segment.GetStatslogs()},
+			{tag: "deltalog", fieldBinlogs: segment.GetDeltalogs()},
+		}
+		for _, item := range items {
+			for _, fbl := range item.fieldBinlogs {
+				for _, l := range fbl.Binlogs {
+					logPath := strings.Replace(l.LogPath, "ROOT_PATH", p.RootPath, 1)
+					_, err := minioClient.StatObject(ctx, bucketName, logPath, minio.StatObjectOptions{})
+					if err != nil {
+						errResp := minio.ToErrorResponse(err)
+						fmt.Println("failed to check ", logPath, err, errResp.Code)
+						if errResp.Code == "NoSuchKey" {
+							switch item.tag {
+							case "binlog":
+								fmt.Println("path", logPath, p.Fix)
+								splits := strings.Split(logPath, "/")
+								logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse logID")
+								}
 
-										partitionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse partitionID")
-										}
+								fieldID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse fieldID")
+								}
 
-										collectionID, err := strconv.ParseInt(splits[len(splits)-5], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse collectionID")
-										}
+								segmentID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse segmentID")
+								}
 
-										if fix && err == nil {
-											err := common.RemoveSegmentInsertLogPath(context.Background(), cli, basePath, collectionID, partitionID, segmentID, fieldID, logID)
-											if err != nil {
-												fmt.Println("failed to remove segment insert path")
-											}
-										}
-									case "statslog":
-										splits := strings.Split(l.LogPath, "/")
-										logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse logID")
-										}
+								partitionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse partitionID")
+								}
 
-										fieldID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse fieldID")
-										}
+								collectionID, err := strconv.ParseInt(splits[len(splits)-5], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse collectionID")
+								}
 
-										segmentID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse segmentID")
-										}
+								if p.Fix && err == nil {
+									err := common.RemoveSegmentInsertLogPath(ctx, s.client, s.basePath, collectionID, partitionID, segmentID, fieldID, logID)
+									if err != nil {
+										fmt.Println("failed to remove segment insert path")
+									}
+								}
+							case "statslog":
+								splits := strings.Split(logPath, "/")
+								logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse logID")
+								}
 
-										partitionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse parititonID")
-										}
+								fieldID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse fieldID")
+								}
 
-										collectionID, err := strconv.ParseInt(splits[len(splits)-5], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse col id")
-										}
+								segmentID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse segmentID")
+								}
 
-										if fix && err == nil {
-											err := common.RemoveSegmentStatLogPath(context.Background(), cli, basePath, collectionID, partitionID, segmentID, fieldID, logID)
-											if err != nil {
-												fmt.Println("failed to remove segment insert path")
-											}
-										}
-									case "deltalog":
-										splits := strings.Split(l.LogPath, "/")
-										logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse logID")
-										}
-										segmentID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse segmentID")
-										}
+								partitionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse parititonID")
+								}
 
-										partitionID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse partitionID")
-										}
+								collectionID, err := strconv.ParseInt(splits[len(splits)-5], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse col id")
+								}
 
-										collectionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
-										if err != nil {
-											fmt.Println("failed to parse col id")
-										}
+								if p.Fix && err == nil {
+									err := common.RemoveSegmentStatLogPath(ctx, s.client, s.basePath, collectionID, partitionID, segmentID, fieldID, logID)
+									if err != nil {
+										fmt.Println("failed to remove segment insert path")
+									}
+								}
+							case "deltalog":
+								splits := strings.Split(logPath, "/")
+								logID, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse logID")
+								}
+								segmentID, err := strconv.ParseInt(splits[len(splits)-2], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse segmentID")
+								}
 
-										if fix && err == nil {
-											err := common.RemoveSegmentDeltaLogPath(context.Background(), cli, basePath, collectionID, partitionID, segmentID, logID)
-											if err != nil {
-												fmt.Println("failed to remove segment insert path")
-											}
-										}
+								partitionID, err := strconv.ParseInt(splits[len(splits)-3], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse partitionID")
+								}
+
+								collectionID, err := strconv.ParseInt(splits[len(splits)-4], 10, 64)
+								if err != nil {
+									fmt.Println("failed to parse col id")
+								}
+
+								if p.Fix && err == nil {
+									err := common.RemoveSegmentDeltaLogPath(ctx, s.client, s.basePath, collectionID, partitionID, segmentID, logID)
+									if err != nil {
+										fmt.Println("failed to remove segment insert path")
 									}
 								}
 							}
 						}
 					}
-
-					fmt.Printf("Segment(%d) %s done\n", segment.ID, item.tag)
 				}
 			}
-		},
-	}
 
-	cmd.Flags().Int64("collection", 0, "collection id")
-	cmd.Flags().Bool("fix", false, "remove the log path to fix no such key")
-	return cmd
+			fmt.Printf("Segment(%d) %s done\n", segment.ID, item.tag)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
segment.logPaths now contains "ROOT_PATH" placeholder which shall be replaced by actual rootPath when executing `verify-segment`

This patch add replace logic and rewrite `verify-segment` with bw framework