### PR TITLE
feat: add unified table format support for show commands via TableResultSet interface

### DIFF
--- a/framework/command.go
+++ b/framework/command.go
@@ -147,7 +147,7 @@ func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool
 					}
 				}
 				if outputFormat == FormatTable {
-					innerRS := ResultSet(rs)
+					innerRS := rs
 					if preset, ok := rs.(*PresetResultSet); ok {
 						innerRS = preset.ResultSet
 					}

--- a/framework/command.go
+++ b/framework/command.go
@@ -146,6 +146,20 @@ func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool
 						outputFormat = preset.GetFormat()
 					}
 				}
+				if outputFormat == FormatTable {
+					innerRS := ResultSet(rs)
+					if preset, ok := rs.(*PresetResultSet); ok {
+						innerRS = preset.ResultSet
+					}
+					if trs, ok := innerRS.(TableResultSet); ok {
+						title := ""
+						if titler, ok := innerRS.(TableTitler); ok {
+							title = titler.TableTitle()
+						}
+						fmt.Println(RenderTable(trs.TableHeaders(), trs.TableRows(), title))
+						continue
+					}
+				}
 				fmt.Println(rs.PrintAs(outputFormat))
 			}
 		}

--- a/framework/resultset.go
+++ b/framework/resultset.go
@@ -1,6 +1,10 @@
 package framework
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+)
 
 type Format int32
 
