### PR TITLE
enhance: separate basePath and metaPath in remove component

### DIFF
--- a/states/backup_mock_connect.go
+++ b/states/backup_mock_connect.go
@@ -83,7 +83,7 @@ func (s *embedEtcdMockState) SetInstance(instanceName string) {
 	s.instanceName = instanceName
 	rootPath := path.Join(instanceName, metaPath)
 	s.ComponentShow = show.NewComponent(s.client, s.config, instanceName, metaPath)
-	s.ComponentRemove = remove.NewComponent(s.client, s.config, rootPath)
+	s.ComponentRemove = remove.NewComponent(s.client, s.config, instanceName, metaPath)
 	s.ComponentRepair = repair.NewComponent(s.client, s.config, rootPath)
 	s.SetupCommands()
 }
@@ -163,12 +163,10 @@ func (s *embedEtcdMockState) readWorkspaceMeta(path string) {
 }
 
 func getEmbedEtcdInstance(server *embed.Etcd, cli kv.MetaKV, instanceName string, config *configs.Config) framework.State {
-	basePath := path.Join(instanceName, metaPath)
-
 	state := &embedEtcdMockState{
 		CmdState:        framework.NewCmdState(fmt.Sprintf("Backup(%s)", instanceName), config),
 		ComponentShow:   show.NewComponent(cli, config, instanceName, metaPath),
-		ComponentRemove: remove.NewComponent(cli, config, basePath),
+		ComponentRemove: remove.NewComponent(cli, config, instanceName, metaPath),
 		instanceName:    instanceName,
 		server:          server,
 		client:          cli,

--- a/states/etcd/remove/binlog.go
+++ b/states/etcd/remove/binlog.go
@@ -15,7 +15,7 @@ import (
 var backupKeyPrefix = "birdwatcher/backup"
 
 type RemoveBinlogParam struct {
-	framework.ExecutionParam `use:"remove etcd-config" desc:"remove etcd stored configuations"`
+	framework.ExecutionParam `use:"remove binlog" desc:"remove binlog from meta"`
 	LogType                  string `name:"p.LogType" default:"unknown" desc:"log type: binlog/deltalog/statslog"`
 	CollectionID             int64  `name:"p.CollectionID" default:"0" desc:"collection id to remove"`
 	PartitionID              int64  `name:"p.PartitionID" default:"0" desc:"partition id to remove"`
@@ -31,13 +31,13 @@ func (c *ComponentRemove) RemoveBinlogCommand(ctx context.Context, p *RemoveBinl
 	var key string
 	switch p.LogType {
 	case "binlog":
-		key = path.Join(c.basePath, "datacoord-meta",
+		key = path.Join(c.metaPath, "datacoord-meta",
 			fmt.Sprintf("binlog/%d/%d/%d/%d", p.CollectionID, p.PartitionID, p.SegmentID, p.FieldID))
 	case "deltalog":
-		key = path.Join(c.basePath, "datacoord-meta",
+		key = path.Join(c.metaPath, "datacoord-meta",
 			fmt.Sprintf("deltalog/%d/%d/%d/%d", p.CollectionID, p.PartitionID, p.SegmentID, p.FieldID))
 	case "statslog":
-		key = path.Join(c.basePath, "datacoord-meta",
+		key = path.Join(c.metaPath, "datacoord-meta",
 			fmt.Sprintf("statslog/%d/%d/%d/%d", p.CollectionID, p.PartitionID, p.SegmentID, p.FieldID))
 	default:
 		return fmt.Errorf("p.LogType unknown: %s", p.LogType)

--- a/states/etcd/remove/bulkinsert.go
+++ b/states/etcd/remove/bulkinsert.go
@@ -25,7 +25,7 @@ type RemoveImportTaskParam struct {
 }
 
 func (c *ComponentRemove) RemoveImportJobCommand(ctx context.Context, p *RemoveImportJobParam) error {
-	jobs, err := common.ListImportJobs(ctx, c.client, c.basePath, func(job *models.ImportJob) bool {
+	jobs, err := common.ListImportJobs(ctx, c.client, c.metaPath, func(job *models.ImportJob) bool {
 		return job.GetProto().GetJobID() == p.JobID
 	})
 	if err != nil {
@@ -45,7 +45,7 @@ func (c *ComponentRemove) RemoveImportJobCommand(ctx context.Context, p *RemoveI
 	targetJob := jobs[0].GetProto()
 	targetPath := jobs[0].Key()
 	fmt.Printf("selected target import job, jobID: %d, key=%s\n", targetJob.GetJobID(), targetPath)
-	show.PrintDetailedImportJob(ctx, c.client, c.basePath, targetJob, false)
+	show.PrintDetailedImportJob(ctx, c.client, c.metaPath, targetJob, false)
 
 	// If without-tasks flag is set, remove only the job (old behavior)
 	if p.WithoutTasks {
@@ -67,7 +67,7 @@ func (c *ComponentRemove) RemoveImportJobCommand(ctx context.Context, p *RemoveI
 
 	// Default behavior: remove job with associated tasks
 	// Query associated PreImportTasks
-	preimportTasks, err := common.ListPreImportTasks(ctx, c.client, c.basePath, func(task *models.PreImportTask) bool {
+	preimportTasks, err := common.ListPreImportTasks(ctx, c.client, c.metaPath, func(task *models.PreImportTask) bool {
 		return task.GetProto().GetJobID() == p.JobID
 	})
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *ComponentRemove) RemoveImportJobCommand(ctx context.Context, p *RemoveI
 	}
 
 	// Query associated ImportTaskV2 tasks
-	importTasks, err := common.ListImportTasks(ctx, c.client, c.basePath, func(task *models.ImportTaskV2) bool {
+	importTasks, err := common.ListImportTasks(ctx, c.client, c.metaPath, func(task *models.ImportTaskV2) bool {
 		return task.GetProto().GetJobID() == p.JobID
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func (c *ComponentRemove) RemoveImportTaskCommand(ctx context.Context, p *Remove
 	}
 
 	// Search in PreImportTasks
-	preimportTasks, err := common.ListPreImportTasks(ctx, c.client, c.basePath, func(task *models.PreImportTask) bool {
+	preimportTasks, err := common.ListPreImportTasks(ctx, c.client, c.metaPath, func(task *models.PreImportTask) bool {
 		return task.GetProto().GetTaskID() == p.TaskID
 	})
 	if err != nil {
@@ -190,7 +190,7 @@ func (c *ComponentRemove) RemoveImportTaskCommand(ctx context.Context, p *Remove
 	}
 
 	// Search in ImportTaskV2
-	importTasks, err := common.ListImportTasks(ctx, c.client, c.basePath, func(task *models.ImportTaskV2) bool {
+	importTasks, err := common.ListImportTasks(ctx, c.client, c.metaPath, func(task *models.ImportTaskV2) bool {
 		return task.GetProto().GetTaskID() == p.TaskID
 	})
 	if err != nil {

--- a/states/etcd/remove/channel.go
+++ b/states/etcd/remove/channel.go
@@ -18,7 +18,7 @@ type RemoveChannelParam struct {
 
 // RemoveChannelCommand defines `remove channel` command.
 func (c *ComponentRemove) RemoveChannelCommand(ctx context.Context, p *RemoveChannelParam) error {
-	collections, err := common.ListCollections(ctx, c.client, c.basePath)
+	collections, err := common.ListCollections(ctx, c.client, c.metaPath)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func (c *ComponentRemove) RemoveChannelCommand(ctx context.Context, p *RemoveCha
 		}
 	}
 
-	watchChannels, err := common.ListChannelWatch(ctx, c.client, c.basePath, func(info *models.ChannelWatch) bool {
+	watchChannels, err := common.ListChannelWatch(ctx, c.client, c.metaPath, func(info *models.ChannelWatch) bool {
 		if len(p.Channel) > 0 {
 			return info.GetProto().GetVchan().GetChannelName() == p.Channel
 		}
@@ -40,7 +40,7 @@ func (c *ComponentRemove) RemoveChannelCommand(ctx context.Context, p *RemoveCha
 		return err
 	}
 
-	cps, err := common.ListChannelCheckpoint(ctx, c.client, c.basePath, func(pos *models.MsgPosition) bool {
+	cps, err := common.ListChannelCheckpoint(ctx, c.client, c.metaPath, func(pos *models.MsgPosition) bool {
 		if len(p.Channel) > 0 {
 			return pos.GetProto().GetChannelName() == p.Channel
 		}

--- a/states/etcd/remove/collection_clean.go
+++ b/states/etcd/remove/collection_clean.go
@@ -23,7 +23,7 @@ type CollectionMetaLeakedParam struct {
 }
 
 func (c *ComponentRemove) CollectionMetaLeakedCommand(ctx context.Context, p *CollectionMetaLeakedParam) error {
-	collections, err := common.ListCollections(ctx, c.client, c.basePath)
+	collections, err := common.ListCollections(ctx, c.client, c.metaPath)
 	if err != nil {
 		return fmt.Errorf("failed to list collections: %s", err.Error())
 	}
@@ -64,15 +64,15 @@ func (c *ComponentRemove) CollectionMetaLeakedCommand(ctx context.Context, p *Co
 
 	// remove collection meta
 	// meta before database
-	collectionMetaPrefix := path.Join(c.basePath, common.CollectionMetaPrefix)
+	collectionMetaPrefix := path.Join(c.metaPath, common.CollectionMetaPrefix)
 	// with database
-	dbCollectionMetaPrefix := path.Join(c.basePath, common.DBCollectionMetaPrefix)
+	dbCollectionMetaPrefix := path.Join(c.metaPath, common.DBCollectionMetaPrefix)
 	// remove collection field meta
-	fieldsPrefix := path.Join(c.basePath, common.FieldMetaPrefix)
-	fieldsSnapShotPrefix := path.Join(c.basePath, common.SnapshotPrefix, common.FieldMetaPrefix)
+	fieldsPrefix := path.Join(c.metaPath, common.FieldMetaPrefix)
+	fieldsSnapShotPrefix := path.Join(c.metaPath, common.SnapshotPrefix, common.FieldMetaPrefix)
 	// remove collection partition meta
-	partitionsPrefix := path.Join(c.basePath, common.PartitionPrefix)
-	partitionsSnapShotPrefix := path.Join(c.basePath, common.SnapshotPrefix, common.PartitionPrefix)
+	partitionsPrefix := path.Join(c.metaPath, common.PartitionPrefix)
+	partitionsSnapShotPrefix := path.Join(c.metaPath, common.SnapshotPrefix, common.PartitionPrefix)
 	prefixes := []string{
 		collectionMetaPrefix,
 		dbCollectionMetaPrefix,
@@ -92,8 +92,8 @@ func (c *ComponentRemove) CollectionMetaLeakedCommand(ctx context.Context, p *Co
 	}
 
 	// remove segment meta
-	segmentPrefix := path.Join(c.basePath, common.DCPrefix, common.SegmentMetaPrefix)
-	segmentStatsPrefix := path.Join(c.basePath, common.DCPrefix, common.SegmentStatsMetaPrefix)
+	segmentPrefix := path.Join(c.metaPath, common.DCPrefix, common.SegmentMetaPrefix)
+	segmentStatsPrefix := path.Join(c.metaPath, common.DCPrefix, common.SegmentStatsMetaPrefix)
 	fmt.Printf("start cleaning leaked segment meta, prefix: %s, exclude prefix%s\n", segmentPrefix, segmentStatsPrefix)
 	err = cleanMetaFn(ctx, segmentPrefix, func(key string) bool {
 		return strings.HasPrefix(key, segmentStatsPrefix)

--- a/states/etcd/remove/collection_dropping.go
+++ b/states/etcd/remove/collection_dropping.go
@@ -20,7 +20,7 @@ func (c *ComponentRemove) CollectionDropCommand(ctx context.Context, p *Collecti
 	var collections []*models.Collection
 	var err error
 	if p.CollectionID > 0 {
-		collection, err := common.GetCollectionByIDVersion(ctx, c.client, c.basePath, p.CollectionID)
+		collection, err := common.GetCollectionByIDVersion(ctx, c.client, c.metaPath, p.CollectionID)
 		if err != nil {
 			fmt.Printf("failed to get collection by id(%d): %s\n", p.CollectionID, err.Error())
 			return err
@@ -32,7 +32,7 @@ func (c *ComponentRemove) CollectionDropCommand(ctx context.Context, p *Collecti
 		}
 		collections = append(collections, collection)
 	} else {
-		collections, err = common.ListCollections(context.Background(), c.client, c.basePath, func(coll *models.Collection) bool {
+		collections, err = common.ListCollections(context.Background(), c.client, c.metaPath, func(coll *models.Collection) bool {
 			return coll.GetProto().State == etcdpb.CollectionState_CollectionDropping || coll.GetProto().State == etcdpb.CollectionState_CollectionDropped
 		})
 		if err != nil {
@@ -57,7 +57,7 @@ func (c *ComponentRemove) cleanCollectionMeta(ctx context.Context, info *models.
 	if info.Key() == "" {
 		return fmt.Errorf("Collection %s[%d] key is empty string, cannot perform cleanup", collection.Schema.Name, collection.ID)
 	}
-	basePath := c.basePath
+	basePath := c.metaPath
 	cli := c.client
 
 	// TODO: alias meta can't be cleaned conveniently.

--- a/states/etcd/remove/compaction_task.go
+++ b/states/etcd/remove/compaction_task.go
@@ -21,7 +21,7 @@ type CompactionTaskParam struct {
 
 // RemoveCompactionTaskCommand is the command function to remove compaction task.
 func (c *ComponentRemove) RemoveCompactionTaskCommand(ctx context.Context, p *CompactionTaskParam) error {
-	compactionTasks, err := common.ListCompactionTask(ctx, c.client, c.basePath, func(task *models.CompactionTask) bool {
+	compactionTasks, err := common.ListCompactionTask(ctx, c.client, c.metaPath, func(task *models.CompactionTask) bool {
 		if p.CompactionType != "" && p.CompactionType != task.GetType().String() {
 			return false
 		}

--- a/states/etcd/remove/component.go
+++ b/states/etcd/remove/component.go
@@ -1,20 +1,28 @@
 package remove
 
 import (
+	"path"
+
 	"github.com/milvus-io/birdwatcher/configs"
 	"github.com/milvus-io/birdwatcher/states/kv"
 )
 
 type ComponentRemove struct {
-	client   kv.MetaKV
-	config   *configs.Config
+	client kv.MetaKV
+	config *configs.Config
+	// basePath is the root path of etcd key-value pairs.
+	// by default is by-dev
 	basePath string
+	// metaPath is the concatenated path of basePath & metaPath
+	// by default is by-dev/meta
+	metaPath string
 }
 
-func NewComponent(cli kv.MetaKV, config *configs.Config, basePath string) *ComponentRemove {
+func NewComponent(cli kv.MetaKV, config *configs.Config, basePath string, metaPart string) *ComponentRemove {
 	return &ComponentRemove{
 		client:   cli,
 		config:   config,
 		basePath: basePath,
+		metaPath: path.Join(basePath, metaPart),
 	}
 }

--- a/states/etcd/remove/dirty_importing_segment.go
+++ b/states/etcd/remove/dirty_importing_segment.go
@@ -21,7 +21,7 @@ type DirtyImportingSegment struct {
 // DirtyImportingSegmentCommand returns command to remove
 func (c *ComponentRemove) DirtyImportingSegmentCommand(ctx context.Context, p *DirtyImportingSegment) error {
 	fmt.Println("start to remove dirty importing segment")
-	segments, err := common.ListSegments(ctx, c.client, c.basePath, func(segment *models.Segment) bool {
+	segments, err := common.ListSegments(ctx, c.client, c.metaPath, func(segment *models.Segment) bool {
 		return (p.CollectionID == 0 || segment.CollectionID == p.CollectionID)
 	})
 	if err != nil {
@@ -43,7 +43,7 @@ func (c *ComponentRemove) DirtyImportingSegmentCommand(ctx context.Context, p *D
 				if segment.NumOfRows == 0 && segmentTs < uint64(p.Ts) {
 					cnt++
 					if p.Run {
-						err := common.RemoveSegmentByID(ctx, c.client, c.basePath, segment.CollectionID, segment.PartitionID, segment.ID)
+						err := common.RemoveSegmentByID(ctx, c.client, c.metaPath, segment.CollectionID, segment.PartitionID, segment.ID)
 						if err != nil {
 							fmt.Printf("failed to remove segment %d, err: %s\n", segment.ID, err.Error())
 						}

--- a/states/etcd/remove/etcd_config.go
+++ b/states/etcd/remove/etcd_config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type RemoveEtcdConfigParam struct {
-	framework.ExecutionParam `use:"remove etcd-config" desc:"remove etcd stored configuations"`
+	framework.ExecutionParam `use:"remove config-etcd" desc:"remove etcd stored configuations"`
 	Key                      string `name:"key" desc:"etcd config key" default:""`
 }
 

--- a/states/etcd/remove/index.go
+++ b/states/etcd/remove/index.go
@@ -15,7 +15,7 @@ type RemoveIndexParam struct {
 }
 
 func (c *ComponentRemove) RemoveIndexCommand(ctx context.Context, p *RemoveIndexParam) error {
-	indexes, err := common.ListIndex(ctx, c.client, c.basePath, func(index *models.FieldIndex) bool {
+	indexes, err := common.ListIndex(ctx, c.client, c.metaPath, func(index *models.FieldIndex) bool {
 		return index.GetProto().GetIndexInfo().GetIndexID() == p.IndexID
 	})
 	if err != nil {

--- a/states/etcd/remove/segment.go
+++ b/states/etcd/remove/segment.go
@@ -46,7 +46,7 @@ func (c *ComponentRemove) RemoveSegmentCommand(ctx context.Context, p *SegmentPa
 			return err
 		}
 
-		if err := common.RemoveSegment(ctx, c.client, c.basePath, info); err != nil {
+		if err := common.RemoveSegment(ctx, c.client, c.metaPath, info); err != nil {
 			fmt.Printf("Remove segment %d from Etcd failed, err: %s\n", info.ID, err.Error())
 			return err
 		}
@@ -56,7 +56,7 @@ func (c *ComponentRemove) RemoveSegmentCommand(ctx context.Context, p *SegmentPa
 		return nil
 	}
 
-	err := common.WalkAllSegments(ctx, c.client, c.basePath, filterFunc, opFunc, p.MaxNum)
+	err := common.WalkAllSegments(ctx, c.client, c.metaPath, filterFunc, opFunc, p.MaxNum)
 	if err != nil && !errors.Is(err, common.ErrReachMaxNumOfWalkSegment) {
 		fmt.Printf("WalkAllSegments failed, err: %s\n", err.Error())
 	}

--- a/states/etcd/remove/segment_orphan.go
+++ b/states/etcd/remove/segment_orphan.go
@@ -19,7 +19,7 @@ type SegmentOrphan struct {
 
 // SegmentOrphanCommand returns command to remove
 func (c *ComponentRemove) SegmentOrphanCommand(ctx context.Context, p *SegmentOrphan) error {
-	segments, err := common.ListSegments(ctx, c.client, c.basePath, func(segment *models.Segment) bool {
+	segments, err := common.ListSegments(ctx, c.client, c.metaPath, func(segment *models.Segment) bool {
 		return (p.CollectionID == 0 || segment.CollectionID == p.CollectionID)
 	})
 	if err != nil {
@@ -31,7 +31,7 @@ func (c *ComponentRemove) SegmentOrphanCommand(ctx context.Context, p *SegmentOr
 	})
 
 	for collectionID, segments := range groups {
-		_, err := common.GetCollectionByIDVersion(ctx, c.client, c.basePath, collectionID)
+		_, err := common.GetCollectionByIDVersion(ctx, c.client, c.metaPath, collectionID)
 		if errors.Is(err, common.ErrCollectionNotFound) {
 			// print segments
 			fmt.Printf("Collection %d missing, orphan segments: %v\n", collectionID, lo.Map(segments, func(segment *models.Segment, idx int) int64 {
@@ -40,7 +40,7 @@ func (c *ComponentRemove) SegmentOrphanCommand(ctx context.Context, p *SegmentOr
 
 			if p.Run {
 				for _, segment := range segments {
-					err := common.RemoveSegmentByID(ctx, c.client, c.basePath, segment.CollectionID, segment.PartitionID, segment.ID)
+					err := common.RemoveSegmentByID(ctx, c.client, c.metaPath, segment.CollectionID, segment.PartitionID, segment.ID)
 					if err != nil {
 						fmt.Printf("failed to remove segment %d, err: %s\n", segment.ID, err.Error())
 					}

--- a/states/etcd/remove/session.go
+++ b/states/etcd/remove/session.go
@@ -23,7 +23,7 @@ type RemoveSessionParam struct {
 }
 
 func (c *ComponentRemove) RemoveSessionCommand(ctx context.Context, p *RemoveSessionParam) error {
-	sessions, err := common.ListSessions(ctx, c.client, c.basePath)
+	sessions, err := common.ListSessions(ctx, c.client, c.metaPath)
 	if err != nil {
 		return err
 	}

--- a/states/etcd/remove/stats_task.go
+++ b/states/etcd/remove/stats_task.go
@@ -24,7 +24,7 @@ func (c *ComponentRemove) RemoveStatsTaskCommand(ctx context.Context, p *StatsTa
 		return fmt.Errorf("subJobType parameter is required")
 	}
 
-	statsTasks, err := common.ListStatsTask(ctx, c.client, c.basePath, func(task *models.StatsTask) bool {
+	statsTasks, err := common.ListStatsTask(ctx, c.client, c.metaPath, func(task *models.StatsTask) bool {
 		if p.SubJobType != task.GetProto().GetSubJobType().String() {
 			return false
 		}

--- a/states/instance.go
+++ b/states/instance.go
@@ -130,7 +130,7 @@ func getInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceNam
 	state := &InstanceState{
 		CmdState:        parent.Spawn(fmt.Sprintf("Milvus(%s)", instanceName)),
 		ComponentShow:   show.NewComponent(cli, config, instanceName, metaPath),
-		ComponentRemove: remove.NewComponent(cli, config, basePath),
+		ComponentRemove: remove.NewComponent(cli, config, instanceName, metaPath),
 		ComponentRepair: repair.NewComponent(cli, config, basePath),
 		ComponentSet:    set.NewComponent(cli, config, basePath),
 		instanceName:    instanceName,


### PR DESCRIPTION
Refactor `remove.ComponentRemove` to accept `basePath` and `metaPath` separately (matching the show component) instead of a pre-joined path, and update all remove subcommands to use `c.metaPath` for meta key construction.

Also fix two incorrect `use` tags:
- `remove binlog` (was duplicated as `remove etcd-config`)
- `remove config-etcd` (renamed from the conflicting `remove etcd-config`)