### PR TITLE
enhance: enrich show replica/resource-group display with session hostname

### DIFF
--- a/models/session.go
+++ b/models/session.go
@@ -8,13 +8,14 @@ import (
 
 // Session is the json model for milvus session struct in etcd.
 type Session struct {
-	ServerID   int64  `json:"ServerID,omitempty"`
-	ServerName string `json:"ServerName,omitempty"`
-	Address    string `json:"Address,omitempty"`
-	Exclusive  bool   `json:"Exclusive,omitempty"`
-	Version    string `json:"Version,omitempty"`
-	HostName   string `json:"HostName,omitempty"`
-	LeaseID    int64  `json:"LeaseID,omitempty"`
+	ServerID     int64             `json:"ServerID,omitempty"`
+	ServerName   string            `json:"ServerName,omitempty"`
+	Address      string            `json:"Address,omitempty"`
+	Exclusive    bool              `json:"Exclusive,omitempty"`
+	Version      string            `json:"Version,omitempty"`
+	HostName     string            `json:"HostName,omitempty"`
+	LeaseID      int64             `json:"LeaseID,omitempty"`
+	ServerLabels map[string]string `json:"ServerLabels,omitempty"`
 
 	key string
 }

--- a/states/etcd/show/replica.go
+++ b/states/etcd/show/replica.go
@@ -3,8 +3,9 @@ package show
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/cockroachdb/errors"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -46,14 +47,21 @@ func (c *ComponentShow) ReplicaCommand(ctx context.Context, p *ReplicaParam) (*f
 		return nil, errors.Wrap(err, "failed to list replica info")
 	}
 
+	sessions, err := common.ListSessions(ctx, c.client, c.metaPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list sessions")
+	}
+
 	rs := framework.NewListResult[Replicas](replicas)
 	rs.collections = lo.SliceToMap(collections, func(c *models.Collection) (int64, *models.Collection) { return c.GetProto().GetID(), c })
