### PR TITLE
feat: expose birdwatcher extension hooks

### DIFF
--- a/states/app_state.go
+++ b/states/app_state.go
@@ -33,6 +33,22 @@ func (app *ApplicationState) Ctx() (context.Context, context.CancelFunc) {
 	return app.core.Ctx()
 }
 
+func (app *ApplicationState) Core() *framework.CmdState {
+	return app.core
+}
+
+func (app *ApplicationState) Config() *configs.Config {
+	return app.config
+}
+
+func (app *ApplicationState) Extensions() []Extension {
+	return app.extensions
+}
+
+func (app *ApplicationState) State() framework.State {
+	return app
+}
+
 func (app *ApplicationState) Label() string {
 	if len(app.states) == 0 {
 		return "Offline"
@@ -99,6 +115,15 @@ func (app *ApplicationState) SetupCommands() {
 	cmd := app.core.GetCmd()
 
 	app.core.UpdateState(cmd, app, app.SetupCommands)
+	for _, ext := range app.extensions {
+		provider, ok := ext.(ApplicationFunctionCommandProvider)
+		if !ok {
+			continue
+		}
+		for _, receiver := range provider.ApplicationFunctionCommands(app) {
+			app.core.MergeFunctionCommandsFrom(cmd, app, receiver)
+		}
+	}
 	for _, state := range app.states {
 		state.SetupCommands()
 	}

--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -24,13 +24,14 @@ import (
 )
 
 const (
-	metaPath = `meta`
+	DefaultMetaPath = `meta`
+	metaPath        = DefaultMetaPath
 )
 
 // ErrNotMilvsuRootPath sample error for non-valid root path.
 var ErrNotMilvsuRootPath = errors.New("is not a Milvus RootPath")
 
-func pingMetaStore(ctx context.Context, cli kv.MetaKV, rootPath string, metaPath string) error {
+func PingMetaStore(ctx context.Context, cli kv.MetaKV, rootPath string, metaPath string) error {
 	key := path.Join(rootPath, metaPath, "session/id")
 	_, err := cli.Load(ctx, key)
 	if err != nil {
@@ -68,7 +69,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 	if !cp.Dry {
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
-		err = pingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
+		err = PingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
 		if err != nil {
 			if errors.Is(err, ErrNotMilvsuRootPath) {
 				if !cp.Force {
@@ -85,7 +86,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(tikvTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
+		app.SetTagNext(tikvTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to metastore connected state
@@ -162,7 +163,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
 		if !cp.Force {
-			err = pingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
+			err = PingMetaStore(ctx, cli, cp.RootPath, cp.MetaPath)
 			if err != nil {
 				fmt.Printf("Connection established, but %s, please check your config or use Dry mode\n", err.Error())
 				return err
@@ -172,7 +173,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(etcdTag, getInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
+		app.SetTagNext(etcdTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to etcd connected state
@@ -275,8 +276,8 @@ func (s *kvConnectedState) SetupCommands() {
 	s.UpdateState(cmd, s, s.SetupCommands)
 }
 
-// getKVConnectedState returns kvConnectedState for unknown instance
-func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
+// GetKVConnectedState returns kvConnectedState for unknown instance
+func GetKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
 	state := &kvConnectedState{
 		CmdState:   parent.Spawn(fmt.Sprintf("MetaStore(%s)", addr)),
 		client:     cli,
@@ -286,6 +287,10 @@ func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string,
 	}
 
 	return state
+}
+
+func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
+	return GetKVConnectedState(parent, cli, addr, config, extensions)
 }
 
 type FindMilvusParam struct {
@@ -321,7 +326,7 @@ func (p *UseParam) ParseArgs(args []string) error {
 }
 
 func (s *kvConnectedState) UseCommand(ctx context.Context, p *UseParam) error {
-	err := pingMetaStore(ctx, s.client, p.instanceName, p.MetaPath)
+	err := PingMetaStore(ctx, s.client, p.instanceName, p.MetaPath)
 	if err != nil {
 		if errors.Is(err, ErrNotMilvsuRootPath) {
 			if !p.Force {
@@ -336,7 +341,7 @@ func (s *kvConnectedState) UseCommand(ctx context.Context, p *UseParam) error {
 
 	fmt.Fprintf(os.Stderr, "Using meta path: %s/%s/\n", p.instanceName, p.MetaPath)
 
-	s.SetNext(etcdTag, getInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config, s.extensions))
+	s.SetNext(etcdTag, GetInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config, s.extensions))
 	return nil
 }
 

--- a/states/etcd_connect_export_test.go
+++ b/states/etcd_connect_export_test.go
@@ -1,0 +1,36 @@
+package states
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/birdwatcher/configs"
+	"github.com/milvus-io/birdwatcher/framework"
+	metakv "github.com/milvus-io/birdwatcher/states/kv"
+)
+
+func TestGetKVConnectedStateReturnsMetastoreState(t *testing.T) {
+	config := &configs.Config{}
+	core := framework.NewCmdState("[core]", config)
+	client := metakv.NewFileAuditKV(nil, nil)
+
+	state := GetKVConnectedState(core, client, "scout:2379", config, nil)
+	require.NotNil(t, state)
+	require.Contains(t, state.Label(), "MetaStore(scout:2379)")
+}
+
+func TestDefaultMetaPathIsMeta(t *testing.T) {
+	require.Equal(t, "meta", DefaultMetaPath)
+}
+
+func TestPingMetaStoreIsExported(t *testing.T) {
+	require.NotNil(t, PingMetaStore)
+}
+
+func TestExportedStateTags(t *testing.T) {
+	require.Equal(t, "etcd", EtcdTag)
+	require.Equal(t, "tikv", TiKVTag)
+	require.Equal(t, "pulsar", PulsarTag)
+	require.Equal(t, "oss", OSSTag)
+}

--- a/states/extensions.go
+++ b/states/extensions.go
@@ -12,6 +12,18 @@ type Option func(*ApplicationState)
 
 type Extension any
 
+type ApplicationContext interface {
+	Core() *framework.CmdState
+	Config() *configs.Config
+	Extensions() []Extension
+	State() framework.State
+	SetTagNext(tag string, state framework.State)
+}
+
+type ApplicationFunctionCommandProvider interface {
+	ApplicationFunctionCommands(ctx ApplicationContext) []any
+}
+
 func WithExtensions(exts ...Extension) Option {
 	return func(app *ApplicationState) {
 		app.extensions = append(app.extensions, exts...)

--- a/states/extensions_test.go
+++ b/states/extensions_test.go
@@ -56,6 +56,55 @@ func (r *testInstanceReceiver) FunctionCommand(ctx context.Context, p *testInsta
 	return nil
 }
 
+type testApplicationExtension struct {
+	ctx      ApplicationContext
+	receiver *testApplicationReceiver
+}
+
+func (e *testApplicationExtension) ApplicationFunctionCommands(ctx ApplicationContext) []any {
+	e.ctx = ctx
+	e.receiver = &testApplicationReceiver{}
+	return []any{e.receiver}
+}
+
+type testApplicationFunctionParam struct {
+	framework.ParamBase `use:"extension app" desc:"extension app command"`
+	Value               string `name:"value" default:"" desc:"value"`
+}
+
+type testApplicationReceiver struct {
+	called bool
+	value  string
+}
+
+func (r *testApplicationReceiver) AppCommand(ctx context.Context, p *testApplicationFunctionParam) error {
+	r.called = true
+	r.value = p.Value
+	return nil
+}
+
+func TestApplicationStateMergesExtensionFunctionCommands(t *testing.T) {
+	config := &configs.Config{}
+	ext := &testApplicationExtension{}
+	state, ok := Start(config, false, WithExtensions(ext)).(*ApplicationState)
+	require.True(t, ok)
+
+	_, _, err := state.core.RootCmd.Find([]string{"extension", "app"})
+	require.NoError(t, err)
+
+	require.Same(t, state, ext.ctx.State())
+	require.Same(t, state.core, ext.ctx.Core())
+	require.Same(t, config, ext.ctx.Config())
+	require.Len(t, ext.ctx.Extensions(), 1)
+	require.Same(t, ext, ext.ctx.Extensions()[0])
+
+	state.core.RootCmd.SetArgs([]string{"extension", "app", "--value", "ok"})
+	err = state.core.RootCmd.Execute()
+	require.NoError(t, err)
+	require.True(t, ext.receiver.called)
+	require.Equal(t, "ok", ext.receiver.value)
+}
+
 func TestInstanceStateMergesExtensionCommands(t *testing.T) {
 	config := &configs.Config{}
 	client := metakv.NewFileAuditKV(nil, nil)

--- a/states/instance.go
+++ b/states/instance.go
@@ -145,7 +145,7 @@ func (s *InstanceState) DryModeCommand(ctx context.Context, p *DryModeParam) {
 	s.SetNext(etcdTag, s.etcdState)
 }
 
-func getInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config, extensions []Extension) framework.State {
+func GetInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config, extensions []Extension) framework.State {
 	var kv metakv.MetaKV
 	name := fmt.Sprintf("audit_%s.log", time.Now().Format("2006_0102_150405"))
 	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/states/start.go
+++ b/states/start.go
@@ -8,10 +8,15 @@ import (
 )
 
 const (
-	etcdTag   = "etcd"
-	tikvTag   = "tikv"
-	pulsarTag = "pulsar"
-	ossTag    = "oss"
+	EtcdTag   = "etcd"
+	TiKVTag   = "tikv"
+	PulsarTag = "pulsar"
+	OSSTag    = "oss"
+
+	etcdTag   = EtcdTag
+	tikvTag   = TiKVTag
+	pulsarTag = PulsarTag
+	ossTag    = OSSTag
 )
 
 // Start returns the first state - offline.


### PR DESCRIPTION
Expose application-level extension context and command providers so external extensions can register commands before entering an instance state. Export metastore and state helper APIs needed to compose custom birdwatcher states.