### PR TITLE
fix: lazy load BM25 stats logs for segment details

### DIFF
--- a/models/segment.go
+++ b/models/segment.go
@@ -15,9 +15,10 @@ type Segment struct {
 	*datapb.SegmentInfo
 
 	// field binlogs
-	binlogs   []*FieldBinlog
-	statslogs []*FieldBinlog
-	deltalogs []*FieldBinlog
+	binlogs       []*FieldBinlog
+	statslogs     []*FieldBinlog
+	deltalogs     []*FieldBinlog
+	bm25Statslogs []*FieldBinlog
 	// Semantic version
 	Version string
 
@@ -30,7 +31,7 @@ type Segment struct {
 }
 
 func NewSegment(segment *datapb.SegmentInfo, key string,
-	lazy func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error),
+	lazy func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error),
 ) *Segment {
 	s := &Segment{
 		SegmentInfo: segment,
@@ -48,14 +49,18 @@ func NewSegment(segment *datapb.SegmentInfo, key string,
 			}
 			return r
 		}
-		binlogs, statslogs, deltalogs, err := lazy()
+		binlogs, statslogs, deltalogs, bm25Statslogs, err := lazy()
 		if err != nil {
 			fmt.Println("lazy load binlog failed", err.Error())
 			return
 		}
+		if len(bm25Statslogs) == 0 {
+			bm25Statslogs = segment.GetBm25Statslogs()
+		}
 		s.binlogs = lo.Map(binlogs, mFunc)
 		s.statslogs = lo.Map(statslogs, mFunc)
 		s.deltalogs = lo.Map(deltalogs, mFunc)
+		s.bm25Statslogs = lo.Map(bm25Statslogs, mFunc)
 	}
 
 	return s
@@ -114,6 +119,15 @@ func (s *Segment) GetDeltalogs() []*FieldBinlog {
 		}
 	})
 	return s.deltalogs
