### PR TITLE
enhance: optimize metastore list scans with key-aware selectors

### DIFF
--- a/states/etcd/common/collection.go
+++ b/states/etcd/common/collection.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/birdwatcher/models"
@@ -25,6 +24,8 @@ var (
 	DBCollectionMetaPrefix = path.Join(RCPrefix, DBPrefix, CollectionInfoPrefix) // `root-coord/database/collection-info`
 	// FieldMetaPrefix is prefix for rootcoord collection fields meta
 	FieldMetaPrefix = `root-coord/fields`
+	// StructArrayFieldMetaPrefix is prefix for rootcoord collection struct array fields meta.
+	StructArrayFieldMetaPrefix = `root-coord/struct-array-fields`
 	// FunctionMetaPrefix is prefix for rootcoord function meta
 	FunctionMetaPrefix = `root-coord/functions`
 	// CollectionLoadPrefix is prefix for querycoord collection loaded in milvus v2.1.x
@@ -45,38 +46,128 @@ var (
 	CollectionTombstone = []byte{0xE2, 0x9B, 0xBC}
 )
 
-func ListCollections(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Collection) bool) ([]*models.Collection, error) {
-	prefixes := []string{
-		path.Join(basePath, CollectionMetaPrefix),
-		path.Join(basePath, DBCollectionMetaPrefix),
+const DefaultListCollectionsBulkEnrichmentThreshold = 1
+
+var (
+	collectionMetaKeySpec = MetaKeySpec{
+		Prefix: CollectionMetaPrefix,
+		Parts:  []MetaKeyPart{KeyCollectionID},
 	}
-	var results []*models.Collection
-	for _, prefix := range prefixes {
-		collections, err := ListObj2Models(ctx, cli, prefix, models.NewCollection, filters...)
-		if err != nil {
-			return nil, err
+	dbCollectionMetaKeySpec = MetaKeySpec{
+		Prefix: DBCollectionMetaPrefix,
+		Parts:  []MetaKeyPart{KeyDatabaseID, KeyCollectionID},
+	}
+)
+
+type CollectionSelector struct {
+	DatabaseID     int64
+	UseDatabaseID  bool
+	CollectionID   int64
+	CollectionName string
+	Filters        []PostFilter[models.Collection]
+
+	BulkEnrichmentThreshold *int
+}
+
+func (s CollectionSelector) legacyMetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().WithInt64(KeyCollectionID, s.CollectionID)
+}
+
+func (s CollectionSelector) dbMetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().
+		WithInt64If(KeyDatabaseID, s.DatabaseID, s.UseDatabaseID).
+		WithInt64(KeyCollectionID, s.CollectionID)
+}
+
+func (s CollectionSelector) Match(collection *models.Collection) bool {
+	proto := collection.GetProto()
+	if s.UseDatabaseID && proto.GetDbId() != s.DatabaseID {
+		return false
+	}
+	if s.CollectionID > 0 && proto.GetID() != s.CollectionID {
+		return false
+	}
+	if s.CollectionName != "" {
+		schema := proto.GetSchema()
+		if schema == nil || schema.GetName() != s.CollectionName {
+			return false
 		}
-		results = append(results, collections...)
+	}
+	for _, filter := range s.Filters {
+		if !filter.Match(collection) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s CollectionSelector) enrichmentBulkThreshold() int {
+	if s.BulkEnrichmentThreshold == nil {
+		return DefaultListCollectionsBulkEnrichmentThreshold
+	}
+	return *s.BulkEnrichmentThreshold
+}
+
+func ListCollections(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Collection) bool) ([]*models.Collection, error) {
+	return ListCollectionsBy(ctx, cli, basePath, CollectionSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListCollectionsBy(ctx context.Context, cli kv.MetaKV, basePath string, selector CollectionSelector) ([]*models.Collection, error) {
+	results, err := ListCollectionWithoutFieldsBy(ctx, cli, basePath, selector)
+	if err != nil {
+		return nil, err
 	}
 
-	results = lo.Map(results, func(collection *models.Collection, _ int) *models.Collection {
-		collection.GetProto().GetSchema().Fields, _ = getCollectionFields(ctx, cli, basePath, collection.GetProto().GetID())
-		collection.GetProto().GetSchema().StructArrayFields, _ = getCollectionStructFields(ctx, cli, basePath, collection.GetProto().GetID())
-		collection.Functions, _ = ListCollectionFunctions(ctx, cli, basePath, collection.GetProto().GetID())
-		return collection
-	})
+	if len(results) > selector.enrichmentBulkThreshold() {
+		enrichCollectionsBulk(ctx, cli, basePath, results)
+	} else {
+		enrichCollectionsIndividually(ctx, cli, basePath, results)
+	}
 
 	return results, nil
 }
 
-func ListCollectionWithoutFields(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Collection) bool) ([]*models.Collection, error) {
-	prefixes := []string{
-		path.Join(basePath, CollectionMetaPrefix),
-		path.Join(basePath, DBCollectionMetaPrefix),
+func enrichCollectionsIndividually(ctx context.Context, cli kv.MetaKV, basePath string, collections []*models.Collection) {
+	for _, collection := range collections {
+		collection.GetProto().GetSchema().Fields, _ = getCollectionFields(ctx, cli, basePath, collection.GetProto().GetID())
+		collection.GetProto().GetSchema().StructArrayFields, _ = getCollectionStructFields(ctx, cli, basePath, collection.GetProto().GetID())
+		collection.Functions, _ = ListCollectionFunctions(ctx, cli, basePath, collection.GetProto().GetID())
 	}
+}
+
+func enrichCollectionsBulk(ctx context.Context, cli kv.MetaKV, basePath string, collections []*models.Collection) {
+	wanted := make(map[int64]struct{}, len(collections))
+	for _, collection := range collections {
+		wanted[collection.GetProto().GetID()] = struct{}{}
+	}
+
+	fields := listFieldSchemasByCollectionID(ctx, cli, ensureMetaPrefix(path.Join(basePath, FieldMetaPrefix)), wanted)
+	structFields := listStructArrayFieldSchemasByCollectionID(ctx, cli, ensureMetaPrefix(path.Join(basePath, StructArrayFieldMetaPrefix)), wanted)
+	functions := listFunctionsByCollectionID(ctx, cli, ensureMetaPrefix(path.Join(basePath, FunctionMetaPrefix)), wanted)
+
+	for _, collection := range collections {
+		collectionID := collection.GetProto().GetID()
+		collection.GetProto().GetSchema().Fields = fields[collectionID]
+		collection.GetProto().GetSchema().StructArrayFields = structFields[collectionID]
+		collection.Functions = functions[collectionID]
+	}
+}
+
+func ListCollectionWithoutFields(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Collection) bool) ([]*models.Collection, error) {
+	return ListCollectionWithoutFieldsBy(ctx, cli, basePath, CollectionSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListCollectionWithoutFieldsBy(ctx context.Context, cli kv.MetaKV, basePath string, selector CollectionSelector) ([]*models.Collection, error) {
 	var results []*models.Collection
-	for _, prefix := range prefixes {
-		collections, err := ListObj2Models(ctx, cli, prefix, models.NewCollection, filters...)
+	scans := []struct {
+		spec  MetaKeySpec
+		hints MetaKeyHints
+	}{
+		{spec: collectionMetaKeySpec, hints: selector.legacyMetaKeyHints()},
+		{spec: dbCollectionMetaKeySpec, hints: selector.dbMetaKeyHints()},
+	}
+	for _, scan := range scans {
+		collections, err := ListObj2ModelsBySpec(ctx, cli, basePath, scan.spec, scan.hints, models.NewCollection, selector)
 		if err != nil {
 			return nil, err
 		}
@@ -88,9 +179,7 @@ func ListCollectionWithoutFields(ctx context.Context, cli kv.MetaKV, basePath st
 
 // GetCollectionByIDVersion retruns collection info from etcd with provided version & id.
 func GetCollectionByIDVersion(ctx context.Context, cli kv.MetaKV, basePath string, collID int64) (*models.Collection, error) {
-	colls, err := ListCollections(ctx, cli, basePath, func(c *models.Collection) bool {
-		return c.GetProto().GetID() == collID
-	})
+	colls, err := ListCollectionsBy(ctx, cli, basePath, CollectionSelector{CollectionID: collID})
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +197,83 @@ func getCollectionFields(ctx context.Context, cli kv.MetaKV, basePath string, co
 }
 
 func getCollectionStructFields(ctx context.Context, cli kv.MetaKV, basePath string, collID int64) ([]*schemapb.StructArrayFieldSchema, error) {
-	fields, _, err := ListProtoObjects[schemapb.StructArrayFieldSchema](ctx, cli, path.Join(basePath, fmt.Sprintf("root-coord/struct-array-fields/%d", collID)))
+	fields, _, err := ListProtoObjects[schemapb.StructArrayFieldSchema](ctx, cli, path.Join(basePath, fmt.Sprintf("%s/%d", StructArrayFieldMetaPrefix, collID)))
 	return fields, err
+}
+
+func listFieldSchemasByCollectionID(ctx context.Context, cli kv.MetaKV, prefix string, wanted map[int64]struct{}) map[int64][]*schemapb.FieldSchema {
+	keys, vals, err := cli.LoadWithPrefix(ctx, prefix)
+	if err != nil || len(keys) != len(vals) {
+		return nil
+	}
+
+	fields := make(map[int64][]*schemapb.FieldSchema)
+	for i, key := range keys {
+		collectionID, err := PathPartInt64(key, -2)
+		if err != nil {
+			continue
+		}
+		if _, ok := wanted[collectionID]; !ok {
+			continue
+		}
+
+		field := &schemapb.FieldSchema{}
+		if err := proto.Unmarshal([]byte(vals[i]), field); err != nil {
+			continue
+		}
+		fields[collectionID] = append(fields[collectionID], field)
+	}
+	return fields
+}
+
+func listStructArrayFieldSchemasByCollectionID(ctx context.Context, cli kv.MetaKV, prefix string, wanted map[int64]struct{}) map[int64][]*schemapb.StructArrayFieldSchema {
+	keys, vals, err := cli.LoadWithPrefix(ctx, prefix)
+	if err != nil || len(keys) != len(vals) {
+		return nil
+	}
+
+	fields := make(map[int64][]*schemapb.StructArrayFieldSchema)
+	for i, key := range keys {
+		collectionID, err := PathPartInt64(key, -2)
+		if err != nil {
+			continue
+		}
+		if _, ok := wanted[collectionID]; !ok {
+			continue
+		}
+
+		field := &schemapb.StructArrayFieldSchema{}
+		if err := proto.Unmarshal([]byte(vals[i]), field); err != nil {
+			continue
+		}
+		fields[collectionID] = append(fields[collectionID], field)
+	}
+	return fields
+}
+
+func listFunctionsByCollectionID(ctx context.Context, cli kv.MetaKV, prefix string, wanted map[int64]struct{}) map[int64][]*models.Function {
+	keys, vals, err := cli.LoadWithPrefix(ctx, prefix)
+	if err != nil || len(keys) != len(vals) {
+		return nil
+	}
+
+	functions := make(map[int64][]*models.Function)
+	for i, key := range keys {
+		collectionID, err := PathPartInt64(key, -2)
+		if err != nil {
+			continue
+		}
+		if _, ok := wanted[collectionID]; !ok {
+			continue
+		}
+
+		function := &schemapb.FunctionSchema{}
+		if err := proto.Unmarshal([]byte(vals[i]), function); err != nil {
+			continue
+		}
+		functions[collectionID] = append(functions[collectionID], models.NewFunction(function, key))
+	}
+	return functions
 }
 
 func FillFieldSchemaIfEmpty(cli kv.MetaKV, basePath string, collection *etcdpb.CollectionInfo) error {

--- a/states/etcd/common/collection_enrichment_test.go
+++ b/states/etcd/common/collection_enrichment_test.go
@@ -1,0 +1,161 @@
+package common
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+)
+
+func TestListCollectionsByUsesIndividualEnrichmentAtDefaultThreshold(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	functionKey := path.Join(basePath, FunctionMetaPrefix, "100", "30")
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, CollectionMetaPrefix, "100"):             mustCollectionValue(t, 100, 0, "coll100"),
+		path.Join(basePath, FieldMetaPrefix, "100", "10"):            mustFieldSchemaValue(t, 10, "field10"),
+		path.Join(basePath, StructArrayFieldMetaPrefix, "100", "20"): mustStructArrayFieldSchemaValue(t, 20, "struct20"),
+		functionKey: mustFunctionSchemaValue(t, 30, "function30"),
+	}}
+
+	collections, err := ListCollectionsBy(ctx, cli, basePath, CollectionSelector{CollectionID: 100})
+	require.NoError(t, err)
+	require.Len(t, collections, 1)
+	require.Len(t, collections[0].GetProto().GetSchema().GetFields(), 1)
+	require.Equal(t, "field10", collections[0].GetProto().GetSchema().GetFields()[0].GetName())
+	require.Len(t, collections[0].GetProto().GetSchema().GetStructArrayFields(), 1)
+	require.Equal(t, "struct20", collections[0].GetProto().GetSchema().GetStructArrayFields()[0].GetName())
+	require.Len(t, collections[0].Functions, 1)
+	require.Equal(t, functionKey, collections[0].Functions[0].Key())
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix, "100")))
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, StructArrayFieldMetaPrefix, "100")))
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FunctionMetaPrefix, "100")+"/"))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix)+"/"))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, StructArrayFieldMetaPrefix)+"/"))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, FunctionMetaPrefix)+"/"))
+}
+
+func TestListCollectionsByBulkEnrichesAboveDefaultThreshold(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	function100Key := path.Join(basePath, FunctionMetaPrefix, "100", "30")
+	function200Key := path.Join(basePath, FunctionMetaPrefix, "200", "60")
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, CollectionMetaPrefix, "100"):             mustCollectionValue(t, 100, 0, "coll100"),
+		path.Join(basePath, CollectionMetaPrefix, "200"):             mustCollectionValue(t, 200, 0, "coll200"),
+		path.Join(basePath, FieldMetaPrefix, "100", "10"):            mustFieldSchemaValue(t, 10, "field100"),
+		path.Join(basePath, FieldMetaPrefix, "200", "20"):            mustFieldSchemaValue(t, 20, "field200"),
+		path.Join(basePath, FieldMetaPrefix, "300", "30"):            mustFieldSchemaValue(t, 30, "field300"),
+		path.Join(basePath, StructArrayFieldMetaPrefix, "100", "40"): mustStructArrayFieldSchemaValue(t, 40, "struct100"),
+		path.Join(basePath, StructArrayFieldMetaPrefix, "200", "50"): mustStructArrayFieldSchemaValue(t, 50, "struct200"),
+		function100Key: mustFunctionSchemaValue(t, 30, "function100"),
+		function200Key: mustFunctionSchemaValue(t, 60, "function200"),
+		path.Join(basePath, FunctionMetaPrefix, "300", "90"): mustFunctionSchemaValue(t, 90, "function300"),
+	}}
+
+	collections, err := ListCollectionsBy(ctx, cli, basePath, CollectionSelector{})
+	require.NoError(t, err)
+	byID := collectionsByID(collections)
+	require.Len(t, byID, 2)
+	require.Equal(t, "field100", byID[100].GetProto().GetSchema().GetFields()[0].GetName())
+	require.Equal(t, "field200", byID[200].GetProto().GetSchema().GetFields()[0].GetName())
+	require.Equal(t, "struct100", byID[100].GetProto().GetSchema().GetStructArrayFields()[0].GetName())
+	require.Equal(t, "struct200", byID[200].GetProto().GetSchema().GetStructArrayFields()[0].GetName())
+	require.Equal(t, function100Key, byID[100].Functions[0].Key())
+	require.Equal(t, function200Key, byID[200].Functions[0].Key())
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix)+"/"))
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, StructArrayFieldMetaPrefix)+"/"))
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FunctionMetaPrefix)+"/"))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix, "100")))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, StructArrayFieldMetaPrefix, "100")))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, FunctionMetaPrefix, "100")+"/"))
+}
+
+func TestListCollectionsByHonorsBulkEnrichmentThreshold(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, CollectionMetaPrefix, "100"):  mustCollectionValue(t, 100, 0, "coll100"),
+		path.Join(basePath, CollectionMetaPrefix, "200"):  mustCollectionValue(t, 200, 0, "coll200"),
+		path.Join(basePath, FieldMetaPrefix, "100", "10"): mustFieldSchemaValue(t, 10, "field100"),
+		path.Join(basePath, FieldMetaPrefix, "200", "20"): mustFieldSchemaValue(t, 20, "field200"),
+	}}
+
+	collections, err := ListCollectionsBy(ctx, cli, basePath, CollectionSelector{BulkEnrichmentThreshold: intPtr(2)})
+	require.NoError(t, err)
+	require.Len(t, collections, 2)
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix, "100")))
+	require.Equal(t, 1, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix, "200")))
+	require.Equal(t, 0, prefixCount(cli.loadedPrefixes, path.Join(basePath, FieldMetaPrefix)+"/"))
+}
+
+func TestListCollectionsByBulkEnrichmentSkipsMalformedAndUnwantedEntries(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, CollectionMetaPrefix, "100"):  mustCollectionValue(t, 100, 0, "coll100"),
+		path.Join(basePath, CollectionMetaPrefix, "200"):  mustCollectionValue(t, 200, 0, "coll200"),
+		path.Join(basePath, FieldMetaPrefix, "100", "10"): mustFieldSchemaValue(t, 10, "field100"),
+		path.Join(basePath, FieldMetaPrefix, "300", "30"): mustFieldSchemaValue(t, 30, "field300"),
+		path.Join(basePath, FieldMetaPrefix, "bad", "40"): mustFieldSchemaValue(t, 40, "fieldBad"),
+		path.Join(basePath, FieldMetaPrefix, "100", "50"): string([]byte{0xff}),
+	}}
+
+	collections, err := ListCollectionsBy(ctx, cli, basePath, CollectionSelector{})
+	require.NoError(t, err)
+	byID := collectionsByID(collections)
+	require.Len(t, byID[100].GetProto().GetSchema().GetFields(), 1)
+	require.Equal(t, "field100", byID[100].GetProto().GetSchema().GetFields()[0].GetName())
+	require.Empty(t, byID[200].GetProto().GetSchema().GetFields())
+}
+
+func mustFieldSchemaValue(t *testing.T, id int64, name string) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(&schemapb.FieldSchema{FieldID: id, Name: name})
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func mustStructArrayFieldSchemaValue(t *testing.T, id int64, name string) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(&schemapb.StructArrayFieldSchema{FieldID: id, Name: name})
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func mustFunctionSchemaValue(t *testing.T, id int64, name string) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(&schemapb.FunctionSchema{Id: id, Name: name})
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func prefixCount(prefixes []string, target string) int {
+	count := 0
+	for _, prefix := range prefixes {
+		if prefix == target {
+			count++
+		}
+	}
+	return count
+}
+
+func collectionsByID(collections []*models.Collection) map[int64]*models.Collection {
+	result := make(map[int64]*models.Collection, len(collections))
+	for _, collection := range collections {
+		result[collection.GetProto().GetID()] = collection
+	}
+	return result
+}

