### PR TITLE
chore: Bump version to v1.1.1

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -6,5 +6,5 @@ import "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("1.1.0")
+	Version = semver.MustParse("1.1.1")
 }

--- a/states/etcd/show/session.go
+++ b/states/etcd/show/session.go
@@ -17,7 +17,7 @@ import (
 
 type SessionParam struct {
 	framework.ParamBase `use:"show session" desc:"list online milvus components" alias:"sessions"`
-	Format              string `name:"format" default:"line" desc:"output format"`
+	Format              string `name:"format" default:"default" desc:"output format"`
 }
 
 // SessionCommand returns show session command.
@@ -34,8 +34,6 @@ func (c *ComponentShow) SessionCommand(ctx context.Context, p *SessionParam) (*f
 type Sessions struct {
 	framework.ListResultSet[*models.Session]
 }
-
-type SessionGroup struct{}
 
 func (rs *Sessions) PrintAs(format framework.Format) string {
 	switch format {


### PR DESCRIPTION
- Update version from 1.1.0 to 1.1.1
- Fix session format default value from "line" to "default"
- Remove unused SessionGroup type