### PR TITLE
enhance: Add storage version filter for segment commands

### DIFF
--- a/states/compact_batch.go
+++ b/states/compact_batch.go
@@ -30,7 +30,7 @@ func (s *InstanceState) CompactBatchCommand(ctx context.Context, p *CompactBatch
 	}
 	// list segment info to get row count information
 	segments, err := common.ListSegments(ctx, s.client, s.basePath, func(s *models.Segment) bool {
-		return (p.CollectionID == 0 || p.CollectionID == s.CollectionID) &&
+		return p.CollectionID == s.CollectionID &&
 			(p.StorageVersion == -1 || p.StorageVersion == s.StorageVersion) &&
 			s.GetState() == commonpb.SegmentState_Flushed
 	})
@@ -47,6 +47,12 @@ func (s *InstanceState) CompactBatchCommand(ctx context.Context, p *CompactBatch
 	if !p.Run {
 		return nil
 	}
+
+	if len(segmentIDs) == 0 {
+		fmt.Println("no segment selected for compaction")
+		return nil
+	}
+
 	sessions, err := common.ListSessions(ctx, s.client, s.basePath)
 	if err != nil {
 		return err

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -27,6 +27,7 @@ type SegmentParam struct {
 	State               string `name:"state" default:"" desc:"target segment state"`
 	Level               string `name:"level" default:"" desc:"target segment level"`
 	Sorted              string `name:"sorted" default:"" desc:"flags indicating whether sort segments by segmentID"`
+	StorageVersion      int64  `name:"storageVersion" default:"-1" desc:"segment storage version to filter"`
 }
 
 type segStats struct {
@@ -49,7 +50,8 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 			(p.SegmentID == 0 || segment.ID == p.SegmentID) &&
 			(p.State == "" || strings.EqualFold(segment.State.String(), p.State)) &&
 			(p.Level == "" || strings.EqualFold(segment.Level.String(), p.Level)) &&
-			(p.Sorted == "" || strings.EqualFold(strconv.FormatBool(segment.IsSorted), p.Sorted))
+			(p.Sorted == "" || strings.EqualFold(strconv.FormatBool(segment.IsSorted), p.Sorted)) &&
+			(p.StorageVersion == -1 || segment.StorageVersion == p.StorageVersion)
 	})
 	if err != nil {
 		fmt.Println("failed to list segments", err.Error())
@@ -222,6 +224,7 @@ func PrintSegmentInfo(info *models.Segment, detailBinlog bool) {
 	} else {
 		fmt.Println("Dml Position: nil")
 	}
+	fmt.Printf("Manifest Path: %s\n", info.ManifestPath)
 	fmt.Printf("Binlog Nums %d\tStatsLog Nums: %d\tDeltaLog Nums:%d\n",
 		countBinlogNum(info.GetBinlogs()), countBinlogNum(info.GetStatslogs()), countBinlogNum(info.GetDeltalogs()))
 


### PR DESCRIPTION
- Add --storageVersion flag to `show segment` command for filtering segments
- Display ManifestPath in segment info output
- Require explicit collection ID in compact-batch command
- Add empty segment check before compaction execution