--- a/states/etcd/common/database.go
+++ b/states/etcd/common/database.go
@@ -13,8 +13,42 @@ const (
 	DataBaseMetaPrefix = `root-coord/database/db-info`
 )
 
+var databaseMetaKeySpec = MetaKeySpec{
+	Prefix: path.Join(RCPrefix, DBPrefix, DBInfoPrefix),
+	Parts:  []MetaKeyPart{KeyDatabaseID},
+}
+
+type DatabaseSelector struct {
+	DatabaseID   int64
+	DatabaseName string
+	Filters      []PostFilter[models.Database]
+}
+
+func (s DatabaseSelector) MetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().WithInt64(KeyDatabaseID, s.DatabaseID)
+}
+
+func (s DatabaseSelector) Match(db *models.Database) bool {
+	proto := db.GetProto()
+	if s.DatabaseID > 0 && proto.GetId() != s.DatabaseID {
+		return false
+	}
+	if s.DatabaseName != "" && proto.GetName() != s.DatabaseName {
+		return false
+	}
+	for _, filter := range s.Filters {
+		if !filter.Match(db) {
+			return false
+		}
+	}
+	return true
+}
+
 // ListDatabase returns all database info from etcd meta converted to models.
 func ListDatabase(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(db *models.Database) bool) ([]*models.Database, error) {
-	prefix := path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix) + "/"
-	return ListObj2Models(ctx, cli, prefix, models.NewDatabase, filters...)
+	return ListDatabaseBy(ctx, cli, basePath, DatabaseSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListDatabaseBy(ctx context.Context, cli kv.MetaKV, basePath string, selector DatabaseSelector) ([]*models.Database, error) {
+	return ListObj2ModelsBySpec(ctx, cli, basePath, databaseMetaKeySpec, selector.MetaKeyHints(), models.NewDatabase, selector)
 }

--- a/states/etcd/common/list.go
+++ b/states/etcd/common/list.go
@@ -115,6 +115,24 @@ LOOP:
 	return result, keys, nil
 }
 
