### PR TITLE
enhance: add instance extension framework

### DIFF
--- a/framework/command.go
+++ b/framework/command.go
@@ -22,8 +22,15 @@ type FormatProvider interface {
 	GetGlobalFormat() Format
 }
 
-func parseFunctionCommands(state State) []commandItem {
-	v := reflect.ValueOf(state)
+func parseFunctionCommandsFrom(host State, receiver any) []commandItem {
+	if receiver == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(receiver)
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
 	tp := v.Type()
 
 	var commands []commandItem
@@ -35,7 +42,7 @@ func parseFunctionCommands(state State) []commandItem {
 			continue
 		}
 
-		cmd, uses, ok := parseMethod(state, mt)
+		cmd, uses, ok := parseMethodFrom(host, receiver, mt)
 		if !ok {
 			continue
 		}
@@ -49,40 +56,32 @@ func parseFunctionCommands(state State) []commandItem {
 	return commands
 }
 
-func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool) {
-	v := reflect.ValueOf(state)
+func parseMethodFrom(host State, receiver any, mt reflect.Method) (*cobra.Command, []string, bool) {
+	v := reflect.ValueOf(receiver)
 	t := mt.Type
 	var use string
 	var short string
 	var paramType reflect.Type
 
-	if t.NumIn() == 0 {
-		// shall not be reached
+	if t.NumIn() < 3 {
 		return nil, nil, false
 	}
-	if t.NumIn() > 1 {
-		// should be context.Context
-		in := t.In(1)
-		if !in.Implements(reflect.TypeOf((*context.Context)(nil)).Elem()) {
-			return nil, nil, false
-		}
+	in := t.In(1)
+	if !in.Implements(reflect.TypeOf((*context.Context)(nil)).Elem()) {
+		return nil, nil, false
 	}
-	if t.NumIn() > 2 {
-		// should be CmdParam
-		in := t.In(2)
-		if !in.Implements(reflect.TypeOf((*CmdParam)(nil)).Elem()) {
-			return nil, nil, false
-		}
-		cp, ok := reflect.New(in.Elem()).Interface().(CmdParam)
-		if !ok {
-			fmt.Println("conversion failed", in.Name())
-		} else {
-			paramType = in
-			use, short = cp.Desc()
-		}
+	in = t.In(2)
+	if in.Kind() != reflect.Pointer || !in.Implements(reflect.TypeOf((*CmdParam)(nil)).Elem()) {
+		return nil, nil, false
 	}
+	cp, ok := reflect.New(in.Elem()).Interface().(CmdParam)
+	if !ok {
+		fmt.Println("conversion failed", in.Name())
+		return nil, nil, false
+	}
+	paramType = in
+	use, short = cp.Desc()
 
-	cp := reflect.New(paramType.Elem()).Interface().(CmdParam)
 	fUse, fDesc := GetCmdFromFlag(cp)
 	if len(use) == 0 {
 		use = fUse
@@ -110,10 +109,14 @@ func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool
 			fmt.Println(err.Error())
 			return
 		}
-		ctx, cancel := state.Ctx()
+		ctx, cancel := host.Ctx()
 		defer cancel()
 
 		m := v.MethodByName(mt.Name)
+		if !m.IsValid() {
+			fmt.Println("command method not found", mt.Name)
+			return
+		}
 		results := m.Call([]reflect.Value{
 			reflect.ValueOf(ctx),
 			reflect.ValueOf(cp),
@@ -136,10 +139,7 @@ func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool
 				}
 				rs := result.Interface().(ResultSet)
 				// Determine output format: command param > global config > default
-				outputFormat := FormatDefault
-				if fp, ok := state.(FormatProvider); ok {
-					outputFormat = fp.GetGlobalFormat()
-				}
+				outputFormat := commandOutputFormat(host, receiver)
 				if preset, ok := rs.(*PresetResultSet); ok {
 					// If command explicitly set a format, use it
 					if preset.GetFormat() != FormatUnset {
@@ -165,6 +165,16 @@ func parseMethod(state State, mt reflect.Method) (*cobra.Command, []string, bool
 		}
 	}
 	return cmd, uses, true
+}
+
+func commandOutputFormat(host State, receiver any) Format {
+	if fp, ok := receiver.(FormatProvider); ok {
+		return fp.GetGlobalFormat()
+	}
+	if fp, ok := host.(FormatProvider); ok {
+		return fp.GetGlobalFormat()
+	}
+	return FormatDefault
 }
 
 func GetCmdFromFlag(p CmdParam) (string, string) {

--- a/framework/command_test.go
+++ b/framework/command_test.go
@@ -1,0 +1,126 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/birdwatcher/configs"
+)
+
+type testExternalParam struct {
+	ParamBase `use:"external foo" desc:"external command"`
+	Name      string `name:"name" default:"" desc:"name value"`
+}
+
+type testExternalReceiver struct {
+	called bool
+	name   string
+}
+
+func (r *testExternalReceiver) FooCommand(ctx context.Context, p *testExternalParam) error {
+	r.called = true
+	r.name = p.Name
+	return nil
+}
+
+func TestMergeFunctionCommandsFromRegistersExternalReceiver(t *testing.T) {
+	host := &struct{ *CmdState }{CmdState: NewCmdState("host", &configs.Config{})}
+	receiver := &testExternalReceiver{}
+	root := &cobra.Command{SilenceUsage: true, SilenceErrors: true}
+
+	items := parseFunctionCommandsFrom(host, receiver)
+	require.Len(t, items, 1)
+	host.MergeFunctionCommandsFrom(root, host, receiver)
+	require.NotEmpty(t, root.Commands())
+
+	root.SetArgs([]string{"external", "foo", "--name", "bird"})
+	err := root.Execute()
+	require.NoError(t, err)
+	require.True(t, receiver.called)
+	require.Equal(t, "bird", receiver.name)
+}
+
+type testLocalParam struct {
+	ParamBase `use:"local" desc:"local command"`
+}
+
+type testLocalState struct {
+	*CmdState
+	called bool
+}
+
+func (s *testLocalState) LocalCommand(ctx context.Context, p *testLocalParam) error {
+	s.called = true
+	return nil
+}
+
+func TestMergeFunctionCommandsKeepsStateReceiverBehavior(t *testing.T) {
+	state := &testLocalState{CmdState: NewCmdState("state", &configs.Config{})}
+	root := &cobra.Command{SilenceUsage: true, SilenceErrors: true}
+
+	state.MergeFunctionCommands(root, state)
+
+	root.SetArgs([]string{"local"})
+	err := root.Execute()
+	require.NoError(t, err)
+	require.True(t, state.called)
+}
+
+type testFormatParam struct {
+	ParamBase `use:"format" desc:"format command"`
+}
+
+type testFormatReceiver struct{}
+
+func (r *testFormatReceiver) GetGlobalFormat() Format { return FormatJSON }
+
+func (r *testFormatReceiver) FormatCommand(ctx context.Context, p *testFormatParam) (ResultSet, error) {
+	return testFormatResultSet{}, nil
+}
+
+type testFormatResultSet struct{}
+
+func (rs testFormatResultSet) PrintAs(format Format) string {
+	return fmt.Sprintf("format:%d", format)
+}
+
+func (rs testFormatResultSet) Entities() any { return nil }
+
+func TestMergeFunctionCommandsFromPrefersReceiverFormat(t *testing.T) {
+	host := &struct{ *CmdState }{CmdState: NewCmdState("host", &configs.Config{OutputFormat: "plain"})}
+	receiver := &testFormatReceiver{}
+	root := &cobra.Command{SilenceUsage: true, SilenceErrors: true}
+	host.MergeFunctionCommandsFrom(root, host, receiver)
+
+	output := captureStdout(t, func() {
+		root.SetArgs([]string{"format"})
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+
+	require.Equal(t, fmt.Sprintf("format:%d", FormatJSON), strings.TrimSpace(output))
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/framework/state.go
+++ b/framework/state.go
@@ -125,7 +125,12 @@ func (s *CmdState) SetupCommands() {
 
 // MergeFunctionCommands parses all member methods for provided state and add it into cmd.
 func (s *CmdState) MergeFunctionCommands(cmd *cobra.Command, state State) {
-	items := parseFunctionCommands(state)
+	s.MergeFunctionCommandsFrom(cmd, state, state)
+}
+
+// MergeFunctionCommandsFrom parses command methods from receiver and binds them to host state.
+func (s *CmdState) MergeFunctionCommandsFrom(cmd *cobra.Command, host State, receiver any) {
+	items := parseFunctionCommandsFrom(host, receiver)
 	for _, item := range items {
 		target := cmd
 		for _, kw := range item.kws {

--- a/states/app_state.go
+++ b/states/app_state.go
@@ -25,6 +25,8 @@ type ApplicationState struct {
 
 	// config stores configuration items
 	config *configs.Config
+
+	extensions []Extension
 }
 
 func (app *ApplicationState) Ctx() (context.Context, context.CancelFunc) {

--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -64,7 +64,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 	}
 
 	cli := kv.NewTiKV(tikvCli)
-	kvState := getKVConnectedState(app.core, cli, cp.TiKVAddr, app.config)
+	kvState := getKVConnectedState(app.core, cli, cp.TiKVAddr, app.config, app.extensions)
 	if !cp.Dry {
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
@@ -85,7 +85,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(tikvTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config))
+		app.SetTagNext(tikvTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to metastore connected state
@@ -156,7 +156,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 	}
 
 	cli := kv.NewEtcdKV(etcdCli)
-	kvState := getKVConnectedState(app.core, cli, cp.EtcdAddr, app.config)
+	kvState := getKVConnectedState(app.core, cli, cp.EtcdAddr, app.config, app.extensions)
 	if !cp.Dry {
 		// ping etcd
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
@@ -172,7 +172,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(etcdTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config))
+		app.SetTagNext(etcdTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to etcd connected state
@@ -264,6 +264,7 @@ type kvConnectedState struct {
 	addr       string
 	candidates []string
 	config     *configs.Config
+	extensions []Extension
 }
 
 // SetupCommands setups the command.
@@ -275,12 +276,13 @@ func (s *kvConnectedState) SetupCommands() {
 }
 
 // getKVConnectedState returns kvConnectedState for unknown instance
-func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config) framework.State {
+func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
 	state := &kvConnectedState{
-		CmdState: parent.Spawn(fmt.Sprintf("MetaStore(%s)", addr)),
-		client:   cli,
-		addr:     addr,
-		config:   config,
+		CmdState:   parent.Spawn(fmt.Sprintf("MetaStore(%s)", addr)),
+		client:     cli,
+		addr:       addr,
+		config:     config,
+		extensions: extensions,
 	}
 
 	return state
@@ -334,7 +336,7 @@ func (s *kvConnectedState) UseCommand(ctx context.Context, p *UseParam) error {
 
 	fmt.Fprintf(os.Stderr, "Using meta path: %s/%s/\n", p.instanceName, p.MetaPath)
 
-	s.SetNext(etcdTag, getInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config))
+	s.SetNext(etcdTag, getInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config, s.extensions))
 	return nil
 }
 

--- a/states/extensions.go
+++ b/states/extensions.go
@@ -1,0 +1,36 @@
+package states
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/milvus-io/birdwatcher/configs"
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/states/kv"
+)
+
+type Option func(*ApplicationState)
+
+type Extension any
+
+func WithExtensions(exts ...Extension) Option {
+	return func(app *ApplicationState) {
+		app.extensions = append(app.extensions, exts...)
+	}
+}
+
+type InstanceContext interface {
+	InstanceName() string
+	MetaPath() string
+	BasePath() string
+	Client() kv.MetaKV
+	Config() *configs.Config
+	State() framework.State
+}
+
+type InstanceCobraCommandProvider interface {
+	InstanceCobraCommands(ctx InstanceContext) []*cobra.Command
+}
+
+type InstanceFunctionCommandProvider interface {
+	InstanceFunctionCommands(ctx InstanceContext) []any
+}

--- a/states/extensions_test.go
+++ b/states/extensions_test.go
@@ -1,0 +1,98 @@
+package states
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/birdwatcher/configs"
+	"github.com/milvus-io/birdwatcher/framework"
+	metakv "github.com/milvus-io/birdwatcher/states/kv"
+)
+
+type testExtensionMarker struct{}
+
+func TestWithExtensionsStoresExtensions(t *testing.T) {
+	ext := &testExtensionMarker{}
+
+	app, ok := Start(&configs.Config{}, false, WithExtensions(ext)).(*ApplicationState)
+	require.True(t, ok)
+	require.Len(t, app.extensions, 1)
+	require.Same(t, ext, app.extensions[0])
+}
+
+type testInstanceExtension struct {
+	cobraCtx InstanceContext
+	fnCtx    InstanceContext
+	receiver *testInstanceReceiver
+}
+
+func (e *testInstanceExtension) InstanceCobraCommands(ctx InstanceContext) []*cobra.Command {
+	e.cobraCtx = ctx
+	return []*cobra.Command{{Use: "extension-cobra", Short: "extension cobra command"}}
+}
+
+func (e *testInstanceExtension) InstanceFunctionCommands(ctx InstanceContext) []any {
+	e.fnCtx = ctx
+	e.receiver = &testInstanceReceiver{}
+	return []any{e.receiver}
+}
+
+type testInstanceFunctionParam struct {
+	framework.ParamBase `use:"extension function" desc:"extension function command"`
+	Value               string `name:"value" default:"" desc:"value"`
+}
+
+type testInstanceReceiver struct {
+	called bool
+	value  string
+}
+
+func (r *testInstanceReceiver) FunctionCommand(ctx context.Context, p *testInstanceFunctionParam) error {
+	r.called = true
+	r.value = p.Value
+	return nil
+}
+
+func TestInstanceStateMergesExtensionCommands(t *testing.T) {
+	config := &configs.Config{}
+	client := metakv.NewFileAuditKV(nil, nil)
+	ext := &testInstanceExtension{}
+	state := &InstanceState{
+		CmdState:     framework.NewCmdState("Milvus(test)", config),
+		instanceName: "test-root",
+		metaPath:     "custom-meta",
+		client:       client,
+		config:       config,
+		basePath:     "test-root/custom-meta",
+		extensions:   []Extension{ext},
+	}
+
+	state.SetupCommands()
+
+	_, _, err := state.RootCmd.Find([]string{"extension-cobra"})
+	require.NoError(t, err)
+	_, _, err = state.RootCmd.Find([]string{"extension", "function"})
+	require.NoError(t, err)
+	_, _, err = state.RootCmd.Find([]string{"dry-mode"})
+	require.NoError(t, err)
+	_, _, err = state.RootCmd.Find([]string{"show"})
+	require.NoError(t, err)
+
+	require.Same(t, state, ext.cobraCtx)
+	require.Same(t, state, ext.fnCtx)
+	require.Equal(t, "test-root", ext.cobraCtx.InstanceName())
+	require.Equal(t, "custom-meta", ext.cobraCtx.MetaPath())
+	require.Equal(t, "test-root/custom-meta", ext.cobraCtx.BasePath())
+	require.Same(t, client, ext.cobraCtx.Client())
+	require.Same(t, config, ext.cobraCtx.Config())
+	require.Same(t, state, ext.cobraCtx.State())
+
+	state.RootCmd.SetArgs([]string{"extension", "function", "--value", "ok"})
+	err = state.RootCmd.Execute()
+	require.NoError(t, err)
+	require.True(t, ext.receiver.called)
+	require.Equal(t, "ok", ext.receiver.value)
+}

--- a/states/instance.go
+++ b/states/instance.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/milvus-io/birdwatcher/configs"
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/states/etcd"
@@ -25,12 +27,14 @@ type InstanceState struct {
 	*repair.ComponentRepair
 	*set.ComponentSet
 	instanceName string
+	metaPath     string
 	client       metakv.MetaKV
 	auditFile    *os.File
 
-	etcdState framework.State
-	config    *configs.Config
-	basePath  string
+	etcdState  framework.State
+	config     *configs.Config
+	basePath   string
+	extensions []Extension
 }
 
 func (s *InstanceState) Close() {
@@ -50,6 +54,18 @@ func (s *InstanceState) GetGlobalFormat() framework.Format {
 	return framework.FormatDefault
 }
 
+func (s *InstanceState) InstanceName() string { return s.instanceName }
+
+func (s *InstanceState) MetaPath() string { return s.metaPath }
+
+func (s *InstanceState) BasePath() string { return s.basePath }
+
+func (s *InstanceState) Client() metakv.MetaKV { return s.client }
+
+func (s *InstanceState) Config() *configs.Config { return s.config }
+
+func (s *InstanceState) State() framework.State { return s }
+
 // SetupCommands setups the command.
 // also called after each command run to reset flag values.
 func (s *InstanceState) SetupCommands() {
@@ -57,6 +73,7 @@ func (s *InstanceState) SetupCommands() {
 
 	cli := s.client
 	instanceName := s.instanceName
+	metaPath := s.metaPath
 
 	basePath := s.basePath
 
@@ -99,9 +116,24 @@ func (s *InstanceState) SetupCommands() {
 		etcd.DownloadCommand(cli, basePath),
 	)
 
+	s.mergeExtensionCommands(cmd)
+
 	// cmd.AddCommand(etcd.RawCommands(cli)...)
 
 	s.UpdateState(cmd, s, s.SetupCommands)
+}
+
+func (s *InstanceState) mergeExtensionCommands(cmd *cobra.Command) {
+	for _, ext := range s.extensions {
+		if provider, ok := ext.(InstanceCobraCommandProvider); ok {
+			s.MergeCobraCommands(cmd, provider.InstanceCobraCommands(s)...)
+		}
+		if provider, ok := ext.(InstanceFunctionCommandProvider); ok {
+			for _, receiver := range provider.InstanceFunctionCommands(s) {
+				s.MergeFunctionCommandsFrom(cmd, s, receiver)
+			}
+		}
+	}
 }
 
 type DryModeParam struct {
@@ -113,7 +145,7 @@ func (s *InstanceState) DryModeCommand(ctx context.Context, p *DryModeParam) {
 	s.SetNext(etcdTag, s.etcdState)
 }
 
-func getInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config) framework.State {
+func getInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config, extensions []Extension) framework.State {
 	var kv metakv.MetaKV
 	name := fmt.Sprintf("audit_%s.log", time.Now().Format("2006_0102_150405"))
 	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -134,12 +166,14 @@ func getInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceNam
 		ComponentRepair: repair.NewComponent(cli, config, basePath),
 		ComponentSet:    set.NewComponent(cli, config, basePath),
 		instanceName:    instanceName,
+		metaPath:        metaPath,
 		client:          kv,
 		auditFile:       file,
 
-		etcdState: etcdState,
-		config:    config,
-		basePath:  basePath,
+		etcdState:  etcdState,
+		config:     config,
+		basePath:   basePath,
+		extensions: extensions,
 	}
 
 	return state

--- a/states/start.go
+++ b/states/start.go
@@ -15,10 +15,16 @@ const (
 )
 
 // Start returns the first state - offline.
-func Start(config *configs.Config, multiStage bool) framework.State {
+func Start(config *configs.Config, multiStage bool, opts ...Option) framework.State {
 	app := &ApplicationState{
 		states: map[string]framework.State{},
 		config: config,
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(app)
+		}
 	}
 
 	app.core = framework.NewCmdState("[core]", config)


### PR DESCRIPTION
Add app-local extension options and instance context provider interfaces so downstream apps can register InstanceState commands without copying birdwatcher internals.

Support external function command receivers in the command framework, propagate extensions through connect/use flows, and cover extension registration with focused framework and states tests.