### PR TITLE
enhance: support milvus-storage manifest v4 and storage-v3 inspect-parquet

### DIFF
--- a/states/inspect_parquet.go
+++ b/states/inspect_parquet.go
@@ -2,8 +2,11 @@ package states
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -88,6 +91,13 @@ func (s *InstanceState) inspectSegmentParquet(ctx context.Context, p *InspectPar
 		return err
 	}
 
+	if segment.GetStorageVersion() >= 3 {
+		if segment.GetManifestPath() == "" {
+			return errors.Newf("segment %d storage version is %d but got empty manifest", segment.GetID(), segment.GetStorageVersion())
+		}
+		return inspectV3SegmentParquet(ctx, minioClient, bucketName, rootPath, segment, p)
+	}
+
 	for _, fieldBinlog := range segment.GetBinlogs() {
 		if p.FieldID != 0 && fieldBinlog.FieldID != p.FieldID {
 			continue
@@ -97,6 +107,58 @@ func (s *InstanceState) inspectSegmentParquet(ctx context.Context, p *InspectPar
 			fmt.Printf("\n===== Field %d | %s =====\n", fieldBinlog.FieldID, logPath)
 			if err := inspectRemoteBinlog(ctx, minioClient, bucketName, logPath, segment.StorageVersion, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
 				fmt.Printf("failed to inspect %s: %s\n", logPath, err.Error())
+			}
+		}
+	}
+	return nil
+}
+
+// inspectV3SegmentParquet resolves parquet files via the v3 manifest (same logic as show manifest)
+// and inspects each column-group file. The FieldID filter selects column groups whose column list
+// contains the field id (stringified).
+func inspectV3SegmentParquet(ctx context.Context, minioClient *minio.Client, bucketName, rootPath string, segment *models.Segment, p *InspectParquetParam) error {
+	rawManifest := segment.GetManifestPath()
+	fmt.Printf("Manifest Raw: %s\n", rawManifest)
+
+	var manifestRef struct {
+		Ver      int    `json:"ver"`
+		BasePath string `json:"base_path"`
+	}
+	if err := json.Unmarshal([]byte(rawManifest), &manifestRef); err != nil {
+		return errors.Wrap(err, "parse manifest path JSON")
+	}
+
+	basePath := strings.ReplaceAll(manifestRef.BasePath, "ROOT_PATH", rootPath)
+	manifestPath := path.Join(basePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
+	fmt.Printf("Manifest File: %s\n", manifestPath)
+
+	obj, err := minioClient.GetObject(ctx, bucketName, manifestPath, minio.GetObjectOptions{})
+	if err != nil {
+		return errors.Wrap(err, "get manifest object")
+	}
+	m, err := parseManifest(obj)
+	obj.Close()
+	if err != nil {
+		return errors.Wrap(err, "parse manifest")
+	}
+
+	fieldFilter := ""
+	if p.FieldID != 0 {
+		fieldFilter = strconv.FormatInt(p.FieldID, 10)
+	}
+
+	for i, cg := range m.ColumnGroups {
+		if fieldFilter != "" && !slices.Contains(cg.Columns, fieldFilter) {
+			continue
+		}
+		fmt.Printf("\n===== Column Group #%d | columns=%v format=%s =====\n", i, cg.Columns, cg.Format)
+		for _, f := range cg.Files {
+			// Manifest file paths are relative to {basePath}/_data.
+			filePath := path.Join(basePath, "_data", strings.ReplaceAll(f.Path, "ROOT_PATH", rootPath))
+			fmt.Printf("\n----- File %s (rows: [%d, %d)) -----\n", filePath, f.StartIndex, f.EndIndex)
+			// v3 manifest files are plain parquet — use storage version 2 path (direct parquet reader).
+			if err := inspectRemoteBinlog(ctx, minioClient, bucketName, filePath, 2, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
+				fmt.Printf("failed to inspect %s: %s\n", filePath, err.Error())
 			}
 		}
 	}

--- a/states/show_manifest.go
+++ b/states/show_manifest.go
@@ -121,14 +121,22 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 
 const manifestMagic int32 = 0x4D494C56 // "MILV"
 
+// Manifest format evolution:
+//   - v1: initial (column_groups, delta_logs, stats as map<string, array<string>>)
+//   - v2: added indexes
+//   - v3: stats changed to map<string, Statistics>
+//   - v4: ColumnGroupFile.metadata (bytes) replaced by properties (map<string,string>)
+const manifestVersionV4 = 4
+
 // avroOCFMagic is the 4-byte magic header for Avro Object Container Format files.
 var avroOCFMagic = []byte{'O', 'b', 'j', 0x01}
 
 type manifestColumnGroupFile struct {
-	Path       string `json:"path"`
-	StartIndex int64  `json:"start_index"`
-	EndIndex   int64  `json:"end_index"`
-	Metadata   []byte `json:"metadata,omitempty"`
+	Path       string            `json:"path"`
+	StartIndex int64             `json:"start_index"`
+	EndIndex   int64             `json:"end_index"`
+	Metadata   []byte            `json:"metadata,omitempty"`
+	Properties map[string]string `json:"properties,omitempty"`
 }
 
 type manifestColumnGroup struct {
@@ -327,7 +335,7 @@ func readAvroMap[V any](a *avroReader, readValue func() (V, error)) (map[string]
 	return result, nil
 }
 
-func (a *avroReader) readColumnGroupFile() (manifestColumnGroupFile, error) {
+func (a *avroReader) readColumnGroupFile(version int32) (manifestColumnGroupFile, error) {
 	var f manifestColumnGroupFile
 	var err error
 	if f.Path, err = a.readString(); err != nil {
@@ -339,13 +347,22 @@ func (a *avroReader) readColumnGroupFile() (manifestColumnGroupFile, error) {
 	if f.EndIndex, err = a.readLong(); err != nil {
 		return f, fmt.Errorf("ColumnGroupFile.end_index: %w", err)
 	}
-	if f.Metadata, err = a.readBytes(); err != nil {
-		return f, fmt.Errorf("ColumnGroupFile.metadata: %w", err)
+	if version >= manifestVersionV4 {
+		f.Properties, err = readAvroMap(a, func() (string, error) {
+			return a.readString()
+		})
+		if err != nil {
+			return f, fmt.Errorf("ColumnGroupFile.properties: %w", err)
+		}
+	} else {
+		if f.Metadata, err = a.readBytes(); err != nil {
+			return f, fmt.Errorf("ColumnGroupFile.metadata: %w", err)
+		}
 	}
 	return f, nil
 }
 
-func (a *avroReader) readColumnGroup() (manifestColumnGroup, error) {
+func (a *avroReader) readColumnGroup(version int32) (manifestColumnGroup, error) {
 	var cg manifestColumnGroup
 	var err error
 
@@ -357,7 +374,7 @@ func (a *avroReader) readColumnGroup() (manifestColumnGroup, error) {
 	}
 
 	cg.Files, err = readAvroArray(a, func() (manifestColumnGroupFile, error) {
-		return a.readColumnGroupFile()
+		return a.readColumnGroupFile(version)
 	})
 	if err != nil {
 		return cg, fmt.Errorf("ColumnGroup.files: %w", err)
@@ -432,13 +449,13 @@ func (a *avroReader) readStatistics() (manifestStatistics, error) {
 
 // readManifestRecord decodes the Manifest record fields from Avro binary encoding.
 // Field order: column_groups, delta_logs, stats(map<string, Statistics>), indexes
-func readManifestRecord(ar *avroReader) (*manifest, error) {
+func readManifestRecord(ar *avroReader, version int32) (*manifest, error) {
 	m := &manifest{}
 	var err error
 
 	// 1. Column groups: array<ColumnGroup>
 	m.ColumnGroups, err = readAvroArray(ar, func() (manifestColumnGroup, error) {
-		return ar.readColumnGroup()
+		return ar.readColumnGroup(version)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("reading column_groups: %w", err)
@@ -492,6 +509,14 @@ func parseAvroOCF(r io.Reader) (*manifest, error) {
 	codec := "null"
 	if codecBytes, ok := meta["avro.codec"]; ok {
 		codec = string(codecBytes)
+	}
+
+	// Detect manifest version from the embedded Avro schema.
+	// OCF files embed the writer's schema; the shape of ColumnGroupFile tells us
+	// whether this is v4 (properties: map<string,string>) or v3 (metadata: bytes).
+	version := int32(3)
+	if schemaBytes, ok := meta["avro.schema"]; ok {
+		version = detectOCFManifestVersion(schemaBytes)
 	}
 
 	// Read 16-byte sync marker
@@ -563,15 +588,63 @@ func parseAvroOCF(r io.Reader) (*manifest, error) {
 
 	// Decode the manifest record from the accumulated block data
 	blockReader := &avroReader{r: bytes.NewReader(allData)}
-	m, err := readManifestRecord(blockReader)
+	m, err := readManifestRecord(blockReader, version)
 	if err != nil {
 		return nil, fmt.Errorf("decoding manifest record: %w", err)
 	}
 
 	m.Format = "avro_ocf"
-	m.Version = 3 // OCF format implies current version
+	m.Version = version
 
 	return m, nil
+}
+
+// detectOCFManifestVersion inspects the Avro schema JSON embedded in an OCF file's
+// metadata and returns the manifest version inferred from the ColumnGroupFile record.
+//   - "properties" field present  → v4
+//   - "metadata" field present    → v3 (or earlier OCF writer)
+func detectOCFManifestVersion(schemaJSON []byte) int32 {
+	var schema any
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+		return 3
+	}
+	if columnGroupFileHasField(schema, "properties") {
+		return 4
+	}
+	return 3
+}
+
+// columnGroupFileHasField walks a decoded Avro schema tree and reports whether the
+// record named "ColumnGroupFile" has a field with the given name.
+func columnGroupFileHasField(node any, fieldName string) bool {
+	switch v := node.(type) {
+	case map[string]any:
+		if name, _ := v["name"].(string); name == "ColumnGroupFile" {
+			if fields, ok := v["fields"].([]any); ok {
+				for _, f := range fields {
+					fm, ok := f.(map[string]any)
+					if !ok {
+						continue
+					}
+					if fn, _ := fm["name"].(string); fn == fieldName {
+						return true
+					}
+				}
+			}
+		}
+		for _, child := range v {
+			if columnGroupFileHasField(child, fieldName) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if columnGroupFileHasField(child, fieldName) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // manifestSnappyDecode decodes Avro-framed snappy data.
@@ -751,8 +824,9 @@ func parseLegacyManifest(r io.Reader) (*manifest, error) {
 	}
 
 	// 3. Column groups: array<ColumnGroup>
+	// Legacy MILV format always used metadata (bytes); it was replaced by OCF before v4.
 	m.ColumnGroups, err = readAvroArray(ar, func() (manifestColumnGroup, error) {
-		return ar.readColumnGroup()
+		return ar.readColumnGroup(m.Version)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("reading column_groups: %w", err)
@@ -851,6 +925,12 @@ func printManifest(m *manifest) {
 			fmt.Printf("        Range: [%d, %d)\n", f.StartIndex, f.EndIndex)
 			if len(f.Metadata) > 0 {
 				fmt.Printf("        Metadata (%d bytes): %s\n", len(f.Metadata), hex.EncodeToString(f.Metadata))
+			}
+			if len(f.Properties) > 0 {
+				fmt.Printf("        Properties:\n")
+				for pk, pv := range f.Properties {
+					fmt.Printf("          %s: %s\n", pk, pv)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
milvus-storage v4 changed ColumnGroupFile.metadata (bytes) to properties (map<string,string>), bumping MANIFEST_VERSION to 4 (milvus-io/milvus-storage#434). Detect the writer's version from the Avro schema embedded in the OCF metadata by inspecting the ColumnGroupFile record fields, then decode column-group files with the matching binary layout. Older v3 OCFs and legacy MILV files continue to work unchanged. `show manifest` now prints the properties map.

`inspect-parquet --segment` now dispatches to the manifest-based reader when segment.StorageVersion >= 3, resolving parquet files via the manifest's column groups instead of the legacy binlog paths.