+type ModelFilter[M any] interface {
+	Match(*M) bool
+}
+
+type PostFilter[M any] func(*M) bool
+
+func (f PostFilter[M]) Match(model *M) bool {
+	return f == nil || f(model)
+}
+
+func wrapPostFilters[M any](filters []func(*M) bool) []PostFilter[M] {
+	postFilters := make([]PostFilter[M], 0, len(filters))
+	for _, filter := range filters {
+		postFilters = append(postFilters, PostFilter[M](filter))
+	}
+	return postFilters
+}
+
 func ListObj2Models[T any, proto interface {
 	*T
 	protoreflect.ProtoMessage
@@ -132,4 +150,63 @@ func ListObj2Models[T any, proto interface {
 		}
 		return result, true
 	}), nil
+}
+
+func ListObj2ModelsBySpec[T any, P interface {
+	*T
+	protoreflect.ProtoMessage
+}, M any](ctx context.Context, cli kv.MetaKV, basePath string, spec MetaKeySpec, hints MetaKeyHints, convert func(P, string) *M, filters ...ModelFilter[M]) ([]*M, error) {
+	return ListObj2ModelsByTarget(ctx, cli, spec.BuildScanTarget(basePath, hints), convert, filters...)
+}
+
+func ListObj2ModelsByTarget[T any, P interface {
+	*T
+	protoreflect.ProtoMessage
+}, M any](ctx context.Context, cli kv.MetaKV, target ScanTarget, convert func(P, string) *M, filters ...ModelFilter[M]) ([]*M, error) {
+	keys, vals, err := loadScanTarget(ctx, cli, target)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) != len(vals) {
+		return nil, fmt.Errorf("error: keys and vals of different size in ListObj2ModelsByTarget:%d vs %d", len(keys), len(vals))
+	}
+
+	result := make([]*M, 0, len(vals))
+LOOP:
+	for idx, val := range vals {
+		var elem T
+		info := P(&elem)
+		err = proto.Unmarshal([]byte(val), info)
+		if err != nil {
+			if bytes.Equal([]byte(val), []byte{0xE2, 0x9B, 0xBC}) {
+				fmt.Printf("Tombstone found, key: %s\n", keys[idx])
+				continue
+			}
+			fmt.Printf("failed to unmarshal key=%s, err: %s\n", keys[idx], err.Error())
+			continue
+		}
+
+		model := convert(info, keys[idx])
+		for _, filter := range filters {
+			if !filter.Match(model) {
+				continue LOOP
+			}
+		}
+		result = append(result, model)
+	}
+	return result, nil
+}
+
+func loadScanTarget(ctx context.Context, cli kv.MetaKV, target ScanTarget) ([]string, []string, error) {
+	if !target.Exact {
+		return cli.LoadWithPrefix(ctx, target.Key)
+	}
+	val, err := cli.Load(ctx, target.Key)
+	if err == kv.ErrKeyNotFound {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return []string{target.Key}, []string{val}, nil
 }

--- a/states/etcd/common/meta_key.go
+++ b/states/etcd/common/meta_key.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"path"
+	"strconv"
+	"strings"
+)
+
+type MetaKeyPart string
+
+const (
+	KeyDatabaseID   MetaKeyPart = "databaseID"
+	KeyCollectionID MetaKeyPart = "collectionID"
+	KeyPartitionID  MetaKeyPart = "partitionID"
+	KeySegmentID    MetaKeyPart = "segmentID"
+	KeyFieldID      MetaKeyPart = "fieldID"
+	KeyIndexID      MetaKeyPart = "indexID"
+	KeyJobID        MetaKeyPart = "jobID"
+	KeyTaskID       MetaKeyPart = "taskID"
+)
+
+type MetaKeyHints map[MetaKeyPart]string
+
+func NewMetaKeyHints() MetaKeyHints {
+	return MetaKeyHints{}
+}
+
+func (h MetaKeyHints) WithInt64(part MetaKeyPart, value int64) MetaKeyHints {
+	return h.WithInt64If(part, value, value > 0)
+}
+
+func (h MetaKeyHints) WithInt64If(part MetaKeyPart, value int64, ok bool) MetaKeyHints {
+	if h == nil {
+		h = NewMetaKeyHints()
+	}
+	if ok {
+		h[part] = strconv.FormatInt(value, 10)
+	}
+	return h
+}
+
+type ScanTarget struct {
+	Key   string
+	Exact bool
+}
+
+type MetaKeySpec struct {
+	Prefix string
+	Parts  []MetaKeyPart
+}
+
+func (s MetaKeySpec) BuildScanTarget(basePath string, hints MetaKeyHints) ScanTarget {
+	key := path.Join(basePath, s.Prefix)
+	for _, part := range s.Parts {
+		value, ok := hints[part]
+		if !ok || value == "" {
+			return ScanTarget{Key: ensureMetaPrefix(key), Exact: false}
+		}
+		key = path.Join(key, value)
+	}
+	if len(s.Parts) == 0 {
+		return ScanTarget{Key: ensureMetaPrefix(key), Exact: false}
+	}
+	return ScanTarget{Key: key, Exact: true}
+}
+
+func ensureMetaPrefix(key string) string {
+	if strings.HasSuffix(key, "/") {
+		return key
+	}
+	return key + "/"
+}

