### PR TITLE
enhance: Dedup standalone session for pprof command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	github.com/milvus-io/milvus/pkg/v2 => github.com/bigsheeper/milvus/pkg/v2 v2.0.0-20250922120106-7b7c4885f631
-	github.com/tecbot/gorocksdb => github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b // indirect
-)
+replace github.com/tecbot/gorocksdb => github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bigsheeper/milvus/pkg/v2 v2.0.0-20250922120106-7b7c4885f631 h1:XNgxKs2/IeBJuBS0GezrqA7t3o7PFbcLz9CVNffsdhw=
-github.com/bigsheeper/milvus/pkg/v2 v2.0.0-20250922120106-7b7c4885f631/go.mod h1:3+FAhWGNNWxYrPKA+EQFqcNaYLXtG4h4AV224SaRThU=
 github.com/bits-and-blooms/bitset v1.4.0 h1:+YZ8ePm+He2pU3dZlIZiOeAKfrBkXi1lSrXJ/Xzgbu8=
 github.com/bits-and-blooms/bitset v1.4.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
@@ -603,6 +601,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.2-0.20250911093549-4cc2bace3f8c h1:B7zmZ30lWHE4wNjT/g2NPe3q0gcUtw7cA5shMtWAmDc=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.2-0.20250911093549-4cc2bace3f8c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus/pkg/v2 v2.6.3-0.20250922024202-3715ddcc81c7 h1:3W/YSDqch2TlxOA2f+ufsUqSJG0umR3nH85Nm5EeJX8=
+github.com/milvus-io/milvus/pkg/v2 v2.6.3-0.20250922024202-3715ddcc81c7/go.mod h1:3+FAhWGNNWxYrPKA+EQFqcNaYLXtG4h4AV224SaRThU=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/states/pprof.go
+++ b/states/pprof.go
@@ -93,7 +93,7 @@ func (s *InstanceState) GetPprofCommand(ctx context.Context, p *PprofParam) erro
 				signal <- err
 			}
 
-			fmt.Printf("%s pprof from %s-%d fetched, added into archive file\n", p.Type, session.ServerName, session.ServerID)
+			fmt.Printf("%s pprof from %s-%d fetched, added into archive file\n", p.Type, serverName, session.ServerID)
 		}
 		close(signal)
 	}()

--- a/states/pprof.go
+++ b/states/pprof.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -53,10 +54,16 @@ func (s *InstanceState) GetPprofCommand(ctx context.Context, p *PprofParam) erro
 	tw := tar.NewWriter(gw)
 	defer tw.Close()
 
+	// dedup by serverID, standalone sessions shares same serverID
+	groups := lo.GroupBy(sessions, func(session *models.Session) int64 {
+		return session.ServerID
+	})
+
 	type pprofResult struct {
-		session *models.Session
-		data    []byte
-		err     error
+		id       int64
+		sessions []*models.Session
+		data     []byte
+		err      error
 	}
 
 	ch := make(chan pprofResult, len(sessions))
@@ -67,11 +74,16 @@ func (s *InstanceState) GetPprofCommand(ctx context.Context, p *PprofParam) erro
 			if result.err != nil {
 				fmt.Println()
 			}
-			session := result.session
+			session := result.sessions[0]
+			serverName := session.ServerName
+			// set to mixture if there are multiple sessions in group
+			if len(result.sessions) > 1 {
+				serverName = "mixture"
+			}
 			tw.WriteHeader(&tar.Header{
 				Typeflag: tar.TypeReg,
 
-				Name: fmt.Sprintf("%s_%d_%s", session.ServerName, session.ServerID, p.Type),
+				Name: fmt.Sprintf("%s_%d_%s", serverName, session.ServerID, p.Type),
 				Size: int64(len(result.data)),
 				Mode: 0o600,
 			})
@@ -87,15 +99,19 @@ func (s *InstanceState) GetPprofCommand(ctx context.Context, p *PprofParam) erro
 	}()
 
 	wg := sync.WaitGroup{}
-	wg.Add(len(sessions))
-	for _, session := range sessions {
-		go func(session *models.Session) {
+	wg.Add(len(groups))
+	for id, sessions := range groups {
+		go func(id int64, sessions []*models.Session) {
 			defer wg.Done()
+			// protection logic
+			if len(sessions) == 0 {
+				return
+			}
 
 			result := pprofResult{
-				session: session,
+				sessions: sessions,
 			}
-			addr := session.IP()
+			addr := sessions[0].IP()
 			// TODO add auto detection from configuration API
 			url := fmt.Sprintf("http://%s:%d/debug/pprof/%s?debug=0", addr, p.Port, p.Type)
 
@@ -116,7 +132,7 @@ func (s *InstanceState) GetPprofCommand(ctx context.Context, p *PprofParam) erro
 
 			result.data = bs
 			ch <- result
-		}(session)
+		}(id, sessions)
 	}
 	wg.Wait()
 	close(ch)


### PR DESCRIPTION
The patch make `pprof` generate unique output for standalone output.
Instead of returning pprof results for all components, the unique pprof result will be generated.