### PR TITLE
fix: Make connect --force flag works

### DIFF
--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -161,16 +161,10 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 		// ping etcd
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
-		err = pingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
-		if err != nil {
-			if errors.Is(err, ErrNotMilvsuRootPath) {
-				if !cp.Force {
-					cli.Close()
-					fmt.Printf("Connection established, but %s, please check your config or use Dry mode\n", err.Error())
-					return err
-				}
-			} else {
-				fmt.Println("cannot connect to etcd with addr:", cp.EtcdAddr, err.Error())
+		if !cp.Force {
+			err = pingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
+			if err != nil {
+				fmt.Printf("Connection established, but %s, please check your config or use Dry mode\n", err.Error())
 				return err
 			}
 		}


### PR DESCRIPTION
`--force` failed to work after kv refactory. This PR make force check happens before pingMetastore fixing this problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug Fix: Restore `--force` flag functionality in etcd connect

**Core Invariant**
When the `--force` flag is specified in the `connect` command, the metastore validation (ping) must be skipped entirely to allow forced connections to non-standard configurations or instances without a valid Milvus root path.

**Root Cause & Fix**
The `--force` flag was broken because the ping validation was happening unconditionally, and subsequent error handling logic was not properly gating on the force flag. The fix moves the force check to occur *before* the `pingMetaStore` call (lines 164-170 of `connectEtcd`), so that when `cp.Force` is true, the validation step is skipped entirely. Previously, the validation would always execute and error handling would decide post-hoc whether to proceed.

**Simplified Logic**
The previous approach attempted to handle `ErrNotMilvsuRootPath` specially by allowing forced connections after the fact. The new implementation is simpler and more correct: skip validation upfront when force is true, rather than performing validation and conditionally accepting errors. This removes the prior error-type differentiation logic and treats the force flag as a straightforward bypass mechanism.

**No Regression**
- When `--force` is not set (`cp.Force = false`), the ping executes as before and connection fails on validation errors (line 165-169)
- When `--force` is set (`cp.Force = true`), the entire ping block is skipped, allowing the connection to proceed directly to state setup (line 175)
- All downstream state initialization (`SetTagNext`) remains unchanged, ensuring normal operation post-connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->