--- a/states/etcd/common/meta_key_test.go
+++ b/states/etcd/common/meta_key_test.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaKeySpecScanTargets(t *testing.T) {
+	spec := MetaKeySpec{
+		Prefix: "datacoord-meta/s",
+		Parts:  []MetaKeyPart{KeyCollectionID, KeyPartitionID, KeySegmentID},
+	}
+
+	target := spec.BuildScanTarget("root", NewMetaKeyHints().WithInt64(KeyCollectionID, 100))
+	require.False(t, target.Exact)
+	require.Equal(t, "root/datacoord-meta/s/100/", target.Key)
+
+	target = spec.BuildScanTarget("root", NewMetaKeyHints().WithInt64(KeySegmentID, 300))
+	require.False(t, target.Exact)
+	require.Equal(t, "root/datacoord-meta/s/", target.Key)
+
+	target = spec.BuildScanTarget("root", NewMetaKeyHints().WithInt64(KeyCollectionID, 100).WithInt64(KeyPartitionID, 200).WithInt64(KeySegmentID, 300))
+	require.True(t, target.Exact)
+	require.Equal(t, "root/datacoord-meta/s/100/200/300", target.Key)
+}

--- a/states/etcd/common/partition.go
+++ b/states/etcd/common/partition.go
@@ -2,22 +2,59 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"path"
 
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/kv"
 )
 
