### PR TITLE
enhance: Introduce typed command param base types (DataSetParam, ExecutionParam)

### DIFF
--- a/framework/param.go
+++ b/framework/param.go
@@ -16,3 +16,27 @@ func (pb ParamBase) ParseArgs(args []string) error {
 func (pb ParamBase) Desc() (string, string) {
 	return "", ""
 }
+
+// DataSetParam is the base for commands that return a ResultSet.
+// It provides a built-in Format flag for output formatting.
+type DataSetParam struct {
+	ParamBase
+	Format string `name:"format" default:"" desc:"output format (default, json, table, line)"`
+}
+
+// GetFormat returns the Format as a framework.Format enum value.
+func (p *DataSetParam) GetFormat() Format {
+	return NameFormat(p.Format)
+}
+
+// ExecutionParam is the base for commands that modify metadata.
+// It provides a built-in Run flag for dry-run support.
+type ExecutionParam struct {
+	ParamBase
+	Run bool `name:"run" default:"false" desc:"actually execute the operation, default is dry-run"`
+}
+
+// IsDryRun returns true if the command should run in dry-run mode.
+func (p *ExecutionParam) IsDryRun() bool {
+	return !p.Run
+}

--- a/states/compact_batch.go
+++ b/states/compact_batch.go
@@ -18,10 +18,9 @@ import (
 )
 
 type CompactBatchParam struct {
-	framework.ParamBase `use:"compact-batch" desc:"dispatch compact job by batch"`
-	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to filter with"`
-	StorageVersion      int64 `name:"storageVersion" default:"-1"`
-	Run                 bool  `name:"run" default:"false"`
+	framework.ExecutionParam `use:"compact-batch" desc:"dispatch compact job by batch"`
+	CollectionID             int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	StorageVersion           int64 `name:"storageVersion" default:"-1"`
 }
 
 func (s *InstanceState) CompactBatchCommand(ctx context.Context, p *CompactBatchParam) error {

--- a/states/etcd/remove/binlog.go
+++ b/states/etcd/remove/binlog.go
@@ -15,17 +15,16 @@ import (
 var backupKeyPrefix = "birdwatcher/backup"
 
 type RemoveBinlogParam struct {
-	framework.ParamBase `use:"remove etcd-config" desc:"remove etcd stored configuations"`
-	LogType             string `name:"p.LogType" default:"unknown" desc:"log type: binlog/deltalog/statslog"`
-	CollectionID        int64  `name:"p.CollectionID" default:"0" desc:"collection id to remove"`
-	PartitionID         int64  `name:"p.PartitionID" default:"0" desc:"partition id to remove"`
-	SegmentID           int64  `name:"p.SegmentID" default:"0" desc:"segment id to remove"`
-	FieldID             int64  `name:"p.FieldID" default:"0" desc:"field id to remove"`
-	LogID               int64  `name:"logID" default:"0" desc:"log id to remove"`
+	framework.ExecutionParam `use:"remove etcd-config" desc:"remove etcd stored configuations"`
+	LogType                  string `name:"p.LogType" default:"unknown" desc:"log type: binlog/deltalog/statslog"`
+	CollectionID             int64  `name:"p.CollectionID" default:"0" desc:"collection id to remove"`
+	PartitionID              int64  `name:"p.PartitionID" default:"0" desc:"partition id to remove"`
+	SegmentID                int64  `name:"p.SegmentID" default:"0" desc:"segment id to remove"`
+	FieldID                  int64  `name:"p.FieldID" default:"0" desc:"field id to remove"`
+	LogID                    int64  `name:"logID" default:"0" desc:"log id to remove"`
 
 	Restore   bool `name:"restore" default:"false" desc:"flags indicating whether to restore removed command"`
 	RemoveAll bool `name:"removeAll" default:"false" desc:"remove all binlogs belongs to the field"`
-	Run       bool `name:"run" default:"false" desc:"flag to control actually run or dry"`
 }
 
 func (c *ComponentRemove) RemoveBinlogCommand(ctx context.Context, p *RemoveBinlogParam) error {

--- a/states/etcd/remove/bulkinsert.go
+++ b/states/etcd/remove/bulkinsert.go
@@ -12,10 +12,9 @@ import (
 )
 
 type RemoveImportJobParam struct {
-	framework.ParamBase `use:"remove import-job" desc:"Remove import job from datacoord meta with specified job id" alias:"import"`
+	framework.ExecutionParam `use:"remove import-job" desc:"Remove import job from datacoord meta with specified job id" alias:"import"`
 
 	JobID int64 `name:"job" default:"" desc:"import job id to remove"`
-	Run   bool  `name:"run" default:"false" desc:"flags indicating whether to remove import job from meta"`
 }
 
 func (c *ComponentRemove) RemoveImportJobCommand(ctx context.Context, p *RemoveImportJobParam) error {

--- a/states/etcd/remove/channel.go
+++ b/states/etcd/remove/channel.go
@@ -10,10 +10,9 @@ import (
 )
 
 type RemoveChannelParam struct {
-	framework.ParamBase `use:"remove channel" desc:"Remove channel from datacoord meta with specified condition if orphan"`
+	framework.ExecutionParam `use:"remove channel" desc:"Remove channel from datacoord meta with specified condition if orphan"`
 
 	Channel string `name:"channel" default:"" desc:"channel name to remove"`
-	Run     bool   `name:"run" default:"false" desc:"flags indicating whether to remove channel from meta, default is false"`
 	Force   bool   `name:"force" default:"false" desc:"force remove channel ignoring collection check"`
 }
 

--- a/states/etcd/remove/collection_clean.go
+++ b/states/etcd/remove/collection_clean.go
@@ -19,8 +19,7 @@ var paginationSize = 2000
 type ExcludePrefixOptions func(string) bool
 
 type CollectionMetaLeakedParam struct {
-	framework.ParamBase `use:"remove collection-meta-leaked" desc:"Remove leaked collection meta for collection has been dropped"`
-	Run                 bool `name:"run" default:"false" desc:"flags indicating whether to execute removed command"`
+	framework.ExecutionParam `use:"remove collection-meta-leaked" desc:"Remove leaked collection meta for collection has been dropped"`
 }
 
 func (c *ComponentRemove) CollectionMetaLeakedCommand(ctx context.Context, p *CollectionMetaLeakedParam) error {

--- a/states/etcd/remove/collection_dropping.go
+++ b/states/etcd/remove/collection_dropping.go
@@ -12,9 +12,8 @@ import (
 )
 
 type CollectionDropParam struct {
-	framework.ParamBase `use:"remove collection-drop" desc:"Remove collection & channel meta for collection in dropping/dropped state"`
-	CollectionID        int64 `name:"collectionID" default:"0" desc:"collection id to remove"`
-	Run                 bool  `name:"run" default:"false" desc:"flags indicating whether to execute removed command"`
+	framework.ExecutionParam `use:"remove collection-drop" desc:"Remove collection & channel meta for collection in dropping/dropped state"`
+	CollectionID             int64 `name:"collectionID" default:"0" desc:"collection id to remove"`
 }
 
 func (c *ComponentRemove) CollectionDropCommand(ctx context.Context, p *CollectionDropParam) error {

--- a/states/etcd/remove/compaction_task.go
+++ b/states/etcd/remove/compaction_task.go
@@ -10,14 +10,13 @@ import (
 )
 
 type CompactionTaskParam struct {
-	framework.ParamBase `use:"remove compaction" desc:"Remove compaction task"`
-	CompactionType      string `name:"type" default:"ClusteringCompaction" desc:"compaction type to remove"`
-	JobID               string `name:"jobID" default:"" desc:"jobID also known as triggerID"`
-	TaskID              string `name:"taskID" default:"" desc:"taskID also known as planID"`
-	State               string `name:"state" default:"" desc:"task state"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
-	PartitionID         int64  `name:"partitionID" default:"0" desc:"partitionID id to filter"`
-	Run                 bool   `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove compaction" desc:"Remove compaction task"`
+	CompactionType           string `name:"type" default:"ClusteringCompaction" desc:"compaction type to remove"`
+	JobID                    string `name:"jobID" default:"" desc:"jobID also known as triggerID"`
+	TaskID                   string `name:"taskID" default:"" desc:"taskID also known as planID"`
+	State                    string `name:"state" default:"" desc:"task state"`
+	CollectionID             int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
+	PartitionID              int64  `name:"partitionID" default:"0" desc:"partitionID id to filter"`
 }
 
 // RemoveCompactionTaskCommand is the command function to remove compaction task.

--- a/states/etcd/remove/dirty_importing_segment.go
+++ b/states/etcd/remove/dirty_importing_segment.go
@@ -13,10 +13,9 @@ import (
 )
 
 type DirtyImportingSegment struct {
-	framework.ParamBase `use:"remove dirty-importing-segment" desc:"remove dirty importing segments with 0 rows"`
-	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to filter with"`
-	Ts                  int64 `name:"ts" default:"0" desc:"only remove segments with ts less than this value"`
-	Run                 bool  `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove dirty-importing-segment" desc:"remove dirty importing segments with 0 rows"`
+	CollectionID             int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	Ts                       int64 `name:"ts" default:"0" desc:"only remove segments with ts less than this value"`
 }
 
 // DirtyImportingSegmentCommand returns command to remove

--- a/states/etcd/remove/etcd_config.go
+++ b/states/etcd/remove/etcd_config.go
@@ -9,9 +9,8 @@ import (
 )
 
 type RemoveEtcdConfigParam struct {
-	framework.ParamBase `use:"remove etcd-config" desc:"remove etcd stored configuations"`
-	Key                 string `name:"key" desc:"etcd config key" default:""`
-	Run                 bool   `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove etcd-config" desc:"remove etcd stored configuations"`
+	Key                      string `name:"key" desc:"etcd config key" default:""`
 }
 
 func (c *ComponentRemove) RemoveEtcdConfigCommand(ctx context.Context, p *RemoveEtcdConfigParam) error {

--- a/states/etcd/remove/index.go
+++ b/states/etcd/remove/index.go
@@ -10,9 +10,8 @@ import (
 )
 
 type RemoveIndexParam struct {
-	framework.ParamBase `use:"remove index" desc:"Remove index meta"`
-	IndexID             int64 `name:"indexID" default:"0" desc:"index id to remove"`
-	Run                 bool  `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove index" desc:"Remove index meta"`
+	IndexID                  int64 `name:"indexID" default:"0" desc:"index id to remove"`
 }
 
 func (c *ComponentRemove) RemoveIndexCommand(ctx context.Context, p *RemoveIndexParam) error {

--- a/states/etcd/remove/segment.go
+++ b/states/etcd/remove/segment.go
@@ -16,12 +16,11 @@ import (
 )
 
 type SegmentParam struct {
-	framework.ParamBase `use:"remove segment" desc:"Remove segment from meta with specified filters"`
-	SegmentID           int64  `name:"segmentID" default:"0" desc:"segment id to remove"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection id to filter with"`
-	State               string `name:"state" default:"" desc:"segment state"`
-	MaxNum              int64  `name:"maxNum" default:"9223372036854775807" desc:"max number of segment to remove"`
-	Run                 bool   `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove segment" desc:"Remove segment from meta with specified filters"`
+	SegmentID                int64  `name:"segmentID" default:"0" desc:"segment id to remove"`
+	CollectionID             int64  `name:"collectionID" default:"0" desc:"collection id to filter with"`
+	State                    string `name:"state" default:"" desc:"segment state"`
+	MaxNum                   int64  `name:"maxNum" default:"9223372036854775807" desc:"max number of segment to remove"`
 }
 
 func (c *ComponentRemove) RemoveSegmentCommand(ctx context.Context, p *SegmentParam) error {
@@ -59,7 +58,7 @@ func (c *ComponentRemove) RemoveSegmentCommand(ctx context.Context, p *SegmentPa
 
 	err := common.WalkAllSegments(ctx, c.client, c.basePath, filterFunc, opFunc, p.MaxNum)
 	if err != nil && !errors.Is(err, common.ErrReachMaxNumOfWalkSegment) {
-		fmt.Printf("WalkAllSegmentsfailed, err: %s\n", err.Error())
+		fmt.Printf("WalkAllSegments failed, err: %s\n", err.Error())
 	}
 
 	if !p.Run {

--- a/states/etcd/remove/segment_orphan.go
+++ b/states/etcd/remove/segment_orphan.go
@@ -13,9 +13,8 @@ import (
 )
 
 type SegmentOrphan struct {
-	framework.ParamBase `use:"remove segment-orphan" desc:"remove orphan segments that collection meta already gone"`
-	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to filter with"`
-	Run                 bool  `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove segment-orphan" desc:"remove orphan segments that collection meta already gone"`
+	CollectionID             int64 `name:"collection" default:"0" desc:"collection id to filter with"`
 }
 
 // SegmentOrphanCommand returns command to remove

--- a/states/etcd/remove/session.go
+++ b/states/etcd/remove/session.go
@@ -17,10 +17,9 @@ import (
 )
 
 type RemoveSessionParam struct {
-	framework.ParamBase `use:"remove session" desc:"remove session with specified component type & node id"`
-	Component           string `name:"component" default:"" desc:"component type to remove"`
-	ID                  int64  `name:"sessionID" default:"0" desc:"session id to remove"`
-	Run                 bool   `name:"run" default:"false" desc:"actual remove session, default in dry-run mode"`
+	framework.ExecutionParam `use:"remove session" desc:"remove session with specified component type & node id"`
+	Component                string `name:"component" default:"" desc:"component type to remove"`
+	ID                       int64  `name:"sessionID" default:"0" desc:"session id to remove"`
 }
 
 func (c *ComponentRemove) RemoveSessionCommand(ctx context.Context, p *RemoveSessionParam) error {

--- a/states/etcd/remove/stats_task.go
+++ b/states/etcd/remove/stats_task.go
@@ -10,13 +10,12 @@ import (
 )
 
 type StatsTaskParam struct {
-	framework.ParamBase `use:"remove stats-task" desc:"Remove stats task"`
-	SubJobType          string `name:"subJobType" default:"" desc:"stats type to remove, e.g. JsonKeyIndexJob, TextIndexJob, etc."`
-	TaskID              string `name:"taskID" default:"" desc:"taskID also known as planID"`
-	State               string `name:"state" default:"" desc:"stats state"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
-	SegmentID           int64  `name:"segmentID" default:"0" desc:"segmentID id to filter"`
-	Run                 bool   `name:"run" default:"false" desc:"flag to control actually run or dry"`
+	framework.ExecutionParam `use:"remove stats-task" desc:"Remove stats task"`
+	SubJobType               string `name:"subJobType" default:"" desc:"stats type to remove, e.g. JsonKeyIndexJob, TextIndexJob, etc."`
+	TaskID                   string `name:"taskID" default:"" desc:"taskID also known as planID"`
+	State                    string `name:"state" default:"" desc:"stats state"`
+	CollectionID             int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
+	SegmentID                int64  `name:"segmentID" default:"0" desc:"segmentID id to filter"`
 }
 
 // RemoveStatsTaskCommand is the command function to remove stats task.

--- a/states/etcd/repair/add_index_param_retrive_friendly.go
+++ b/states/etcd/repair/add_index_param_retrive_friendly.go
@@ -14,11 +14,10 @@ import (
 )
 
 type AddIndexParamParam struct {
-	framework.ParamBase `use:"repair add_index_params" desc:"check index param and try to add param"`
-	Collection          int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	Key                 string `name:"key" default:"retrieve_friendly" desc:"add params key"`
-	Value               string `name:"value" default:"true" desc:"add params value"`
-	Run                 bool   `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair add_index_params" desc:"check index param and try to add param"`
+	Collection               int64  `name:"collection" default:"0" desc:"collection id to filter with"`
+	Key                      string `name:"key" default:"retrieve_friendly" desc:"add params key"`
+	Value                    string `name:"value" default:"true" desc:"add params value"`
 }
 
 func (c *ComponentRepair) AddIndexParamsCommand(ctx context.Context, p *AddIndexParamParam) error {

--- a/states/etcd/repair/channel.go
+++ b/states/etcd/repair/channel.go
@@ -16,9 +16,8 @@ import (
 )
 
 type RepairChannelParam struct {
-	framework.ParamBase `use:"repair channel" desc:"do channel watch change and try to repair"`
-	Collection          int64 `name:"collection" default:"0" desc:"collection id to filter with"`
-	Run                 bool  `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair channel" desc:"do channel watch change and try to repair"`
+	Collection               int64 `name:"collection" default:"0" desc:"collection id to filter with"`
 }
 
 // RepairChannelCommand defines repair channel command.

--- a/states/etcd/repair/channel_watched.go
+++ b/states/etcd/repair/channel_watched.go
@@ -15,10 +15,9 @@ import (
 )
 
 type ChannelWatchedParam struct {
-	framework.ParamBase `use:"repair channel-watch"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to repair"`
-	ChannelName         string `name:"vchannel" default:"" desc:"channel name to repair"`
-	Run                 bool   `name:"run" default:"false" desc:"whether to remove legacy collection meta, default set to \"false\" to dry run"`
+	framework.ExecutionParam `use:"repair channel-watch"`
+	CollectionID             int64  `name:"collection" default:"0" desc:"collection id to repair"`
+	ChannelName              string `name:"vchannel" default:"" desc:"channel name to repair"`
 }
 
 func (c *ComponentRepair) RepairChannelWatchedCommand(ctx context.Context, p *ChannelWatchedParam) error {

--- a/states/etcd/repair/checkpoint.go
+++ b/states/etcd/repair/checkpoint.go
@@ -21,13 +21,12 @@ import (
 )
 
 type RepairCheckpointParam struct {
-	framework.ParamBase `use:"repair checkpoint" desc:"reset checkpoint of vchannels to latest checkpoint(or latest msgID) of physical channel"`
-	Collection          int64  `name:"collection" default:"0" desc:"collection id"`
-	VChannel            string `name:"vchannel" default:"" desc:"vchannel name"`
-	SetTo               string `name:"set_to" default:"latest-cp" desc:"support latest-cp(the latest checkpoint from segment checkpoint of corresponding collection on this physical channel) and latest-msgid(the latest msg from this physical channel)"`
-	MqType              string `name:"mq_type" default:"kafka" desc:"MQ type, only support kafka(default) and pulsar"`
-	Address             string `name:"address" default:"localhost:9092" desc:"mq endpoint, default value is kafka address"`
-	Run                 bool   `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair checkpoint" desc:"reset checkpoint of vchannels to latest checkpoint(or latest msgID) of physical channel"`
+	Collection               int64  `name:"collection" default:"0" desc:"collection id"`
+	VChannel                 string `name:"vchannel" default:"" desc:"vchannel name"`
+	SetTo                    string `name:"set_to" default:"latest-cp" desc:"support latest-cp(the latest checkpoint from segment checkpoint of corresponding collection on this physical channel) and latest-msgid(the latest msg from this physical channel)"`
+	MqType                   string `name:"mq_type" default:"kafka" desc:"MQ type, only support kafka(default) and pulsar"`
+	Address                  string `name:"address" default:"localhost:9092" desc:"mq endpoint, default value is kafka address"`
 }
 
 // CheckpointCommand usage:

--- a/states/etcd/repair/collection_info.go
+++ b/states/etcd/repair/collection_info.go
@@ -23,13 +23,12 @@ import (
 )
 
 type CollectionInfoParam struct {
-	framework.ParamBase `use:"repair collection-info" desc:"repair collection info"`
-	Path                string `name:"filePath" default:"" desc:"path to the collection info file"`
-	DatabaseID          int64  `name:"databaseID" default:"0" desc:"database ID to repair"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection ID to repair"`
-	CollectionName      string `name:"collectionName" default:"" desc:"collection name to repair"`
-	EnableDynamic       bool   `name:"enableDynamic" default:"false" desc:"enable dynamic collection info repair, default is false"`
-	Run                 bool   `name:"run" default:"false" desc:"run the collection info repair command"`
+	framework.ExecutionParam `use:"repair collection-info" desc:"repair collection info"`
+	Path                     string `name:"filePath" default:"" desc:"path to the collection info file"`
+	DatabaseID               int64  `name:"databaseID" default:"0" desc:"database ID to repair"`
+	CollectionID             int64  `name:"collectionID" default:"0" desc:"collection ID to repair"`
+	CollectionName           string `name:"collectionName" default:"" desc:"collection name to repair"`
+	EnableDynamic            bool   `name:"enableDynamic" default:"false" desc:"enable dynamic collection info repair, default is false"`
 }
 
 type ListModel struct {

--- a/states/etcd/repair/collection_legacy.go
+++ b/states/etcd/repair/collection_legacy.go
@@ -10,9 +10,8 @@ import (
 )
 
 type CollectionLegacyDroppedParams struct {
-	framework.ParamBase `use:"repair legacy-collection-remnant"`
-	CollectionID        int64 `name:"collection" default:"0" desc:"collection id to repair"`
-	Run                 bool  `name:"run" default:"false" desc:"whether to remove legacy collection meta, default set to \"false\" to dry run"`
+	framework.ExecutionParam `use:"repair legacy-collection-remnant"`
+	CollectionID             int64 `name:"collection" default:"0" desc:"collection id to repair"`
 }
 
 func (c *ComponentRepair) CollectionLegacyDroppedCommand(ctx context.Context, p *CollectionLegacyDroppedParams) error {

--- a/states/etcd/repair/mixed_binlogs.go
+++ b/states/etcd/repair/mixed_binlogs.go
@@ -14,8 +14,7 @@ import (
 )
 
 type MixedBinlogsParam struct {
-	framework.ParamBase `use:"repair mixed-binlogs" desc:"repair collection info"`
-	Run                 bool `name:"run" default:"false" desc:"run the mixed binlogs repair command"`
+	framework.ExecutionParam `use:"repair mixed-binlogs" desc:"repair collection info"`
 }
 
 func (c *ComponentRepair) MixedBinlogsCommand(ctx context.Context, p *MixedBinlogsParam) error {

--- a/states/etcd/repair/segment.go
+++ b/states/etcd/repair/segment.go
@@ -13,11 +13,10 @@ import (
 )
 
 type RepairSegmentParam struct {
-	framework.ParamBase `use:"repair segment" desc:"do segment & index meta check and try to repair"`
+	framework.ExecutionParam `use:"repair segment" desc:"do segment & index meta check and try to repair"`
 
 	Collection int64 `name:"collection" default:"0" desc:"collection id to filter with"`
 	Segment    int64 `name:"segment" default:"0" desc:"segment id to filter with"`
-	Run        bool  `name:"run" default:"false" desc:"actual do repair"`
 }
 
 // old logic backup

--- a/states/etcd/repair/segment_empty.go
+++ b/states/etcd/repair/segment_empty.go
@@ -12,9 +12,7 @@ import (
 )
 
 type RepairEmptySegmentParam struct {
-	framework.ParamBase `use:"repair empty-segment" desc:"Remove empty segment from meta"`
-
-	Run bool `name:"run" default:"false" desc:"flags indicating whether to remove segments from meta"`
+	framework.ExecutionParam `use:"repair empty-segment" desc:"Remove empty segment from meta"`
 }
 
 // EmptySegmentCommand returns repair empty-segment command.

--- a/states/etcd/repair/segment_partition_drop.go
+++ b/states/etcd/repair/segment_partition_drop.go
@@ -15,10 +15,9 @@ import (
 )
 
 type RepairSegmentPartDropParam struct {
-	framework.ParamBase `use:"repair segment-part-dropping" desc:"mark segments of partitions in dropping state to dropped"`
-	Collection          int64 `name:"collection" default:"0" desc:"collection id to filter with"`
-	Partition           int64 `name:"partition" default:"0" desc:"partition id to filter with"`
-	Run                 bool  `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair segment-part-dropping" desc:"mark segments of partitions in dropping state to dropped"`
+	Collection               int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	Partition                int64 `name:"partition" default:"0" desc:"partition id to filter with"`
 }
 
 func (c *ComponentRepair) RepairSegmentPartDropCommand(ctx context.Context, p *RepairSegmentPartDropParam) error {

--- a/states/etcd/repair/wal_broadcast_task.go
+++ b/states/etcd/repair/wal_broadcast_task.go
@@ -19,10 +19,9 @@ var (
 )
 
 type WALBroadcastTaskParam struct {
-	framework.ParamBase `use:"repair wal-broadcast-task" desc:"repair wal broadcast task"`
-	Mode                string `name:"mode" default:"reset" desc:"reset or remove wal broadcast task"`
-	BroadcastID         int64  `name:"broadcast_id" default:"" desc:"broadcast id to repair"`
-	Run                 bool   `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair wal-broadcast-task" desc:"repair wal broadcast task"`
+	Mode                     string `name:"mode" default:"reset" desc:"reset or remove wal broadcast task"`
+	BroadcastID              int64  `name:"broadcast_id" default:"" desc:"broadcast id to repair"`
 }
 
 func (c *ComponentRepair) WALBroadcastTaskCommand(ctx context.Context, p *WALBroadcastTaskParam) error {

--- a/states/etcd/repair/wal_recovery_storage.go
+++ b/states/etcd/repair/wal_recovery_storage.go
@@ -16,8 +16,7 @@ import (
 )
 
 type WALRecoveryStorageParam struct {
-	framework.ParamBase `use:"repair wal-recovery-storage" desc:"recover wal from storage"`
-	Run                 bool `name:"run" default:"false" desc:"actual do repair"`
+	framework.ExecutionParam `use:"repair wal-recovery-storage" desc:"recover wal from storage"`
 }
 
 func (c *ComponentRepair) WALRecoveryStorageCommand(ctx context.Context, p *WALRecoveryStorageParam) error {

--- a/states/etcd/set/collection_alter.go
+++ b/states/etcd/set/collection_alter.go
@@ -13,9 +13,9 @@ import (
 )
 
 type FieldAttrParam struct {
-	framework.ParamBase `use:"set field-attr" desc:"set field attribute for collection"`
-	CollectionID        int64 `name:"collectionID" default:"0" desc:"collection id to update"`
-	FieldID             int64 `name:"fieldID" default:"0" desc:"field id to update"`
+	framework.ExecutionParam `use:"set field-attr" desc:"set field attribute for collection"`
+	CollectionID             int64 `name:"collectionID" default:"0" desc:"collection id to update"`
+	FieldID                  int64 `name:"fieldID" default:"0" desc:"field id to update"`
 
 	// target attributes
 	IsClusteringKey bool   `name:"clusterKey" default:"false" desc:"flags indicating whether to enable clusterKey"`
@@ -25,8 +25,6 @@ type FieldAttrParam struct {
 	// type params modification
 	TypeParams       []string `name:"typeParams" default:"" desc:"type params to set, format: key=value (e.g., max_length=256,dim=128)"`
 	DeleteTypeParams []string `name:"deleteTypeParams" default:"" desc:"type param keys to delete"`
-
-	Run bool `name:"run" default:"false"`
 }
 
 func (c *ComponentSet) FieldAttrCommand(ctx context.Context, p *FieldAttrParam) error {

--- a/states/etcd/set/collection_consistency_level.go
+++ b/states/etcd/set/collection_consistency_level.go
@@ -13,10 +13,9 @@ import (
 )
 
 type CollectionConsistencyLevelParam struct {
-	framework.ParamBase `use:"set collection consistency-level" desc:"set collection default consistency level"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to update"`
-	ConsistencyLevel    string `name:"consistency-level" default:"" desc:"Consistency Level to set"`
-	Run                 bool   `name:"run" default:"false"`
+	framework.ExecutionParam `use:"set collection consistency-level" desc:"set collection default consistency level"`
+	CollectionID             int64  `name:"collection" default:"0" desc:"collection id to update"`
+	ConsistencyLevel         string `name:"consistency-level" default:"" desc:"Consistency Level to set"`
 }
 
 func (c *ComponentSet) CollectionConsistencyLevelCommand(ctx context.Context, p *CollectionConsistencyLevelParam) error {

--- a/states/etcd/show/alias.go
+++ b/states/etcd/show/alias.go
@@ -16,9 +16,8 @@ import (
 )
 
 type AliasParam struct {
-	framework.ParamBase `use:"show alias" desc:"list alias meta info" alias:"aliases"`
-	DBID                int64  `name:"dbid" default:"-1" desc:"database id to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show alias" desc:"list alias meta info" alias:"aliases"`
+	DBID                   int64 `name:"dbid" default:"-1" desc:"database id to filter with"`
 }
 
 // AliasCommand implements `show alias` command.

--- a/states/etcd/show/bulkinsert.go
+++ b/states/etcd/show/bulkinsert.go
@@ -18,14 +18,13 @@ import (
 const printFileLimit = 3
 
 type ImportJobParam struct {
-	framework.ParamBase `use:"show bulkinsert" desc:"display bulkinsert jobs and tasks" alias:"import"`
+	framework.DataSetParam `use:"show bulkinsert" desc:"display bulkinsert jobs and tasks" alias:"import"`
 
 	JobID        int64  `name:"job" default:"0" desc:"job id to filter with"`
 	CollectionID int64  `name:"collection" default:"0" desc:"collection id to filter with"`
 	State        string `name:"state" default:"" desc:"target import job state, [pending, preimporting, importing, failed, completed]"`
 	Detail       bool   `name:"detail" default:"false" desc:"flags indicating whether printing detail bulkinsert job"`
 	ShowAllFiles bool   `name:"showAllFiles" default:"false" desc:"flags indicating whether printing all files"`
-	Format       string `name:"format" default:"" desc:"output format (default, json)"`
 }
 
 // BulkInsertCommand returns show bulkinsert command.

--- a/states/etcd/show/channel_watched.go
+++ b/states/etcd/show/channel_watched.go
@@ -17,11 +17,10 @@ import (
 )
 
 type ChannelWatchedParam struct {
-	framework.ParamBase `use:"show channel-watch" desc:"display channel watching info from data coord meta store" alias:"channel-watched"`
-	Format              string `name:"format" default:"" desc:"output format"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	WithoutSchema       bool   `name:"withoutSchema" default:"false" desc:"filter channel watch info with not schema"`
-	PrintSchema         bool   `name:"printSchema" default:"false" desc:"print schema info stored in watch info"`
+	framework.DataSetParam `use:"show channel-watch" desc:"display channel watching info from data coord meta store" alias:"channel-watched"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	WithoutSchema          bool  `name:"withoutSchema" default:"false" desc:"filter channel watch info with not schema"`
+	PrintSchema            bool  `name:"printSchema" default:"false" desc:"print schema info stored in watch info"`
 }
 
 // ChannelWatchedCommand return show channel-watched commands.

--- a/states/etcd/show/checkpoint.go
+++ b/states/etcd/show/checkpoint.go
@@ -17,9 +17,8 @@ import (
 )
 
 type CheckpointParam struct {
-	framework.ParamBase `use:"show checkpoint" desc:"list checkpoint collection vchannels" alias:"checkpoints,cp"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show checkpoint" desc:"list checkpoint collection vchannels" alias:"checkpoints,cp"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to filter with"`
 }
 
 // CheckpointCommand returns show checkpoint command.

--- a/states/etcd/show/collection.go
+++ b/states/etcd/show/collection.go
@@ -19,13 +19,12 @@ import (
 // CollectionCommand returns sub command for showCmd.
 // show collection [options...]
 type CollectionParam struct {
-	framework.ParamBase `use:"show collections" desc:"list current available collection from RootCoord"`
-	CollectionID        int64  `name:"id" default:"0" desc:"collection id to display"`
-	CollectionName      string `name:"name" default:"" desc:"collection name to display"`
-	DatabaseID          int64  `name:"dbid" default:"-1" desc:"database id to filter"`
-	State               string `name:"state" default:"" desc:"collection state to filter"`
-	WithPropertyKey     string `name:"propertyKey" default:"" desc:"collection property to filter"`
-	Format              string `name:"format" default:"" desc:"output format"`
+	framework.DataSetParam `use:"show collections" desc:"list current available collection from RootCoord"`
+	CollectionID           int64  `name:"id" default:"0" desc:"collection id to display"`
+	CollectionName         string `name:"name" default:"" desc:"collection name to display"`
+	DatabaseID             int64  `name:"dbid" default:"-1" desc:"database id to filter"`
+	State                  string `name:"state" default:"" desc:"collection state to filter"`
+	WithPropertyKey        string `name:"propertyKey" default:"" desc:"collection property to filter"`
 }
 
 func (c *ComponentShow) CollectionCommand(ctx context.Context, p *CollectionParam) (*framework.PresetResultSet, error) {

--- a/states/etcd/show/collection_loaded.go
+++ b/states/etcd/show/collection_loaded.go
@@ -18,9 +18,8 @@ const (
 )
 
 type CollectionLoadedParam struct {
-	framework.ParamBase `use:"show collection-loaded" desc:"display information of loaded collection from querycoord" alias:"collection-load"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to check"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show collection-loaded" desc:"display information of loaded collection from querycoord" alias:"collection-load"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to check"`
 }
 
 // CollectionLoadedCommand return show collection-loaded command.

--- a/states/etcd/show/compaction.go
+++ b/states/etcd/show/compaction.go
@@ -17,18 +17,17 @@ import (
 // CompactionCommand returns sub command for showCmd.
 // show compaction [options...]
 type CompactionTaskParam struct {
-	framework.ParamBase `use:"show compactions" desc:"list current available compactions from DataCoord"`
-	CollectionName      string `name:"collectionName" default:"" desc:"collection name to display"`
-	State               string `name:"state" default:"" desc:"compaction state to filter"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
-	PartitionID         int64  `name:"partitionID" default:"0" desc:"partitionID id to filter"`
-	CompactionType      string `name:"type" default:"" desc:"compaction type to filter"`
-	TriggerID           int64  `name:"triggerID" default:"0" desc:"TriggerID to filter"`
-	PlanID              int64  ` name:"planID" default:"0" desc:"PlanID  to filter"`
-	SegmentID           int64  ` name:"segmentID" default:"0" desc:"SegmentID  to filter"`
-	Detail              bool   `name:"detail" default:"false" desc:"flags indicating whether printing input/result segmentIDs"`
-	IgnoreDone          bool   `name:"ignoreDone" default:"true" desc:"ignore finished compaction tasks"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show compactions" desc:"list current available compactions from DataCoord"`
+	CollectionName         string `name:"collectionName" default:"" desc:"collection name to display"`
+	State                  string `name:"state" default:"" desc:"compaction state to filter"`
+	CollectionID           int64  `name:"collectionID" default:"0" desc:"collection id to filter"`
+	PartitionID            int64  `name:"partitionID" default:"0" desc:"partitionID id to filter"`
+	CompactionType         string `name:"type" default:"" desc:"compaction type to filter"`
+	TriggerID              int64  `name:"triggerID" default:"0" desc:"TriggerID to filter"`
+	PlanID                 int64  ` name:"planID" default:"0" desc:"PlanID  to filter"`
+	SegmentID              int64  ` name:"segmentID" default:"0" desc:"SegmentID  to filter"`
+	Detail                 bool   `name:"detail" default:"false" desc:"flags indicating whether printing input/result segmentIDs"`
+	IgnoreDone             bool   `name:"ignoreDone" default:"true" desc:"ignore finished compaction tasks"`
 }
 
 func (c *ComponentShow) CompactionTaskCommand(ctx context.Context, p *CompactionTaskParam) (*framework.PresetResultSet, error) {

--- a/states/etcd/show/config_etcd.go
+++ b/states/etcd/show/config_etcd.go
@@ -10,8 +10,7 @@ import (
 )
 
 type ConfigEtcdParam struct {
-	framework.ParamBase `use:"show config-etcd" desc:"list configuations set by etcd source"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show config-etcd" desc:"list configuations set by etcd source"`
 }
 
 // ConfigEtcdCommand return show config-etcd command.

--- a/states/etcd/show/database.go
+++ b/states/etcd/show/database.go
@@ -13,10 +13,9 @@ import (
 )
 
 type DatabaseParam struct {
-	framework.ParamBase `use:"show database" desc:"display Database info from rootcoord meta"`
-	DatabaseID          int64  `name:"id" default:"0" desc:"database id to filter with"`
-	DatabaseName        string `name:"name" default:"" desc:"database name to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show database" desc:"display Database info from rootcoord meta"`
+	DatabaseID             int64  `name:"id" default:"0" desc:"database id to filter with"`
+	DatabaseName           string `name:"name" default:"" desc:"database name to filter with"`
 }
 
 // DatabaseCommand returns show database comand.

--- a/states/etcd/show/index.go
+++ b/states/etcd/show/index.go
@@ -12,9 +12,8 @@ import (
 )
 
 type IndexParam struct {
-	framework.ParamBase `use:"show index" desc:"" alias:"indexes"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to list index on"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show index" desc:"" alias:"indexes"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to list index on"`
 }
 
 // IndexCommand returns show index command.

--- a/states/etcd/show/partition.go
+++ b/states/etcd/show/partition.go
@@ -13,9 +13,8 @@ import (
 )
 
 type PartitionParam struct {
-	framework.ParamBase `use:"show partition" desc:"list partitions of provided collection"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to list"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show partition" desc:"list partitions of provided collection"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to list"`
 }
 
 // PartitionCommand returns command to list partition info for provided collection.

--- a/states/etcd/show/partition_loaded.go
+++ b/states/etcd/show/partition_loaded.go
@@ -11,10 +11,9 @@ import (
 )
 
 type PartitionLoadedParam struct {
-	framework.ParamBase `use:"show partition-loaded" desc:"display the information of loaded partition(s) from querycoord meta"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	PartitionID         int64  `name:"partition" default:"0" desc:"partition id to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show partition-loaded" desc:"display the information of loaded partition(s) from querycoord meta"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	PartitionID            int64 `name:"partition" default:"0" desc:"partition id to filter with"`
 }
 
 func (c *ComponentShow) PartitionLoadedCommand(ctx context.Context, p *PartitionLoadedParam) (*framework.PresetResultSet, error) {

--- a/states/etcd/show/replica.go
+++ b/states/etcd/show/replica.go
@@ -15,9 +15,8 @@ import (
 )
 
 type ReplicaParam struct {
-	framework.ParamBase `use:"show replica" desc:"list current replica information from QueryCoord" alias:"replicas"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show replica" desc:"list current replica information from QueryCoord" alias:"replicas"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to filter with"`
 }
 
 // ReplicaCommand returns command for show querycoord replicas.

--- a/states/etcd/show/resource_group.go
+++ b/states/etcd/show/resource_group.go
@@ -11,9 +11,8 @@ import (
 )
 
 type ResourceGroupParam struct {
-	framework.ParamBase `use:"show resource-group" desc:"list resource groups in current instance"`
-	Name                string `name:"name" default:"" desc:"resource group name to list"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show resource-group" desc:"list resource groups in current instance"`
+	Name                   string `name:"name" default:"" desc:"resource group name to list"`
 }
 
 func (c *ComponentShow) ResourceGroupCommand(ctx context.Context, p *ResourceGroupParam) (*framework.PresetResultSet, error) {

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -18,16 +18,15 @@ import (
 )
 
 type SegmentParam struct {
-	framework.ParamBase `use:"show segment" desc:"display segment information from data coord meta store" alias:"segments"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	PartitionID         int64  `name:"partition" default:"0" desc:"partition id to filter with"`
-	SegmentID           int64  `name:"segment" default:"0" desc:"segment id to display"`
-	Format              string `name:"format" default:"line" desc:"segment display format"`
-	Detail              bool   `name:"detail" default:"false" desc:"flags indicating whether printing detail binlog info"`
-	State               string `name:"state" default:"" desc:"target segment state"`
-	Level               string `name:"level" default:"" desc:"target segment level"`
-	Sorted              string `name:"sorted" default:"" desc:"flags indicating whether sort segments by segmentID"`
-	StorageVersion      int64  `name:"storageVersion" default:"-1" desc:"segment storage version to filter"`
+	framework.DataSetParam `use:"show segment" desc:"display segment information from data coord meta store" alias:"segments"`
+	CollectionID           int64  `name:"collection" default:"0" desc:"collection id to filter with"`
+	PartitionID            int64  `name:"partition" default:"0" desc:"partition id to filter with"`
+	SegmentID              int64  `name:"segment" default:"0" desc:"segment id to display"`
+	Detail                 bool   `name:"detail" default:"false" desc:"flags indicating whether printing detail binlog info"`
+	State                  string `name:"state" default:"" desc:"target segment state"`
+	Level                  string `name:"level" default:"" desc:"target segment level"`
+	Sorted                 string `name:"sorted" default:"" desc:"flags indicating whether sort segments by segmentID"`
+	StorageVersion         int64  `name:"storageVersion" default:"-1" desc:"segment storage version to filter"`
 }
 
 type segStats struct {
@@ -209,6 +208,8 @@ func (rs *Segments) printDefault() string {
 			switch rs.format {
 			case "table":
 				printSegmentInfoToBuilder(sb, info, rs.detail)
+			case "sheet":
+				PrintSegmentInfo(info, rs.detail)
 			case "statistics":
 				if info.State != commonpb.SegmentState_Dropped {
 					for _, binlog := range info.GetBinlogs() {

--- a/states/etcd/show/segment_index.go
+++ b/states/etcd/show/segment_index.go
@@ -14,12 +14,11 @@ import (
 )
 
 type SegmentIndexParam struct {
-	framework.ParamBase `use:"show segment-index" desc:"display segment index information" alias:"segments-index,segment-indexes,segments-indexes"`
-	CollectionID        int64  `name:"collection" default:"0" desc:"collection id to filter with"`
-	SegmentID           int64  `name:"segment" default:"0" desc:"segment id to filter with"`
-	FieldID             int64  `name:"field" default:"0" desc:"field id to filter with"`
-	IndexID             int64  `name:"indexID" default:"0" desc:"index id to filter with"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show segment-index" desc:"display segment index information" alias:"segments-index,segment-indexes,segments-indexes"`
+	CollectionID           int64 `name:"collection" default:"0" desc:"collection id to filter with"`
+	SegmentID              int64 `name:"segment" default:"0" desc:"segment id to filter with"`
+	FieldID                int64 `name:"field" default:"0" desc:"field id to filter with"`
+	IndexID                int64 `name:"indexID" default:"0" desc:"index id to filter with"`
 }
 
 // SegmentIndexCommand returns show segment-index command.

--- a/states/etcd/show/session.go
+++ b/states/etcd/show/session.go
@@ -16,8 +16,7 @@ import (
 )
 
 type SessionParam struct {
-	framework.ParamBase `use:"show session" desc:"list online milvus components" alias:"sessions"`
-	Format              string `name:"format" default:"default" desc:"output format"`
+	framework.DataSetParam `use:"show session" desc:"list online milvus components" alias:"sessions"`
 }
 
 // SessionCommand returns show session command.

--- a/states/etcd/show/stats_task.go
+++ b/states/etcd/show/stats_task.go
@@ -15,15 +15,14 @@ import (
 )
 
 type StatsTaskParam struct {
-	framework.ParamBase `use:"show stats-task" desc:"display stats task information"`
-	SubJobType          string `name:"subJobType" default:"" desc:"stats type to filter with, e.g. JsonKeyIndexJob, TextIndexJob, etc."`
-	TaskID              string `name:"taskID" default:"" desc:"taskID also known as planID"`
-	State               string `name:"state" default:"" desc:"stats state"`
-	CollectionID        int64  `name:"collectionID" default:"0" desc:"collection id to filter with"`
-	SegmentID           int64  `name:"segmentID" default:"0" desc:"segmentID id to filter with"`
-	Since               string `name:"since" default:"" desc:"only show tasks created after this time, format: 2006-01-02 15:04:05 or duration like 1h, 30m"`
-	Failed              bool   `name:"failed" default:"false" desc:"only show tasks with fail reason"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show stats-task" desc:"display stats task information"`
+	SubJobType             string `name:"subJobType" default:"" desc:"stats type to filter with, e.g. JsonKeyIndexJob, TextIndexJob, etc."`
+	TaskID                 string `name:"taskID" default:"" desc:"taskID also known as planID"`
+	State                  string `name:"state" default:"" desc:"stats state"`
+	CollectionID           int64  `name:"collectionID" default:"0" desc:"collection id to filter with"`
+	SegmentID              int64  `name:"segmentID" default:"0" desc:"segmentID id to filter with"`
+	Since                  string `name:"since" default:"" desc:"only show tasks created after this time, format: 2006-01-02 15:04:05 or duration like 1h, 30m"`
+	Failed                 bool   `name:"failed" default:"false" desc:"only show tasks with fail reason"`
 }
 
 func (c *ComponentShow) StatsTaskCommand(ctx context.Context, p *StatsTaskParam) (*framework.PresetResultSet, error) {

--- a/states/etcd/show/user.go
+++ b/states/etcd/show/user.go
@@ -13,8 +13,7 @@ import (
 )
 
 type UserParam struct {
-	framework.ParamBase `use:"show user" desc:"display user info from rootcoord meta"`
-	Format              string `name:"format" default:"" desc:"output format (default, json)"`
+	framework.DataSetParam `use:"show user" desc:"display user info from rootcoord meta"`
 }
 
 // UserCommand returns show user command.

--- a/states/kill.go
+++ b/states/kill.go
@@ -15,10 +15,9 @@ import (
 )
 
 type EtcdKillParam struct {
-	framework.ParamBase `use:"kill" desc:"Kill component session from etcd"`
-	Component           string `name:"component" default:"" desc:"component type to kill"`
-	NodeID              int64  `name:"id" default:"0" desc:"Server ID to kill"`
-	Run                 bool   `name:"run" default:"false"`
+	framework.ExecutionParam `use:"kill" desc:"Kill component session from etcd"`
+	Component                string `name:"component" default:"" desc:"component type to kill"`
+	NodeID                   int64  `name:"id" default:"0" desc:"Server ID to kill"`
 }
 
 func (s *InstanceState) KillCommand(ctx context.Context, p *EtcdKillParam) error {


### PR DESCRIPTION
Add DataSetParam and ExecutionParam as typed alternatives to ParamBase, consolidating repeated Format and Run flags into reusable embedded structs. DataSetParam provides a built-in --format flag for show commands, while ExecutionParam provides a built-in --run flag with dry-run semantics for mutation commands.

Update the framework to recursively traverse anonymous embedded struct fields when setting up flags, parsing flags, and binding web parameters, enabling multi-level param inheritance.

Migrate all show commands to DataSetParam and all remove/repair/set/kill commands to ExecutionParam, eliminating duplicated field definitions across 50+ command parameter structs