+}
+
+func (s *Segment) GetBm25Statslogs() []*FieldBinlog {
+	s.loadOnce.Do(func() {
+		if s.lazyLoad != nil {
+			s.lazyLoad(s)
+		}
+	})
+	return s.bm25Statslogs
 }
 
 func (s *Segment) GetStartPosition() *msgpb.MsgPosition {

--- a/states/etcd/common/consts.go
+++ b/states/etcd/common/consts.go
@@ -22,6 +22,7 @@ const (
 
 	SegmentMetaPrefix      = "s"
 	SegmentStatsMetaPrefix = "statslog"
+	SegmentBM25LogPrefix   = "bm25log"
 
 	CompactionTaskPrefix = `compaction-task`
 )

--- a/states/etcd/common/segment.go
+++ b/states/etcd/common/segment.go
@@ -103,8 +103,8 @@ func ListSegmentsBy(ctx context.Context, cli kv.MetaKV, basePath string, selecto
 // 	}
 // }
 
-func getSegmentLazyFunc(cli kv.MetaKV, basePath string, segment *datapb.SegmentInfo) func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
-	return func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+func getSegmentLazyFunc(cli kv.MetaKV, basePath string, segment *datapb.SegmentInfo) func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	return func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
 		prefix := path.Join(basePath, "datacoord-meta", fmt.Sprintf("binlog/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID))
 
 		f := func(pb func(segment *datapb.SegmentInfo, fieldID int64, logID int64) string) ([]*datapb.FieldBinlog, error) {
@@ -124,7 +124,7 @@ func getSegmentLazyFunc(cli kv.MetaKV, basePath string, segment *datapb.SegmentI
 			return fmt.Sprintf("ROOT_PATH/insert_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
 		})
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		prefix = path.Join(basePath, "datacoord-meta", fmt.Sprintf("statslog/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID))
@@ -132,7 +132,7 @@ func getSegmentLazyFunc(cli kv.MetaKV, basePath string, segment *datapb.SegmentI
 			return fmt.Sprintf("ROOT_PATH/stats_log/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
 		})
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		prefix = path.Join(basePath, "datacoord-meta", fmt.Sprintf("deltalog/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID))
@@ -140,10 +140,18 @@ func getSegmentLazyFunc(cli kv.MetaKV, basePath string, segment *datapb.SegmentI
 			return fmt.Sprintf("ROOT_PATH/delta_log/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, logID)
 		})
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
-		return binlogs, statslogs, deltalogs, nil
+		prefix = path.Join(basePath, "datacoord-meta", fmt.Sprintf("%s/%d/%d/%d", SegmentBM25LogPrefix, segment.CollectionID, segment.PartitionID, segment.ID))
+		bm25Statslogs, err := f(func(segment *datapb.SegmentInfo, fieldID int64, logID int64) string {
+			return fmt.Sprintf("ROOT_PATH/bm25_stats/%d/%d/%d/%d/%d", segment.CollectionID, segment.PartitionID, segment.ID, fieldID, logID)
+		})
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+
+		return binlogs, statslogs, deltalogs, bm25Statslogs, nil
 	}
 }
 

--- a/states/etcd/common/segment_test.go
+++ b/states/etcd/common/segment_test.go
@@ -114,7 +114,73 @@ func TestListSegmentsKeepsPostFilters(t *testing.T) {
 	require.EqualValues(t, 2, segments[0].ID)
 }
 
+func TestListSegmentsLazyLoadsBM25Statslogs(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &segmentListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1"): mustSegmentValue(t, &datapb.SegmentInfo{ID: 1, CollectionID: 100, PartitionID: 10}),
+		path.Join(basePath, DCPrefix, SegmentBM25LogPrefix, "100", "10", "1", "101"): mustFieldBinlogValue(t, &datapb.FieldBinlog{
+			FieldID: 101,
+			Binlogs: []*datapb.Binlog{{
+				LogID:      1001,
+				LogSize:    10,
+				MemorySize: 20,
+			}},
+		}),
+	}}
+
+	segments, err := ListSegments(ctx, cli, basePath)
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+
+	bm25Statslogs := segments[0].GetBm25Statslogs()
+	require.Len(t, bm25Statslogs, 1)
+	require.EqualValues(t, 101, bm25Statslogs[0].FieldID)
+	require.Len(t, bm25Statslogs[0].Binlogs, 1)
+	require.EqualValues(t, 1001, bm25Statslogs[0].Binlogs[0].LogID)
+	require.EqualValues(t, 10, bm25Statslogs[0].Binlogs[0].LogSize)
+	require.EqualValues(t, 20, bm25Statslogs[0].Binlogs[0].MemSize)
+	require.Equal(t, "ROOT_PATH/bm25_stats/100/10/1/101/1001", bm25Statslogs[0].Binlogs[0].LogPath)
+}
+
+func TestListSegmentsKeepsInlineBM25Statslogs(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &segmentListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, SegmentMetaPrefix, "100", "10", "1"): mustSegmentValue(t, &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: 100,
+			PartitionID:  10,
+			Bm25Statslogs: []*datapb.FieldBinlog{{
+				FieldID: 101,
+				Binlogs: []*datapb.Binlog{{
+					LogID:      1001,
+					LogPath:    "inline-bm25-path",
+					LogSize:    10,
+					MemorySize: 20,
+				}},
+			}},
+		}),
+	}}
+
+	segments, err := ListSegments(ctx, cli, basePath)
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+
+	bm25Statslogs := segments[0].GetBm25Statslogs()
+	require.Len(t, bm25Statslogs, 1)
+	require.Equal(t, "inline-bm25-path", bm25Statslogs[0].Binlogs[0].LogPath)
+}
+
 func mustSegmentValue(t *testing.T, info *datapb.SegmentInfo) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(info)
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func mustFieldBinlogValue(t *testing.T, info *datapb.FieldBinlog) string {
 	t.Helper()
 
 	bs, err := proto.Marshal(info)

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -446,8 +446,23 @@ func PrintSegmentInfo(info *models.Segment, detailBinlog bool) {
 				fmt.Println("\t", logFile)
 			}
 		}
-		fmt.Println("=== Segment Total Textlog Size: ", hrSize(deltaLogSize))
-		fmt.Println("=== Segment Total Textlog Mem Size: ", hrSize(memSize))
+		fmt.Println("=== Segment Total Textlog Size: ", hrSize(textStatsSize))
+		fmt.Println("=== Segment Total Textlog Mem Size: ", hrSize(textStatsMemSize))
+
+		fmt.Println("**************************************")
+		fmt.Println("BM25 stats")
+		var bm25StatsSize int64
+		var bm25StatsMemSize int64
+		for _, bm25stats := range info.GetBm25Statslogs() {
+			for _, statsLog := range bm25stats.Binlogs {
+				bm25StatsSize += statsLog.LogSize
+				bm25StatsMemSize += statsLog.MemSize
+				fmt.Println("\t", statsLog.LogPath)
+			}
+		}
+
+		fmt.Println("=== Segment Total Bm25 Size: ", hrSize(bm25StatsSize))
+		fmt.Println("=== Segment Total Bm25 Mem Size: ", hrSize(bm25StatsMemSize))
 	}
 
 	fmt.Println("================================================================================")


### PR DESCRIPTION
Load standalone datacoord-meta/bm25log entries when listing segments so show segment --detail includes BM25 stats logs that are no longer embedded in the main segment meta. Preserve inline BM25 logs for older metadata and cover both paths with focused tests.