+var partitionMetaKeySpec = MetaKeySpec{
+	Prefix: path.Join(RCPrefix, PartitionPrefix),
+	Parts:  []MetaKeyPart{KeyCollectionID, KeyPartitionID},
+}
+
+type PartitionSelector struct {
+	CollectionID  int64
+	PartitionID   int64
+	PartitionName string
+	Filters       []PostFilter[models.Partition]
+}
+
+func (s PartitionSelector) MetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().
+		WithInt64(KeyCollectionID, s.CollectionID).
+		WithInt64(KeyPartitionID, s.PartitionID)
+}
+
+func (s PartitionSelector) Match(partition *models.Partition) bool {
+	proto := partition.GetProto()
+	if s.CollectionID > 0 && proto.GetCollectionId() != s.CollectionID {
+		return false
+	}
+	if s.PartitionID > 0 && proto.GetPartitionID() != s.PartitionID {
+		return false
+	}
+	if s.PartitionName != "" && proto.GetPartitionName() != s.PartitionName {
+		return false
+	}
+	for _, filter := range s.Filters {
+		if !filter.Match(partition) {
+			return false
+		}
+	}
+	return true
+}
+
 // ListCollectionPartitions returns partition list of collection.
 func ListCollectionPartitions(ctx context.Context, cli kv.MetaKV, basePath string, collectionID int64) ([]*models.Partition, error) {
-	prefix := path.Join(basePath, RCPrefix, PartitionPrefix, fmt.Sprintf("%d", collectionID)) + "/"
-
-	return ListObj2Models(ctx, cli, prefix, models.NewPartition)
+	return ListPartitionsBy(ctx, cli, basePath, PartitionSelector{CollectionID: collectionID})
 }
 
 // ListPartitions returns all partition info which meets the filters.
 func ListPartitions(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Partition) bool) ([]*models.Partition, error) {
-	prefix := path.Join(basePath, RCPrefix, PartitionPrefix) + "/"
-	return ListObj2Models(ctx, cli, prefix, models.NewPartition, filters...)
+	return ListPartitionsBy(ctx, cli, basePath, PartitionSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListPartitionsBy(ctx context.Context, cli kv.MetaKV, basePath string, selector PartitionSelector) ([]*models.Partition, error) {
+	return ListObj2ModelsBySpec(ctx, cli, basePath, partitionMetaKeySpec, selector.MetaKeyHints(), models.NewPartition, selector)
 }

--- a/states/etcd/common/rootcoord_selector_test.go
+++ b/states/etcd/common/rootcoord_selector_test.go
@@ -1,0 +1,222 @@
+package common
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+)
+
+type rootCoordListKV struct {
+	kv.MetaKV
+	data           map[string]string
+	loadedPrefixes []string
+	loadedKeys     []string
+}
+
+func (r *rootCoordListKV) Load(ctx context.Context, key string, opts ...kv.LoadOption) (string, error) {
+	r.loadedKeys = append(r.loadedKeys, key)
+	value, ok := r.data[key]
+	if !ok {
+		return "", kv.ErrKeyNotFound
+	}
+	return value, nil
+}
+
+func (r *rootCoordListKV) LoadWithPrefix(ctx context.Context, prefix string, opts ...kv.LoadOption) ([]string, []string, error) {
+	r.loadedPrefixes = append(r.loadedPrefixes, prefix)
+
+	keys := make([]string, 0)
+	for key := range r.data {
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, r.data[key])
+	}
+	return keys, values, nil
+}
+
+func TestListDatabaseByUsesExactKey(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	dbKey := path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix, "1")
+	cli := &rootCoordListKV{data: map[string]string{
+		dbKey: mustDatabaseValue(t, &etcdpb.DatabaseInfo{Id: 1, Name: "default"}),
+		path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix, "2"): mustDatabaseValue(t, &etcdpb.DatabaseInfo{Id: 2, Name: "tenant"}),
+	}}
+
+	dbs, err := ListDatabaseBy(ctx, cli, basePath, DatabaseSelector{DatabaseID: 1})
+	require.NoError(t, err)
+	require.Empty(t, cli.loadedPrefixes)
+	require.Equal(t, []string{dbKey}, cli.loadedKeys)
+	require.Len(t, dbs, 1)
+	require.EqualValues(t, 1, dbs[0].GetProto().GetId())
+}
+
+func TestListDatabaseByKeepsNameFilter(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix, "1"): mustDatabaseValue(t, &etcdpb.DatabaseInfo{Id: 1, Name: "default"}),
+		path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix, "2"): mustDatabaseValue(t, &etcdpb.DatabaseInfo{Id: 2, Name: "tenant"}),
+	}}
+
+	dbs, err := ListDatabaseBy(ctx, cli, basePath, DatabaseSelector{DatabaseName: "tenant"})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, RCPrefix, DBPrefix, DBInfoPrefix) + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, dbs, 1)
+	require.Equal(t, "tenant", dbs[0].GetProto().GetName())
+}
+
+func TestListCollectionWithoutFieldsByUsesLegacyExactAndDBFallback(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	legacyKey := path.Join(basePath, CollectionMetaPrefix, "100")
+	cli := &rootCoordListKV{data: map[string]string{
+		legacyKey: mustCollectionValue(t, 100, 0, "legacy"),
+		path.Join(basePath, DBCollectionMetaPrefix, "1", "100"): mustCollectionValue(t, 100, 1, "db"),
+		path.Join(basePath, DBCollectionMetaPrefix, "2", "200"): mustCollectionValue(t, 200, 2, "other"),
+	}}
+
+	collections, err := ListCollectionWithoutFieldsBy(ctx, cli, basePath, CollectionSelector{CollectionID: 100})
+	require.NoError(t, err)
+	require.Equal(t, []string{legacyKey}, cli.loadedKeys)
+	require.Equal(t, []string{path.Join(basePath, DBCollectionMetaPrefix) + "/"}, cli.loadedPrefixes)
+	require.Len(t, collections, 2)
+	require.ElementsMatch(t, []int64{0, 1}, []int64{collections[0].GetProto().GetDbId(), collections[1].GetProto().GetDbId()})
+}
+
+func TestListCollectionWithoutFieldsByUsesDBExactWhenDatabaseKnown(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	legacyKey := path.Join(basePath, CollectionMetaPrefix, "100")
+	dbKey := path.Join(basePath, DBCollectionMetaPrefix, "1", "100")
+	cli := &rootCoordListKV{data: map[string]string{
+		dbKey: mustCollectionValue(t, 100, 1, "db"),
+		path.Join(basePath, DBCollectionMetaPrefix, "1", "200"): mustCollectionValue(t, 200, 1, "other"),
+	}}
+
+	collections, err := ListCollectionWithoutFieldsBy(ctx, cli, basePath, CollectionSelector{DatabaseID: 1, UseDatabaseID: true, CollectionID: 100})
+	require.NoError(t, err)
+	require.Equal(t, []string{legacyKey, dbKey}, cli.loadedKeys)
+	require.Empty(t, cli.loadedPrefixes)
+	require.Len(t, collections, 1)
+	require.EqualValues(t, 100, collections[0].GetProto().GetID())
+	require.EqualValues(t, 1, collections[0].GetProto().GetDbId())
+}
+
+func TestListCollectionWithoutFieldsByUsesDBPrefix(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, DBCollectionMetaPrefix, "1", "100"): mustCollectionValue(t, 100, 1, "db"),
+		path.Join(basePath, DBCollectionMetaPrefix, "2", "200"): mustCollectionValue(t, 200, 2, "other"),
+	}}
+
+	collections, err := ListCollectionWithoutFieldsBy(ctx, cli, basePath, CollectionSelector{DatabaseID: 1, UseDatabaseID: true})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		path.Join(basePath, CollectionMetaPrefix) + "/",
+		path.Join(basePath, DBCollectionMetaPrefix, "1") + "/",
+	}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, collections, 1)
+	require.EqualValues(t, 1, collections[0].GetProto().GetDbId())
+}
+
+func TestListPartitionsByUsesCollectionPrefix(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, RCPrefix, PartitionPrefix, "100", "10"): mustPartitionValue(t, 100, 10, "p1"),
+		path.Join(basePath, RCPrefix, PartitionPrefix, "200", "20"): mustPartitionValue(t, 200, 20, "p2"),
+	}}
+
+	partitions, err := ListPartitionsBy(ctx, cli, basePath, PartitionSelector{CollectionID: 100})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, RCPrefix, PartitionPrefix, "100") + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, partitions, 1)
+	require.EqualValues(t, 10, partitions[0].GetProto().GetPartitionID())
+}
+
+func TestListPartitionsByUsesExactKey(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	partitionKey := path.Join(basePath, RCPrefix, PartitionPrefix, "100", "10")
+	cli := &rootCoordListKV{data: map[string]string{
+		partitionKey: mustPartitionValue(t, 100, 10, "p1"),
+		path.Join(basePath, RCPrefix, PartitionPrefix, "100", "11"): mustPartitionValue(t, 100, 11, "p2"),
+	}}
+
+	partitions, err := ListPartitionsBy(ctx, cli, basePath, PartitionSelector{CollectionID: 100, PartitionID: 10})
+	require.NoError(t, err)
+	require.Empty(t, cli.loadedPrefixes)
+	require.Equal(t, []string{partitionKey}, cli.loadedKeys)
+	require.Len(t, partitions, 1)
+	require.EqualValues(t, 10, partitions[0].GetProto().GetPartitionID())
+}
+
+func TestListPartitionsByFallsBackWithoutCollectionID(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &rootCoordListKV{data: map[string]string{
+		path.Join(basePath, RCPrefix, PartitionPrefix, "100", "10"): mustPartitionValue(t, 100, 10, "p1"),
+		path.Join(basePath, RCPrefix, PartitionPrefix, "200", "20"): mustPartitionValue(t, 200, 20, "p2"),
+	}}
+
+	partitions, err := ListPartitionsBy(ctx, cli, basePath, PartitionSelector{PartitionID: 20})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, RCPrefix, PartitionPrefix) + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, partitions, 1)
+	require.EqualValues(t, 20, partitions[0].GetProto().GetPartitionID())
+}
+
+func mustDatabaseValue(t *testing.T, info *etcdpb.DatabaseInfo) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(info)
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func mustCollectionValue(t *testing.T, collectionID int64, dbID int64, name string) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(&etcdpb.CollectionInfo{
+		ID:   collectionID,
+		DbId: dbID,
+		Schema: &schemapb.CollectionSchema{
+			Name: name,
+		},
+	})
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func mustPartitionValue(t *testing.T, collectionID int64, partitionID int64, name string) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(&etcdpb.PartitionInfo{
+		CollectionId:  collectionID,
+		PartitionID:   partitionID,
+		PartitionName: name,
+	})
+	require.NoError(t, err)
+	return string(bs)
+}

