### PR TITLE
enhance: Add HostName field to session display

### DIFF
--- a/models/session.go
+++ b/models/session.go
@@ -13,6 +13,7 @@ type Session struct {
 	Address    string `json:"Address,omitempty"`
 	Exclusive  bool   `json:"Exclusive,omitempty"`
 	Version    string `json:"Version,omitempty"`
+	HostName   string `json:"HostName,omitempty"`
 
 	key string
 }

--- a/states/etcd/show/session.go
+++ b/states/etcd/show/session.go
@@ -86,13 +86,13 @@ func (rs *Sessions) printAsGroups() string {
 			return session.IsMain(coord)
 		})
 		if main != nil {
-			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\n", color.GreenString("[Main]"), main.ServerID, isMixture(main), main.Version, main.Address)
+			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\n", color.GreenString("[Main]"), main.ServerID, isMixture(main), main.Version, main.Address, main.HostName)
 		}
 		standBys := lo.Filter(sessions, func(session *models.Session, _ int) bool {
 			return main == nil || session.ServerID != main.ServerID
 		})
 		for _, standBy := range standBys {
-			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\n", color.YellowString("[Stand]"), standBy.ServerID, isMixture(standBy), standBy.Version, standBy.Address)
+			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\n", color.YellowString("[Stand]"), standBy.ServerID, isMixture(standBy), standBy.Version, standBy.Address, standBy.HostName)
 		}
 		fmt.Fprintln(sb)
 	}
@@ -101,7 +101,7 @@ func (rs *Sessions) printAsGroups() string {
 		fmt.Fprintf(sb, "Node(s) %s\n", color.GreenString(node))
 		sessions := componentGroups[node]
 		for _, session := range sessions {
-			fmt.Fprintf(sb, "\tID: %d\tVersion: %s\tAddress: %s\n", session.ServerID, session.Version, session.Address)
+			fmt.Fprintf(sb, "\tID: %d\tVersion: %s\tAddress: %s\tHostName: %s\n", session.ServerID, session.Version, session.Address, session.HostName)
 		}
 		fmt.Fprintln(sb)
 	}


### PR DESCRIPTION
Display HostName in `show session` output to help identify the relationship between Milvus components and pod names in Kubernetes environments.