### PR TITLE
fix: Set env to skip paramtable fallback formatter

### DIFF
--- a/cmd/birdwatcher/main.go
+++ b/cmd/birdwatcher/main.go
@@ -31,6 +31,8 @@ func init() {
 		Level:  "error",
 		Stdout: true,
 	})
+	// skip LOCAL_STOARGE_SIZE fallback logic
+	os.Setenv("LOCAL_STORAGE_SIZE", "-1")
 	paramtable.Init()
 }
 


### PR DESCRIPTION
Set `LOCAL_STORAGE_SIZE` env to skip paramtable create folder op in fallback formatter.