--- a/states/etcd/common/segment.go
+++ b/states/etcd/common/segment.go
@@ -17,16 +17,51 @@ import (
 
 var ErrReachMaxNumOfWalkSegment = errors.New("reach max number of the walked segments")
 
-func ListSegments(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Segment) bool) ([]*models.Segment, error) {
-	prefix := path.Join(basePath, DCPrefix, SegmentMetaPrefix) + "/"
+var segmentMetaKeySpec = MetaKeySpec{
+	Prefix: path.Join(DCPrefix, SegmentMetaPrefix),
+	Parts:  []MetaKeyPart{KeyCollectionID, KeyPartitionID, KeySegmentID},
+}
 
-	segments, err := ListObj2Models(ctx, cli, prefix, func(info *datapb.SegmentInfo, key string) *models.Segment {
-		return models.NewSegment(info, key, getSegmentLazyFunc(cli, basePath, info))
-	}, filters...)
-	if err != nil {
-		return nil, err
+type SegmentSelector struct {
+	CollectionID int64
+	PartitionID  int64
+	SegmentID    int64
+	Filters      []PostFilter[models.Segment]
+}
+
+func (s SegmentSelector) MetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().
+		WithInt64(KeyCollectionID, s.CollectionID).
+		WithInt64(KeyPartitionID, s.PartitionID).
+		WithInt64(KeySegmentID, s.SegmentID)
+}
+
+func (s SegmentSelector) Match(segment *models.Segment) bool {
+	if s.CollectionID > 0 && segment.CollectionID != s.CollectionID {
+		return false
 	}
-	return segments, nil
+	if s.PartitionID > 0 && segment.PartitionID != s.PartitionID {
+		return false
+	}
+	if s.SegmentID > 0 && segment.ID != s.SegmentID {
+		return false
+	}
+	for _, filter := range s.Filters {
+		if !filter.Match(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+func ListSegments(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Segment) bool) ([]*models.Segment, error) {
+	return ListSegmentsBy(ctx, cli, basePath, SegmentSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListSegmentsBy(ctx context.Context, cli kv.MetaKV, basePath string, selector SegmentSelector) ([]*models.Segment, error) {
+	return ListObj2ModelsBySpec(ctx, cli, basePath, segmentMetaKeySpec, selector.MetaKeyHints(), func(info *datapb.SegmentInfo, key string) *models.Segment {
+		return models.NewSegment(info, key, getSegmentLazyFunc(cli, basePath, info))
+	}, selector)
 }
 
 // ListSegmentsVersion list segment info as specified version.

--- a/states/etcd/common/segment_test.go
+++ b/states/etcd/common/segment_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+type segmentListKV struct {
+	kv.MetaKV
+	data           map[string]string
+	loadedPrefixes []string
+	loadedKeys     []string
+}
+
+func (s *segmentListKV) Load(ctx context.Context, key string, opts ...kv.LoadOption) (string, error) {
+	s.loadedKeys = append(s.loadedKeys, key)
+	value, ok := s.data[key]
+	if !ok {
+		return "", kv.ErrKeyNotFound
+	}
+	return value, nil
+}
+
+func (s *segmentListKV) LoadWithPrefix(ctx context.Context, prefix string, opts ...kv.LoadOption) ([]string, []string, error) {
+	s.loadedPrefixes = append(s.loadedPrefixes, prefix)
+
+	keys := make([]string, 0)
+	for key := range s.data {
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, s.data[key])
+	}
+	return keys, values, nil
+}
+
+func TestListSegmentsByUsesCollectionPrefix(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &segmentListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 1, CollectionID: 100, PartitionID: 10}),
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "200", "20", "2"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 2, CollectionID: 200, PartitionID: 20}),
+	}}
+
+	segments, err := ListSegmentsBy(ctx, cli, basePath, SegmentSelector{CollectionID: 100})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100") + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, segments, 1)
+	require.EqualValues(t, 1, segments[0].ID)
+}
+
+func TestListSegmentsByFallsBackWhenLeadingHintMissing(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &segmentListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 1, CollectionID: 100, PartitionID: 10}),
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "200", "20", "2"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 2, CollectionID: 200, PartitionID: 20}),
+	}}
+
+	segments, err := ListSegmentsBy(ctx, cli, basePath, SegmentSelector{SegmentID: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, DCPrefix, SegmentMetaPrefix) + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, segments, 1)
+	require.EqualValues(t, 2, segments[0].ID)
+}
+
+func TestListSegmentsByUsesExactKey(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	segmentKey := path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1")
+	cli := &segmentListKV{data: map[string]string{
+		segmentKey: mustSegmentValue(t, &datapb.SegmentInfo{ID: 1, CollectionID: 100, PartitionID: 10}),
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "2"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 2, CollectionID: 100, PartitionID: 10}),
+	}}
+
+	segments, err := ListSegmentsBy(ctx, cli, basePath, SegmentSelector{CollectionID: 100, PartitionID: 10, SegmentID: 1})
+	require.NoError(t, err)
+	require.Empty(t, cli.loadedPrefixes)
+	require.Equal(t, []string{segmentKey}, cli.loadedKeys)
+	require.Len(t, segments, 1)
+	require.EqualValues(t, 1, segments[0].ID)
+}
+
+func TestListSegmentsKeepsPostFilters(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &segmentListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 1, CollectionID: 100, PartitionID: 10, NumOfRows: 10}),
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "2"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 2, CollectionID: 100, PartitionID: 10, NumOfRows: 20}),
+	}}
+
+	segments, err := ListSegments(ctx, cli, basePath, func(segment *models.Segment) bool {
+		return segment.NumOfRows == 20
+	})
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+	require.EqualValues(t, 2, segments[0].ID)
+}
+
+func mustSegmentValue(t *testing.T, info *datapb.SegmentInfo) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(info)
+	require.NoError(t, err)
+	return string(bs)
+}

