### PR TITLE
fix: Read until EOF in case of ignore revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,6 +187,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/stathat/consistent v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/states/kv/kv.go
+++ b/states/kv/kv.go
@@ -260,10 +260,14 @@ func (kv *etcdKV) BackupKV(base, prefix string, w *bufio.Writer, ignoreRevision 
 	currentKey := joinPath(base, prefix)
 	var i int
 	prefixBS := []byte(currentKey)
-	for int64(i) < cnt {
+	for {
 		resp, err = kv.client.Get(context.Background(), currentKey, options...)
 		if err != nil {
 			return err
+		}
+
+		if resp.Count == 0 {
+			break
 		}
 
 		valid := 0


### PR DESCRIPTION
Backup etcd using ignoreRevision flag could miss some kv if there are lots of changes during backup. This PR make backup command read until EOF to get as much kv as possible