@@ -82,6 +86,29 @@ func NewListResult[LRS any, P interface {
 	var p P = &t
 	p.SetData(data)
 	return &t
+}
+
+// TableResultSet is an optional interface for ResultSet implementations
+// to support FormatTable output via go-pretty.
+type TableResultSet interface {
+	TableHeaders() table.Row
+	TableRows() []table.Row
+}
+
+// TableTitler is an optional interface for providing a table title.
+type TableTitler interface {
+	TableTitle() string
+}
+
+// RenderTable renders a go-pretty table from headers, rows, and optional title.
+func RenderTable(headers table.Row, rows []table.Row, title string) string {
+	t := table.NewWriter()
+	t.AppendHeader(headers)
+	t.AppendRows(rows)
+	if title != "" {
+		t.SetTitle(title)
+	}
+	return t.Render()
 }
 
 // MarshalJSON is a helper function for JSON serialization.

--- a/states/etcd/show/alias.go
+++ b/states/etcd/show/alias.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -34,6 +35,18 @@ func (c *ComponentShow) AliasCommand(ctx context.Context, p *AliasParam) (*frame
 
 type Aliases struct {
 	framework.ListResultSet[*models.Alias]
+}
+
+func (rs *Aliases) TableHeaders() table.Row {
+	return table.Row{"DBID", "CollectionID", "Name", "State"}
+}
+
+func (rs *Aliases) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, a := range rs.Data {
+		rows = append(rows, table.Row{a.DBID, a.CollectionID, a.Name, a.State.String()})
+	}
+	return rows
 }
 
 func (rs *Aliases) PrintAs(format framework.Format) string {

--- a/states/etcd/show/channel_watched.go
+++ b/states/etcd/show/channel_watched.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -44,6 +45,22 @@ func (c *ComponentShow) ChannelWatchedCommand(ctx context.Context, p *ChannelWat
 type ChannelsWatched struct {
 	data        []*models.ChannelWatch
 	printSchema bool
+}
+
+func (rs *ChannelsWatched) TableHeaders() table.Row {
+	return table.Row{"VChannel", "State", "CollectionID"}
+}
+
+func (rs *ChannelsWatched) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.data))
+	for _, model := range rs.data {
+		info := model.GetProto()
+		rows = append(rows, table.Row{
+			info.Vchan.ChannelName, info.State.String(),
+			info.Vchan.CollectionID,
+		})
+	}
+	return rows
 }
 
 func (rs *ChannelsWatched) Entities() any {

--- a/states/etcd/show/checkpoint.go
+++ b/states/etcd/show/checkpoint.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -71,6 +72,23 @@ type Checkpoint struct {
 
 type Checkpoints struct {
 	framework.ListResultSet[*Checkpoint]
+}
+
+func (rs *Checkpoints) TableHeaders() table.Row {
+	return table.Row{"VChannel", "Source", "Timestamp"}
+}
+
+func (rs *Checkpoints) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, cp := range rs.Data {
+		ts := ""
+		if cp.Checkpoint != nil {
+			t, _ := utils.ParseTS(cp.Checkpoint.GetProto().GetTimestamp())
+			ts = t.Format("2006-01-02 15:04:05")
+		}
+		rows = append(rows, table.Row{cp.Channel.VirtualName, cp.Source, ts})
+	}
+	return rows
 }
 
 func (rs *Checkpoints) PrintAs(format framework.Format) string {

--- a/states/etcd/show/collection.go
+++ b/states/etcd/show/collection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -94,6 +95,23 @@ type Collections struct {
 	total       int64
 	channels    int
 	healthy     int
+}
+
+func (rs *Collections) TableHeaders() table.Row {
+	return table.Row{"ID", "Name", "DBID", "State", "Fields", "Channels"}
+}
+
+func (rs *Collections) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.collections))
+	for _, coll := range rs.collections {
+		proto := coll.GetProto()
+		rows = append(rows, table.Row{
+			proto.ID, proto.Schema.Name, proto.DbId,
+			proto.State.String(), len(proto.Schema.Fields),
+			len(coll.Channels()),
+		})
+	}
+	return rows
 }
 
 func (rs *Collections) PrintAs(format framework.Format) string {

--- a/states/etcd/show/compaction.go
+++ b/states/etcd/show/compaction.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -91,6 +92,21 @@ type CompactionTasks struct {
 	tasks []*models.CompactionTask
 	total int64
 	param *CompactionTaskParam
+}
+
+func (rs *CompactionTasks) TableHeaders() table.Row {
+	return table.Row{"PlanID", "CollectionID", "Type", "State"}
+}
+
+func (rs *CompactionTasks) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.tasks))
+	for _, t := range rs.tasks {
+		rows = append(rows, table.Row{
+			t.GetPlanID(), t.GetCollectionID(),
+			t.GetType().String(), t.GetState().String(),
+		})
+	}
+	return rows
 }
 
 func (rs *CompactionTasks) PrintAs(format framework.Format) string {

--- a/states/etcd/show/config_etcd.go
+++ b/states/etcd/show/config_etcd.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 )
@@ -39,6 +41,18 @@ type ConfigItem struct {
 
 type ConfigEtcdResult struct {
 	configs []ConfigItem
+}
+
+func (rs *ConfigEtcdResult) TableHeaders() table.Row {
+	return table.Row{"Key", "Value"}
+}
+
+func (rs *ConfigEtcdResult) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.configs))
+	for _, config := range rs.configs {
+		rows = append(rows, table.Row{config.Key, config.Value})
+	}
+	return rows
 }
 
 func (rs *ConfigEtcdResult) Entities() any {

--- a/states/etcd/show/database.go
+++ b/states/etcd/show/database.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -33,6 +34,19 @@ func (c *ComponentShow) DatabaseCommand(ctx context.Context, p *DatabaseParam) (
 
 type Databases struct {
 	framework.ListResultSet[*models.Database]
+}
+
+func (rs *Databases) TableHeaders() table.Row {
+	return table.Row{"ID", "Name", "TenantID", "State"}
+}
+
+func (rs *Databases) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, database := range rs.Data {
+		db := database.GetProto()
+		rows = append(rows, table.Row{db.Id, db.Name, db.TenantId, db.State.String()})
+	}
+	return rows
 }
 
 func (rs *Databases) PrintAs(format framework.Format) string {

--- a/states/etcd/show/index.go
+++ b/states/etcd/show/index.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
@@ -30,6 +32,26 @@ func (c *ComponentShow) IndexCommand(ctx context.Context, p *IndexParam) (*frame
 
 type Indexes struct {
 	framework.ListResultSet[*models.FieldIndex]
+}
+
+func (rs *Indexes) TableHeaders() table.Row {
+	return table.Row{"IndexID", "IndexName", "CollectionID", "FieldID", "IndexType", "MetricType"}
+}
+
+func (rs *Indexes) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, info := range rs.Data {
+		index := info.GetProto()
+		rows = append(rows, table.Row{
+			index.GetIndexInfo().GetIndexID(),
+			index.GetIndexInfo().GetIndexName(),
+			index.GetIndexInfo().GetCollectionID(),
+			index.GetIndexInfo().GetFieldID(),
+			common.GetKVPair(index.GetIndexInfo().GetIndexParams(), "index_type"),
+			common.GetKVPair(index.GetIndexInfo().GetIndexParams(), "metric_type"),
+		})
+	}
+	return rows
 }
 
 func (rs *Indexes) PrintAs(format framework.Format) string {

--- a/states/etcd/show/partition.go
+++ b/states/etcd/show/partition.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -37,6 +38,19 @@ func (c *ComponentShow) PartitionCommand(ctx context.Context, p *PartitionParam)
 
 type Partitions struct {
 	framework.ListResultSet[*models.Partition]
+}
+
+func (rs *Partitions) TableHeaders() table.Row {
+	return table.Row{"PartitionID", "Name", "State"}
+}
+
+func (rs *Partitions) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, info := range rs.Data {
+		partition := info.GetProto()
+		rows = append(rows, table.Row{partition.GetPartitionID(), partition.GetPartitionName(), partition.State.String()})
+	}
+	return rows
 }
 
 func (rs *Partitions) PrintAs(format framework.Format) string {

--- a/states/etcd/show/replica.go
+++ b/states/etcd/show/replica.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -53,6 +54,22 @@ func (c *ComponentShow) ReplicaCommand(ctx context.Context, p *ReplicaParam) (*f
 type Replicas struct {
 	framework.ListResultSet[*models.Replica]
 	collections map[int64]*models.Collection
+}
+
+func (rs *Replicas) TableHeaders() table.Row {
+	return table.Row{"ReplicaID", "CollectionID", "ResourceGroup", "Nodes"}
+}
+
+func (rs *Replicas) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, r := range rs.Data {
+		replica := r.GetProto()
+		rows = append(rows, table.Row{
+			replica.ID, replica.CollectionID,
+			replica.ResourceGroup, fmt.Sprintf("%v", replica.Nodes),
+		})
+	}
+	return rows
 }
 
 func (rs *Replicas) PrintAs(format framework.Format) string {

--- a/states/etcd/show/resource_group.go
+++ b/states/etcd/show/resource_group.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
@@ -28,6 +30,19 @@ func (c *ComponentShow) ResourceGroupCommand(ctx context.Context, p *ResourceGro
 
 type ResourceGroups struct {
 	framework.ListResultSet[*models.ResourceGroup]
+}
+
+func (rs *ResourceGroups) TableHeaders() table.Row {
+	return table.Row{"Name", "Capacity", "Nodes"}
+}
+
+func (rs *ResourceGroups) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, info := range rs.Data {
+		rg := info.GetProto()
+		rows = append(rows, table.Row{rg.GetName(), rg.GetCapacity(), fmt.Sprintf("%v", rg.GetNodes())})
+	}
+	return rows
 }
 
 func (rs *ResourceGroups) PrintAs(format framework.Format) string {

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -68,6 +69,22 @@ type Segments struct {
 	segments []*models.Segment
 	format   string
 	detail   bool
+}
+
+func (rs *Segments) TableHeaders() table.Row {
+	return table.Row{"SegmentID", "CollectionID", "PartitionID", "State", "Level", "NumOfRows", "StorageVersion", "IsSorted"}
+}
+
+func (rs *Segments) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.segments))
+	for _, info := range rs.segments {
+		rows = append(rows, table.Row{
+			info.ID, info.CollectionID, info.PartitionID,
+			info.State.String(), info.Level.String(),
+			info.NumOfRows, info.StorageVersion, info.IsSorted,
+		})
+	}
+	return rows
 }
 
 func (rs *Segments) Entities() any {

--- a/states/etcd/show/segment_index.go
+++ b/states/etcd/show/segment_index.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -63,6 +64,22 @@ type SegmentIndexes struct {
 	segments       []*models.Segment
 	segmentIndexes []*models.SegmentIndex
 	indexBuildInfo []*models.FieldIndex
+}
+
+func (rs *SegmentIndexes) TableHeaders() table.Row {
+	return table.Row{"SegmentID", "IndexID", "BuildID", "State"}
+}
+
+func (rs *SegmentIndexes) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.segmentIndexes))
+	for _, info := range rs.segmentIndexes {
+		segIdx := info.GetProto()
+		rows = append(rows, table.Row{
+			segIdx.GetSegmentID(), segIdx.GetIndexID(),
+			segIdx.GetBuildID(), segIdx.GetState().String(),
+		})
+	}
+	return rows
 }
 
 func (rs *SegmentIndexes) Entities() any {

--- a/states/etcd/show/session.go
+++ b/states/etcd/show/session.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -32,6 +33,18 @@ func (c *ComponentShow) SessionCommand(ctx context.Context, p *SessionParam) (*f
 
 type Sessions struct {
 	framework.ListResultSet[*models.Session]
+}
+
+func (rs *Sessions) TableHeaders() table.Row {
+	return table.Row{"ServerID", "ServerName", "Address", "HostName", "Version", "LeaseID"}
+}
+
+func (rs *Sessions) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, s := range rs.Data {
+		rows = append(rows, table.Row{s.ServerID, s.ServerName, s.Address, s.HostName, s.Version, s.LeaseID})
+	}
+	return rows
 }
 
 func (rs *Sessions) PrintAs(format framework.Format) string {

--- a/states/etcd/show/user.go
+++ b/states/etcd/show/user.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -28,6 +29,18 @@ func (c *ComponentShow) UserCommand(ctx context.Context, p *UserParam) (*framewo
 
 type Users struct {
 	framework.ListResultSet[*models.UserInfo]
+}
+
+func (rs *Users) TableHeaders() table.Row {
+	return table.Row{"Username", "Tenant"}
+}
+
+func (rs *Users) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, user := range rs.Data {
+		rows = append(rows, table.Row{user.Username, user.Tenant})
+	}
+	return rows
 }
 
 func (rs *Users) PrintAs(format framework.Format) string {


### PR DESCRIPTION
Add framework-level TableResultSet/TableTitler interfaces and RenderTable helper so any DataSetParam command can support `--format table` with go-pretty rendering. Implement the interface on all 15 show command ResultSet structs.