--- a/states/etcd/show/collection.go
+++ b/states/etcd/show/collection.go
@@ -30,49 +30,46 @@ type CollectionParam struct {
 }
 
 func (c *ComponentShow) CollectionCommand(ctx context.Context, p *CollectionParam) (*framework.PresetResultSet, error) {
-	var collections []*models.Collection
 	var total int64
-	var err error
-	// perform get by id to accelerate
-	if p.CollectionID > 0 {
-		var collection *models.Collection
-		collection, err = common.GetCollectionByIDVersion(ctx, c.client, c.metaPath, p.CollectionID)
-		if err == nil {
-			collections = append(collections, collection)
-		}
-	} else {
-		collections, err = common.ListCollections(ctx, c.client, c.metaPath, func(info *models.Collection) bool {
-			coll := info.GetProto()
-			if p.CollectionName != "" && coll.Schema.Name != p.CollectionName {
-				return false
-			}
-			if p.DatabaseID > -1 && coll.DbId != p.DatabaseID {
-				return false
-			}
-			if p.State != "" && !strings.EqualFold(p.State, coll.State.String()) {
-				return false
-			}
-
-			if p.WithPropertyKey != "" {
-				found := false
-				for _, prop := range coll.Properties {
-					if prop.Key == p.WithPropertyKey {
-						found = true
-						break
-					}
-				}
-				if !found {
+	collections, err := common.ListCollectionsBy(ctx, c.client, c.metaPath, common.CollectionSelector{
+		DatabaseID:     p.DatabaseID,
+		UseDatabaseID:  p.DatabaseID > -1,
+		CollectionID:   p.CollectionID,
+		CollectionName: p.CollectionName,
+		Filters: []common.PostFilter[models.Collection]{
+			func(info *models.Collection) bool {
+				coll := info.GetProto()
+				if p.State != "" && !strings.EqualFold(p.State, coll.State.String()) {
 					return false
 				}
-			}
 
-			total++
-			return true
-		})
-	}
+				if p.WithPropertyKey != "" {
+					found := false
+					for _, prop := range coll.Properties {
+						if prop.Key == p.WithPropertyKey {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return false
+					}
+				}
+
+				total++
+				return true
+			},
+		},
+	})
 
 	if err != nil {
 		return nil, err
+	}
+	if p.CollectionID > 0 {
+		if len(collections) == 0 {
+			return nil, fmt.Errorf("collection %d not found", p.CollectionID)
+		}
+		collections = collections[:1]
 	}
 	channels := 0
 	healthy := 0

--- a/states/etcd/show/collection.go
+++ b/states/etcd/show/collection.go
@@ -61,7 +61,6 @@ func (c *ComponentShow) CollectionCommand(ctx context.Context, p *CollectionPara
 			},
 		},
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/states/etcd/show/database.go
+++ b/states/etcd/show/database.go
@@ -21,8 +21,9 @@ type DatabaseParam struct {
 
 // DatabaseCommand returns show database comand.
 func (c *ComponentShow) DatabaseCommand(ctx context.Context, p *DatabaseParam) (*framework.PresetResultSet, error) {
-	dbs, err := common.ListDatabase(ctx, c.client, c.metaPath, func(db *models.Database) bool {
-		return (p.DatabaseName == "" || db.GetProto().GetName() == p.DatabaseName) && (p.DatabaseID == 0 || db.GetProto().GetId() == p.DatabaseID)
+	dbs, err := common.ListDatabaseBy(ctx, c.client, c.metaPath, common.DatabaseSelector{
+		DatabaseID:   p.DatabaseID,
+		DatabaseName: p.DatabaseName,
 	})
 	if err != nil {
 		fmt.Println("failed to list database info", err.Error())

--- a/states/etcd/show/partition.go
+++ b/states/etcd/show/partition.go
@@ -24,7 +24,7 @@ func (c *ComponentShow) PartitionCommand(ctx context.Context, p *PartitionParam)
 		return nil, errors.New("collection id not provided")
 	}
 
-	partitions, err := common.ListCollectionPartitions(ctx, c.client, c.metaPath, p.CollectionID)
+	partitions, err := common.ListPartitionsBy(ctx, c.client, c.metaPath, common.PartitionSelector{CollectionID: p.CollectionID})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list partition info")
 	}

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -45,15 +45,19 @@ type segStats struct {
 
 // SegmentCommand returns show segments command.
 func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) (*framework.PresetResultSet, error) {
-	segments, err := common.ListSegments(ctx, c.client, c.metaPath, func(segment *models.Segment) bool {
-		return (p.CollectionID == 0 || segment.CollectionID == p.CollectionID) &&
-			(p.PartitionID == 0 || segment.PartitionID == p.PartitionID) &&
-			(p.SegmentID == 0 || segment.ID == p.SegmentID) &&
-			(p.State == "" || strings.EqualFold(segment.State.String(), p.State)) &&
-			(p.Level == "" || strings.EqualFold(segment.Level.String(), p.Level)) &&
-			(p.VChannel == "" || strings.EqualFold(segment.GetInsertChannel(), p.VChannel)) &&
-			(p.Sorted == "" || strings.EqualFold(strconv.FormatBool(segment.IsSorted), p.Sorted)) &&
-			(p.StorageVersion == -1 || segment.StorageVersion == p.StorageVersion)
+	segments, err := common.ListSegmentsBy(ctx, c.client, c.metaPath, common.SegmentSelector{
+		CollectionID: p.CollectionID,
+		PartitionID:  p.PartitionID,
+		SegmentID:    p.SegmentID,
+		Filters: []common.PostFilter[models.Segment]{
+			func(segment *models.Segment) bool {
+				return (p.State == "" || strings.EqualFold(segment.State.String(), p.State)) &&
+					(p.Level == "" || strings.EqualFold(segment.Level.String(), p.Level)) &&
+					(p.VChannel == "" || strings.EqualFold(segment.GetInsertChannel(), p.VChannel)) &&
+					(p.Sorted == "" || strings.EqualFold(strconv.FormatBool(segment.IsSorted), p.Sorted)) &&
+					(p.StorageVersion == -1 || segment.StorageVersion == p.StorageVersion)
+			},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list segments: %w", err)


### PR DESCRIPTION
Introduce a structured meta key scan layer for common ListXXX helpers. Selectors now expose known key parts through MetaKeyHints, allowing list helpers to choose exact key loads or narrower prefix scans instead of always loading broad prefixes and filtering decoded objects.

The new design keeps the existing post-filter API compatible while adding typed selector entry points for database, collection, partition, and segment metadata. MetaKeySpec defines each key layout, ScanTarget represents exact vs prefix reads, and object-level filters still run after decode to preserve behavior across legacy layouts and malformed metadata.

Also optimize collection enrichment for large result sets. When ListCollectionsBy returns more than the configured threshold, it bulk-loads all field, struct field, and function metadata once, parses collection IDs from keys, and maps the grouped results back to collections. Small result sets continue using the existing per-collection reads.

This reduces sequential etcd reads for common show/list paths while keeping legacy behavior and filter semantics intact.