+	rs.sessionMap = lo.SliceToMap(sessions, func(s *models.Session) (int64, *models.Session) { return s.ServerID, s })
 	return framework.NewPresetResultSet(rs, framework.NameFormat(p.Format)), nil
 }
 
 type Replicas struct {
 	framework.ListResultSet[*models.Replica]
 	collections map[int64]*models.Collection
+	sessionMap  map[int64]*models.Session
 }
 
 func (rs *Replicas) TableHeaders() table.Row {
@@ -76,15 +84,21 @@ func (rs *Replicas) PrintAs(format framework.Format) string {
 	switch format {
 	case framework.FormatDefault, framework.FormatPlain:
 		sb := &strings.Builder{}
+		tw := tabwriter.NewWriter(sb, 0, 0, 2, ' ', 0)
 		groups := lo.GroupBy(rs.Data, func(replica *models.Replica) int64 { return replica.GetProto().CollectionID })
 		for collectionID, replicas := range groups {
-			fmt.Fprintf(sb, "CollectionID: %d\t CollectionName:%s\n", collectionID, rs.collections[collectionID].GetProto().Schema.Name)
-			for _, replica := range replicas {
-				rs.printReplica(sb, replica)
+			collName := ""
+			if coll, ok := rs.collections[collectionID]; ok {
+				collName = coll.GetProto().Schema.Name
 			}
-			fmt.Fprintln(sb, "================================================================================")
-			fmt.Fprintln(sb)
+			fmt.Fprintf(tw, "CollectionID: %d\tCollectionName: %s\n", collectionID, collName)
+			for _, replica := range replicas {
+				rs.printReplica(tw, replica)
+			}
+			fmt.Fprintln(tw, "================================================================================")
+			fmt.Fprintln(tw)
 		}
+		tw.Flush()
 		return sb.String()
 	case framework.FormatJSON:
 		return rs.printAsJSON()
@@ -93,18 +107,26 @@ func (rs *Replicas) PrintAs(format framework.Format) string {
 	return ""
 }
 
+type nodeInfoJSON struct {
+	NodeID   int64  `json:"node_id"`
+	HostName string `json:"hostname"`
+}
+
 func (rs *Replicas) printAsJSON() string {
 	type ShardReplicaJSON struct {
-		Shard string  `json:"shard"`
-		Nodes []int64 `json:"nodes"`
+		Shard string         `json:"shard"`
+		Nodes []nodeInfoJSON `json:"nodes"`
 	}
 
 	type ReplicaJSON struct {
-		ReplicaID     int64              `json:"replica_id"`
-		CollectionID  int64              `json:"collection_id"`
-		ResourceGroup string             `json:"resource_group"`
-		Nodes         []int64            `json:"nodes"`
-		ShardReplicas []ShardReplicaJSON `json:"shard_replicas,omitempty"`
+		ReplicaID        int64              `json:"replica_id"`
+		CollectionID     int64              `json:"collection_id"`
+		ResourceGroup    string             `json:"resource_group"`
+		RwNodes          []nodeInfoJSON     `json:"rw_nodes"`
+		RoNodes          []nodeInfoJSON     `json:"ro_nodes,omitempty"`
+		RwStreamingNodes []nodeInfoJSON     `json:"rw_streaming_nodes,omitempty"`
+		RoStreamingNodes []nodeInfoJSON     `json:"ro_streaming_nodes,omitempty"`
+		ShardReplicas    []ShardReplicaJSON `json:"shard_replicas,omitempty"`
 	}
 
 	type CollectionReplicasJSON struct {
@@ -137,15 +159,18 @@ func (rs *Replicas) printAsJSON() string {
 			for shard, shardReplica := range replica.ChannelNodeInfos {
 				shardReplicas = append(shardReplicas, ShardReplicaJSON{
 					Shard: shard,
-					Nodes: shardReplica.RwNodes,
+					Nodes: rs.toNodeInfoJSONs(shardReplica.RwNodes),
 				})
 			}
 			replicaJSONs = append(replicaJSONs, ReplicaJSON{
-				ReplicaID:     replica.ID,
-				CollectionID:  replica.CollectionID,
-				ResourceGroup: replica.ResourceGroup,
-				Nodes:         replica.Nodes,
-				ShardReplicas: shardReplicas,
+				ReplicaID:        replica.ID,
+				CollectionID:     replica.CollectionID,
+				ResourceGroup:    replica.ResourceGroup,
+				RwNodes:          rs.toNodeInfoJSONs(replica.Nodes),
+				RoNodes:          rs.toNodeInfoJSONs(replica.RoNodes),
+				RwStreamingNodes: rs.toNodeInfoJSONs(replica.RwSqNodes),
+				RoStreamingNodes: rs.toNodeInfoJSONs(replica.RoSqNodes),
+				ShardReplicas:    shardReplicas,
 			})
 		}
 
@@ -159,14 +184,49 @@ func (rs *Replicas) printAsJSON() string {
 	return framework.MarshalJSON(output)
 }
 
-func (rs *Replicas) printReplica(sb *strings.Builder, r *models.Replica) {
+func (rs *Replicas) toNodeInfoJSONs(nodeIDs []int64) []nodeInfoJSON {
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+	result := make([]nodeInfoJSON, 0, len(nodeIDs))
+	for _, id := range nodeIDs {
+		result = append(result, nodeInfoJSON{NodeID: id, HostName: rs.getHostName(id)})
+	}
+	return result
+}
+
+func (rs *Replicas) getHostName(nodeID int64) string {
+	if sess, ok := rs.sessionMap[nodeID]; ok {
+		return sess.HostName
+	}
+	return "NotFound"
+}
+
+func (rs *Replicas) printReplica(w *tabwriter.Writer, r *models.Replica) {
 	replica := r.GetProto()
-	fmt.Fprintln(sb, "================================================================================")
-	fmt.Fprintf(sb, "ReplicaID: %d \n", replica.ID)
-	fmt.Fprintf(sb, "ResourceGroup: %s\n", replica.ResourceGroup)
-	sort.Slice(replica.Nodes, func(i, j int) bool { return replica.Nodes[i] < replica.Nodes[j] })
-	fmt.Fprintf(sb, "All Nodes:%v\n", replica.Nodes)
+	fmt.Fprintln(w, "================================================================================")
+	fmt.Fprintf(w, "ReplicaID: %d\n", replica.ID)
+	fmt.Fprintf(w, "ResourceGroup: %s\n", replica.ResourceGroup)
+	rs.printNodeList(w, "RW Query Nodes", replica.Nodes)
+	rs.printNodeList(w, "RO Query Nodes", replica.RoNodes)
+	rs.printNodeList(w, "RW Streaming Nodes", replica.RwSqNodes)
+	rs.printNodeList(w, "RO Streaming Nodes", replica.RoSqNodes)
 	for shard, shardReplica := range replica.ChannelNodeInfos {
-		fmt.Fprintf(sb, "-- Shard Replica: Shard (%s) Nodes:%v\n", shard, shardReplica.RwNodes)
+		fmt.Fprintf(w, "-- Shard (%s) Nodes:\n", shard)
+		for _, id := range shardReplica.RwNodes {
+			fmt.Fprintf(w, "    - %d\t%s\n", id, rs.getHostName(id))
+		}
+	}
+}
+
+func (rs *Replicas) printNodeList(w *tabwriter.Writer, label string, nodeIDs []int64) {
+	if len(nodeIDs) == 0 {
+		return
+	}
+	sorted := append([]int64{}, nodeIDs...)
+	slices.Sort(sorted)
+	fmt.Fprintf(w, "%s (%d):\n", label, len(sorted))
+	for _, id := range sorted {
+		fmt.Fprintf(w, "  - %d\t%s\n", id, rs.getHostName(id))
 	}
 }

--- a/states/etcd/show/replicate.go
+++ b/states/etcd/show/replicate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -22,10 +23,18 @@ func (c *ComponentShow) ReplicateCommand(ctx context.Context, p *ReplicateParam)
 	if err != nil {
 		return err
 	}
-	cfgHelper, err := replicateutil.NewConfigHelper(c.basePath, cfg.ReplicateConfiguration)
+	currentClusterID := c.basePath
+	for _, cluster := range cfg.ReplicateConfiguration.GetClusters() {
+		if strings.Contains(cluster.GetClusterId(), c.basePath) || strings.Contains(c.basePath, cluster.GetClusterId()) {
+			currentClusterID = cluster.GetClusterId()
+			break
+		}
+	}
+	cfgHelper, err := replicateutil.NewConfigHelper(currentClusterID, cfg.ReplicateConfiguration)
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Current Cluster ID: %s\n", currentClusterID)
 	cdcTasks, err := common.ListReplicatePChannel(ctx, c.client, c.metaPath)
 	if err != nil {
 		return err

--- a/states/etcd/show/resource_group.go
+++ b/states/etcd/show/resource_group.go
@@ -124,8 +124,8 @@ func (rs *ResourceGroups) printAsJSON() string {
 	}
 
 	type ResourceGroupJSON struct {
-		Name   string       `json:"name"`
-		Config ConfigJSON   `json:"config"`
+		Name   string         `json:"name"`
+		Config ConfigJSON     `json:"config"`
 		Nodes  []NodeInfoJSON `json:"nodes"`
 	}
 

--- a/states/etcd/show/resource_group.go
+++ b/states/etcd/show/resource_group.go
@@ -8,9 +8,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/cockroachdb/errors"
-	"github.com/samber/lo"
-
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"

--- a/states/etcd/show/resource_group.go
+++ b/states/etcd/show/resource_group.go
@@ -3,13 +3,20 @@ package show
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
+	"text/tabwriter"
+
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/rgpb"
 )
 
 type ResourceGroupParam struct {
@@ -25,11 +32,26 @@ func (c *ComponentShow) ResourceGroupCommand(ctx context.Context, p *ResourceGro
 		return nil, err
 	}
 
-	return framework.NewPresetResultSet(framework.NewListResult[ResourceGroups](rgs), framework.NameFormat(p.Format)), nil
+	sessions, err := common.ListSessions(ctx, c.client, c.metaPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list sessions")
+	}
+
+	rs := framework.NewListResult[ResourceGroups](rgs)
+	rs.sessionMap = lo.SliceToMap(sessions, func(s *models.Session) (int64, *models.Session) { return s.ServerID, s })
+	return framework.NewPresetResultSet(rs, framework.NameFormat(p.Format)), nil
 }
 
 type ResourceGroups struct {
 	framework.ListResultSet[*models.ResourceGroup]
+	sessionMap map[int64]*models.Session
+}
+
+func (rs *ResourceGroups) getHostName(nodeID int64) string {
+	if sess, ok := rs.sessionMap[nodeID]; ok {
+		return sess.HostName
+	}
+	return "NotFound"
 }
 
 func (rs *ResourceGroups) TableHeaders() table.Row {
@@ -49,10 +71,36 @@ func (rs *ResourceGroups) PrintAs(format framework.Format) string {
 	switch format {
 	case framework.FormatDefault, framework.FormatPlain:
 		sb := &strings.Builder{}
+		tw := tabwriter.NewWriter(sb, 0, 0, 2, ' ', 0)
 		for _, info := range rs.Data {
 			rg := info.GetProto()
-			fmt.Fprintf(sb, "Resource Group Name: %s\tCapacity[Legacy]: %d\tNodes: %v\tLimit: %d\tRequest: %d\n", rg.GetName(), rg.GetCapacity(), rg.GetNodes(), rg.GetConfig().GetLimits().GetNodeNum(), rg.GetConfig().GetRequests().GetNodeNum())
+			fmt.Fprintf(tw, "Resource Group: %s\n", rg.GetName())
+			// Config
+			cfg := rg.GetConfig()
+			fmt.Fprintf(tw, "  Config:\n")
+			fmt.Fprintf(tw, "    Request: %d\tLimit: %d\n", cfg.GetRequests().GetNodeNum(), cfg.GetLimits().GetNodeNum())
+			if transferFrom := cfg.GetTransferFrom(); len(transferFrom) > 0 {
+				fmt.Fprintf(tw, "    TransferFrom: %v\n", lo.Map(transferFrom, func(t *rgpb.ResourceGroupTransfer, _ int) string { return t.GetResourceGroup() }))
+			}
+			if transferTo := cfg.GetTransferTo(); len(transferTo) > 0 {
+				fmt.Fprintf(tw, "    TransferTo: %v\n", lo.Map(transferTo, func(t *rgpb.ResourceGroupTransfer, _ int) string { return t.GetResourceGroup() }))
+			}
+			if nodeFilter := cfg.GetNodeFilter(); nodeFilter != nil && len(nodeFilter.GetNodeLabels()) > 0 {
+				labels := lo.Map(nodeFilter.GetNodeLabels(), func(kv *commonpb.KeyValuePair, _ int) string {
+					return fmt.Sprintf("%s=%s", kv.GetKey(), kv.GetValue())
+				})
+				fmt.Fprintf(tw, "    NodeFilter: [%s]\n", strings.Join(labels, ", "))
+			}
+			// Nodes
+			nodes := append([]int64{}, rg.GetNodes()...)
+			slices.Sort(nodes)
+			fmt.Fprintf(tw, "  Nodes (%d):\n", len(nodes))
+			for _, nodeID := range nodes {
+				fmt.Fprintf(tw, "    - %d\t%s\n", nodeID, rs.getHostName(nodeID))
+			}
+			fmt.Fprintln(tw)
 		}
+		tw.Flush()
 		fmt.Fprintf(sb, "--- Total Resource Group(s): %d\n", len(rs.Data))
 		return sb.String()
 	case framework.FormatJSON:
@@ -62,12 +110,23 @@ func (rs *ResourceGroups) PrintAs(format framework.Format) string {
 }
 
 func (rs *ResourceGroups) printAsJSON() string {
+	type NodeInfoJSON struct {
+		NodeID   int64  `json:"node_id"`
+		HostName string `json:"hostname"`
+	}
+
+	type ConfigJSON struct {
+		RequestNodeNum int32    `json:"request_node_num"`
+		LimitNodeNum   int32    `json:"limit_node_num"`
+		TransferFrom   []string `json:"transfer_from,omitempty"`
+		TransferTo     []string `json:"transfer_to,omitempty"`
+		NodeLabels     []string `json:"node_labels,omitempty"`
+	}
+
 	type ResourceGroupJSON struct {
-		Name           string  `json:"name"`
-		CapacityLegacy int32   `json:"capacity_legacy"`
-		Nodes          []int64 `json:"nodes"`
-		LimitNodeNum   int32   `json:"limit_node_num"`
-		RequestNodeNum int32   `json:"request_node_num"`
+		Name   string       `json:"name"`
+		Config ConfigJSON   `json:"config"`
+		Nodes  []NodeInfoJSON `json:"nodes"`
 	}
 
 	type OutputJSON struct {
@@ -82,12 +141,35 @@ func (rs *ResourceGroups) printAsJSON() string {
 
 	for _, info := range rs.Data {
 		rg := info.GetProto()
+		cfg := rg.GetConfig()
+
+		cfgJSON := ConfigJSON{
+			RequestNodeNum: cfg.GetRequests().GetNodeNum(),
+			LimitNodeNum:   cfg.GetLimits().GetNodeNum(),
+		}
+		if transferFrom := cfg.GetTransferFrom(); len(transferFrom) > 0 {
+			cfgJSON.TransferFrom = lo.Map(transferFrom, func(t *rgpb.ResourceGroupTransfer, _ int) string { return t.GetResourceGroup() })
+		}
+		if transferTo := cfg.GetTransferTo(); len(transferTo) > 0 {
+			cfgJSON.TransferTo = lo.Map(transferTo, func(t *rgpb.ResourceGroupTransfer, _ int) string { return t.GetResourceGroup() })
+		}
+		if nodeFilter := cfg.GetNodeFilter(); nodeFilter != nil && len(nodeFilter.GetNodeLabels()) > 0 {
+			cfgJSON.NodeLabels = lo.Map(nodeFilter.GetNodeLabels(), func(kv *commonpb.KeyValuePair, _ int) string {
+				return fmt.Sprintf("%s=%s", kv.GetKey(), kv.GetValue())
+			})
+		}
+
+		sortedNodes := append([]int64{}, rg.GetNodes()...)
+		slices.Sort(sortedNodes)
+		nodes := make([]NodeInfoJSON, 0, len(sortedNodes))
+		for _, nodeID := range sortedNodes {
+			nodes = append(nodes, NodeInfoJSON{NodeID: nodeID, HostName: rs.getHostName(nodeID)})
+		}
+
 		output.ResourceGroups = append(output.ResourceGroups, ResourceGroupJSON{
-			Name:           rg.GetName(),
-			CapacityLegacy: rg.GetCapacity(),
-			Nodes:          rg.GetNodes(),
-			LimitNodeNum:   rg.GetConfig().GetLimits().GetNodeNum(),
-			RequestNodeNum: rg.GetConfig().GetRequests().GetNodeNum(),
+			Name:   rg.GetName(),
+			Config: cfgJSON,
+			Nodes:  nodes,
 		})
 	}
 

--- a/states/etcd/show/session.go
+++ b/states/etcd/show/session.go
@@ -98,13 +98,13 @@ func (rs *Sessions) printAsGroups() string {
 			return session.IsMain(coord)
 		})
 		if main != nil {
-			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d\n", color.GreenString("[Main]"), main.ServerID, isMixture(main), main.Version, main.Address, main.HostName, main.LeaseID)
+			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d%s\n", color.GreenString("[Main]"), main.ServerID, isMixture(main), main.Version, main.Address, main.HostName, main.LeaseID, formatServerLabels(main.ServerLabels))
 		}
 		standBys := lo.Filter(sessions, func(session *models.Session, _ int) bool {
 			return main == nil || session.ServerID != main.ServerID
 		})
 		for _, standBy := range standBys {
-			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d\n", color.YellowString("[Stand]"), standBy.ServerID, isMixture(standBy), standBy.Version, standBy.Address, standBy.HostName, standBy.LeaseID)
+			fmt.Fprintf(sb, "%s\tID: %d%s\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d%s\n", color.YellowString("[Stand]"), standBy.ServerID, isMixture(standBy), standBy.Version, standBy.Address, standBy.HostName, standBy.LeaseID, formatServerLabels(standBy.ServerLabels))
 		}
 		fmt.Fprintln(sb)
 	}
@@ -113,10 +113,21 @@ func (rs *Sessions) printAsGroups() string {
 		fmt.Fprintf(sb, "Node(s) %s\n", color.GreenString(node))
 		sessions := componentGroups[node]
 		for _, session := range sessions {
-			fmt.Fprintf(sb, "\tID: %d\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d\n", session.ServerID, session.Version, session.Address, session.HostName, session.LeaseID)
+			fmt.Fprintf(sb, "\tID: %d\tVersion: %s\tAddress: %s\tHostName: %s\tLeaseID: %d%s\n", session.ServerID, session.Version, session.Address, session.HostName, session.LeaseID, formatServerLabels(session.ServerLabels))
 		}
 		fmt.Fprintln(sb)
 	}
 
 	return sb.String()
+}
+
+func formatServerLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(labels))
+	for k, v := range labels {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	return fmt.Sprintf("\tLabels: [%s]", strings.Join(parts, ", "))
 }

--- a/states/etcd/show/wal_distribution.go
+++ b/states/etcd/show/wal_distribution.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
@@ -27,6 +29,12 @@ func (c *ComponentShow) WalDistributionCommand(ctx context.Context, p *WALDistri
 		return err
 	}
 
+	sessions, err := common.ListSessions(ctx, c.client, c.metaPath)
+	if err != nil {
+		return err
+	}
+	sessionMap := lo.SliceToMap(sessions, func(s *models.Session) (int64, *models.Session) { return s.ServerID, s })
+
 	t := table.NewWriter()
 	t.SetTitle("WAL Distribution At Coordinator")
 	t.SetOutputMirror(os.Stdout)
@@ -37,16 +45,16 @@ func (c *ComponentShow) WalDistributionCommand(ctx context.Context, p *WALDistri
 	t.AppendHeader(header)
 	for _, meta := range metas {
 		channelInfo := types.NewPChannelInfoFromProto(meta.Channel)
-		assignedTo := types.NewStreamingNodeInfoFromProto(meta.Node)
+		nodeInfo := types.NewStreamingNodeInfoFromProto(meta.Node)
 		lastAssignTimestamp := time.Unix(int64(meta.LastAssignTimestampSeconds), 0)
 		row := table.Row{
 			channelInfo,
-			assignedTo,
+			formatStreamingNode(nodeInfo, sessionMap),
 			strings.TrimPrefix(meta.State.String(), "PCHANNEL_META_STATE_"),
 			lastAssignTimestamp,
 		}
 		if p.WithHistory {
-			row = append(row, c.formatHistory(meta.Histories))
+			row = append(row, c.formatHistory(meta.Histories, sessionMap))
 		}
 		t.AppendRow(row)
 	}
@@ -54,14 +62,21 @@ func (c *ComponentShow) WalDistributionCommand(ctx context.Context, p *WALDistri
 	return nil
 }
 
-func (c *ComponentShow) formatHistory(histories []*streamingpb.PChannelAssignmentLog) string {
+func (c *ComponentShow) formatHistory(histories []*streamingpb.PChannelAssignmentLog, sessionMap map[int64]*models.Session) string {
 	if len(histories) == 0 {
 		return ""
 	}
 	ss := make([]string, 0, len(histories))
 	for _, history := range histories {
-		assignedTo := types.NewStreamingNodeInfoFromProto(history.Node)
-		ss = append(ss, fmt.Sprintf("%s@%d->%s", types.AccessMode(history.AccessMode).String(), history.Term, assignedTo.String()))
+		nodeInfo := types.NewStreamingNodeInfoFromProto(history.Node)
+		ss = append(ss, fmt.Sprintf("%s@%d->%s", types.AccessMode(history.AccessMode).String(), history.Term, formatStreamingNode(nodeInfo, sessionMap)))
 	}
 	return strings.Join(ss, "\n")
+}
+
+func formatStreamingNode(node types.StreamingNodeInfo, sessionMap map[int64]*models.Session) string {
+	if sess, ok := sessionMap[node.ServerID]; ok {
+		return fmt.Sprintf("%d(%s)", node.ServerID, sess.HostName)
+	}
+	return fmt.Sprintf("%d(NotFound)", node.ServerID)
 }

--- a/states/etcd/show/wal_recovery_storage.go
+++ b/states/etcd/show/wal_recovery_storage.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
@@ -33,11 +35,18 @@ func (c *ComponentShow) WalRecoveryStorageCommand(ctx context.Context, p *WALRec
 		return err
 	}
 
+	sessions, err := common.ListSessions(ctx, c.client, c.metaPath)
+	if err != nil {
+		return err
+	}
+	sessionMap := lo.SliceToMap(sessions, func(s *models.Session) (int64, *models.Session) { return s.ServerID, s })
+
+	nodeInfo := types.NewStreamingNodeInfoFromProto(metas.Channel.Node)
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetTitle(fmt.Sprintf("WAL Recovery Storage: %s, At StreamingNode: %s, Checkpoints: %s",
 		types.NewPChannelInfoFromProto(metas.Channel.Channel).String(),
-		types.NewStreamingNodeInfoFromProto(metas.Channel.Node).String(),
+		formatStreamingNode(nodeInfo, sessionMap),
 		common.FormatWALCheckpoint(p.WALName, metas.Checkpoints)))
 	t.AppendHeader(table.Row{"Channel", "Partition Count", "Segment Count", "Segments", "SchemaVersion"})
 	for _, meta := range metas.VChannels {


### PR DESCRIPTION
- show replica: display RW/RO Query Nodes and RW/RO Streaming Nodes with hostname from session info, one node per line with tabwriter alignment
- show resource-group: display full ResourceGroupConfig (request, limit, transfer_from, transfer_to, node_filter) and nodes with hostname
- show wal-distribution: replace StreamingNode address with hostname
- show wal-recovery-storage: replace StreamingNode address with hostname
- All node displays show "NotFound" when session is missing