### PR TITLE
enhance: add snapshot metadata listing commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,6 +180,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/stathat/consistent v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/models/snapshot.go
+++ b/models/snapshot.go
@@ -1,0 +1,9 @@
+package models
+
+import "github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+
+type Snapshot = ProtoWrapper[*datapb.SnapshotInfo]
+
+func NewSnapshot(info *datapb.SnapshotInfo, key string) *Snapshot {
+	return NewProtoWrapper(info, key)
+}

--- a/states/etcd/common/consts.go
+++ b/states/etcd/common/consts.go
@@ -23,6 +23,7 @@ const (
 	SegmentMetaPrefix      = "s"
 	SegmentStatsMetaPrefix = "statslog"
 	SegmentBM25LogPrefix   = "bm25log"
+	DCSnapshotPrefix       = "snapshot"
 
 	CompactionTaskPrefix = `compaction-task`
 )

--- a/states/etcd/common/meta_key.go
+++ b/states/etcd/common/meta_key.go
@@ -13,6 +13,7 @@ const (
 	KeyCollectionID MetaKeyPart = "collectionID"
 	KeyPartitionID  MetaKeyPart = "partitionID"
 	KeySegmentID    MetaKeyPart = "segmentID"
+	KeySnapshotID   MetaKeyPart = "snapshotID"
 	KeyFieldID      MetaKeyPart = "fieldID"
 	KeyIndexID      MetaKeyPart = "indexID"
 	KeyJobID        MetaKeyPart = "jobID"

--- a/states/etcd/common/snapshot.go
+++ b/states/etcd/common/snapshot.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"context"
+	"path"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/kv"
+)
+
+var snapshotMetaKeySpec = MetaKeySpec{
+	Prefix: path.Join(DCPrefix, DCSnapshotPrefix),
+	Parts:  []MetaKeyPart{KeyCollectionID, KeySnapshotID},
+}
+
+type SnapshotSelector struct {
+	CollectionID int64
+	SnapshotID   int64
+	Filters      []PostFilter[models.Snapshot]
+}
+
+func (s SnapshotSelector) MetaKeyHints() MetaKeyHints {
+	return NewMetaKeyHints().
+		WithInt64(KeyCollectionID, s.CollectionID).
+		WithInt64(KeySnapshotID, s.SnapshotID)
+}
+
+func (s SnapshotSelector) Match(snapshot *models.Snapshot) bool {
+	proto := snapshot.GetProto()
+	if s.CollectionID > 0 && proto.GetCollectionId() != s.CollectionID {
+		return false
+	}
+	if s.SnapshotID > 0 && proto.GetId() != s.SnapshotID {
+		return false
+	}
+	for _, filter := range s.Filters {
+		if !filter.Match(snapshot) {
+			return false
+		}
+	}
+	return true
+}
+
+func ListSnapshots(ctx context.Context, cli kv.MetaKV, basePath string, filters ...func(*models.Snapshot) bool) ([]*models.Snapshot, error) {
+	return ListSnapshotsBy(ctx, cli, basePath, SnapshotSelector{Filters: wrapPostFilters(filters)})
+}
+
+func ListSnapshotsBy(ctx context.Context, cli kv.MetaKV, basePath string, selector SnapshotSelector) ([]*models.Snapshot, error) {
+	return ListObj2ModelsBySpec(ctx, cli, basePath, snapshotMetaKeySpec, selector.MetaKeyHints(), models.NewSnapshot, selector)
+}

--- a/states/etcd/common/snapshot_test.go
+++ b/states/etcd/common/snapshot_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+type snapshotListKV struct {
+	kv.MetaKV
+	data           map[string]string
+	loadedPrefixes []string
+	loadedKeys     []string
+}
+
+func (s *snapshotListKV) Load(ctx context.Context, key string, opts ...kv.LoadOption) (string, error) {
+	s.loadedKeys = append(s.loadedKeys, key)
+	value, ok := s.data[key]
+	if !ok {
+		return "", kv.ErrKeyNotFound
+	}
+	return value, nil
+}
+
+func (s *snapshotListKV) LoadWithPrefix(ctx context.Context, prefix string, opts ...kv.LoadOption) ([]string, []string, error) {
+	s.loadedPrefixes = append(s.loadedPrefixes, prefix)
+
+	keys := make([]string, 0)
+	for key := range s.data {
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, s.data[key])
+	}
+	return keys, values, nil
+}
+
+func TestListSnapshotsByUsesCollectionPrefix(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &snapshotListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "1"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 1, CollectionId: 100}),
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "200", "2"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 2, CollectionId: 200}),
+	}}
+
+	snapshots, err := ListSnapshotsBy(ctx, cli, basePath, SnapshotSelector{CollectionID: 100})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100") + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, snapshots, 1)
+	require.EqualValues(t, 1, snapshots[0].GetProto().GetId())
+}
+
+func TestListSnapshotsByFallsBackWhenLeadingHintMissing(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &snapshotListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "1"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 1, CollectionId: 100}),
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "200", "2"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 2, CollectionId: 200}),
+	}}
+
+	snapshots, err := ListSnapshotsBy(ctx, cli, basePath, SnapshotSelector{SnapshotID: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(basePath, DCPrefix, DCSnapshotPrefix) + "/"}, cli.loadedPrefixes)
+	require.Empty(t, cli.loadedKeys)
+	require.Len(t, snapshots, 1)
+	require.EqualValues(t, 2, snapshots[0].GetProto().GetId())
+}
+
+func TestListSnapshotsByUsesExactKey(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	snapshotKey := path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "1")
+	cli := &snapshotListKV{data: map[string]string{
+		snapshotKey: mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 1, CollectionId: 100}),
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "2"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 2, CollectionId: 100}),
+	}}
+
+	snapshots, err := ListSnapshotsBy(ctx, cli, basePath, SnapshotSelector{CollectionID: 100, SnapshotID: 1})
+	require.NoError(t, err)
+	require.Empty(t, cli.loadedPrefixes)
+	require.Equal(t, []string{snapshotKey}, cli.loadedKeys)
+	require.Len(t, snapshots, 1)
+	require.EqualValues(t, 1, snapshots[0].GetProto().GetId())
+}
+
+func TestListSnapshotsKeepsPostFilters(t *testing.T) {
+	ctx := context.Background()
+	basePath := "root"
+	cli := &snapshotListKV{data: map[string]string{
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "1"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 1, CollectionId: 100, Name: "first"}),
+		path.Join(basePath, DCPrefix, DCSnapshotPrefix, "100", "2"): mustSnapshotValue(t, &datapb.SnapshotInfo{Id: 2, CollectionId: 100, Name: "second"}),
+	}}
+
+	snapshots, err := ListSnapshots(ctx, cli, basePath, func(snapshot *models.Snapshot) bool {
+		return snapshot.GetProto().GetName() == "second"
+	})
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	require.EqualValues(t, 2, snapshots[0].GetProto().GetId())
+}
+
+func mustSnapshotValue(t *testing.T, info *datapb.SnapshotInfo) string {
+	t.Helper()
+
+	bs, err := proto.Marshal(info)
+	require.NoError(t, err)
+	return string(bs)
+}

--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -325,7 +325,7 @@ const (
 func PrintSegmentInfo(info *models.Segment, detailBinlog bool) {
 	fmt.Println("================================================================================")
 	fmt.Printf("Segment ID: %d\n", info.ID)
-	fmt.Printf("Segment State: %v", info.State)
+	fmt.Printf("Segment State: %v\t IsImporting: %t\n", info.State, info.IsImporting)
 	if info.State == commonpb.SegmentState_Dropped {
 		dropTime := time.Unix(0, int64(info.DroppedAt))
 		fmt.Printf("\tDropped Time: %s", dropTime.Format(tsPrintFormat))

--- a/states/etcd/show/snapshot.go
+++ b/states/etcd/show/snapshot.go
@@ -1,0 +1,220 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/birdwatcher/utils"
+)
+
+type SnapshotParam struct {
+	framework.DataSetParam `use:"show snapshots" desc:"display snapshot metadata from data coord meta store" alias:"snapshot"`
+	CollectionID           int64  `name:"collection" default:"0" desc:"collection id to filter with"`
+	SnapshotID             int64  `name:"snapshot" default:"0" desc:"snapshot id to display"`
+	State                  string `name:"state" default:"" desc:"snapshot state to filter"`
+}
+
+func (c *ComponentShow) SnapshotCommand(ctx context.Context, p *SnapshotParam) (*framework.PresetResultSet, error) {
+	snapshots, err := common.ListSnapshotsBy(ctx, c.client, c.metaPath, common.SnapshotSelector{
+		CollectionID: p.CollectionID,
+		SnapshotID:   p.SnapshotID,
+		Filters: []common.PostFilter[models.Snapshot]{
+			func(snapshot *models.Snapshot) bool {
+				return p.State == "" || strings.EqualFold(snapshot.GetProto().GetState().String(), p.State)
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list snapshots: %w", err)
+	}
+	if p.SnapshotID > 0 && len(snapshots) == 0 {
+		return nil, fmt.Errorf("snapshot %d not found", p.SnapshotID)
+	}
+
+	return framework.NewPresetResultSet(framework.NewListResult[Snapshots](snapshots), framework.NameFormat(p.Format)), nil
+}
+
+type Snapshots struct {
+	framework.ListResultSet[*models.Snapshot]
+}
+
+func (rs *Snapshots) TableHeaders() table.Row {
+	return table.Row{"SnapshotID", "Name", "CollectionID", "State", "Partitions", "CreateTS", "S3Location"}
+}
+
+func (rs *Snapshots) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(rs.Data))
+	for _, snapshot := range rs.Data {
+		info := snapshot.GetProto()
+		rows = append(rows, table.Row{
+			info.GetId(),
+			info.GetName(),
+			info.GetCollectionId(),
+			info.GetState().String(),
+			len(info.GetPartitionIds()),
+			formatHybridTS(info.GetCreateTs()),
+			info.GetS3Location(),
+		})
+	}
+	return rows
+}
+
+func (rs *Snapshots) PrintAs(format framework.Format) string {
+	switch format {
+	case framework.FormatDefault, framework.FormatPlain:
+		return rs.printDefault()
+	case framework.FormatJSON:
+		return rs.printAsJSON()
+	default:
+	}
+	return ""
+}
+
+func (rs *Snapshots) printDefault() string {
+	sb := &strings.Builder{}
+	for _, snapshot := range rs.Data {
+		rs.printSnapshot(sb, snapshot)
+	}
+	fmt.Fprintf(sb, "--- Total Snapshot(s): %d\n", len(rs.Data))
+	return sb.String()
+}
+
+func (rs *Snapshots) printAsJSON() string {
+	type SnapshotJSON struct {
+		Key                   string          `json:"key"`
+		Name                  string          `json:"name"`
+		SnapshotID            int64           `json:"snapshot_id"`
+		Description           string          `json:"description,omitempty"`
+		CollectionID          int64           `json:"collection_id"`
+		PartitionIDs          []int64         `json:"partition_ids,omitempty"`
+		CreateTS              int64           `json:"create_ts"`
+		CreateTime            string          `json:"create_time,omitempty"`
+		CreateTSLogical       uint64          `json:"create_ts_logical,omitempty"`
+		S3Location            string          `json:"s3_location,omitempty"`
+		State                 string          `json:"state"`
+		PendingStartTime      int64           `json:"pending_start_time"`
+		PendingStartTimeHuman string          `json:"pending_start_time_human,omitempty"`
+		CompactionExpireTime  uint64          `json:"compaction_expire_time"`
+		CompactionExpireHuman string          `json:"compaction_expire_time_human,omitempty"`
+		PinIDs                []int64         `json:"pin_ids,omitempty"`
+		PinExpireAtMs         map[int64]int64 `json:"pin_expire_at_ms,omitempty"`
+	}
+
+	type OutputJSON struct {
+		Snapshots    []SnapshotJSON `json:"snapshots"`
+		MatchedCount int            `json:"matched_count"`
+	}
+
+	output := OutputJSON{
+		Snapshots:    make([]SnapshotJSON, 0, len(rs.Data)),
+		MatchedCount: len(rs.Data),
+	}
+
+	for _, snapshot := range rs.Data {
+		info := snapshot.GetProto()
+		createTime, logical := utils.ParseTS(uint64(info.GetCreateTs()))
+		item := SnapshotJSON{
+			Key:                  snapshot.Key(),
+			Name:                 info.GetName(),
+			SnapshotID:           info.GetId(),
+			Description:          info.GetDescription(),
+			CollectionID:         info.GetCollectionId(),
+			PartitionIDs:         append([]int64(nil), info.GetPartitionIds()...),
+			CreateTS:             info.GetCreateTs(),
+			CreateTime:           createTime.Format(tsPrintFormat),
+			CreateTSLogical:      logical,
+			S3Location:           info.GetS3Location(),
+			State:                info.GetState().String(),
+			PendingStartTime:     info.GetPendingStartTime(),
+			CompactionExpireTime: info.GetCompactionExpireTime(),
+			PinIDs:               append([]int64(nil), info.GetPinIds()...),
+			PinExpireAtMs:        cloneInt64Map(info.GetPinExpireAtMs()),
+		}
+		if info.GetPendingStartTime() > 0 {
+			item.PendingStartTimeHuman = time.UnixMilli(info.GetPendingStartTime()).Format(tsPrintFormat)
+		}
+		if info.GetCompactionExpireTime() > 0 {
+			item.CompactionExpireHuman = time.Unix(int64(info.GetCompactionExpireTime()), 0).Format(tsPrintFormat)
+		}
+		output.Snapshots = append(output.Snapshots, item)
+	}
+
+	return framework.MarshalJSON(output)
+}
+
+func (rs *Snapshots) printSnapshot(sb *strings.Builder, snapshot *models.Snapshot) {
+	info := snapshot.GetProto()
+	createTime, logical := utils.ParseTS(uint64(info.GetCreateTs()))
+
+	fmt.Fprintln(sb, "=============================")
+	fmt.Fprintf(sb, "Key: %s\n", snapshot.Key())
+	fmt.Fprintf(sb, "Snapshot ID: %d\tName: %s\n", info.GetId(), info.GetName())
+	fmt.Fprintf(sb, "CollectionID: %d\tState: %s\n", info.GetCollectionId(), info.GetState().String())
+	if description := info.GetDescription(); description != "" {
+		fmt.Fprintf(sb, "Description: %s\n", description)
+	}
+	fmt.Fprintf(sb, "Create TS: %d\tTime: %s\tLogical: %d\n", info.GetCreateTs(), createTime.Format(tsPrintFormat), logical)
+	fmt.Fprintf(sb, "Partitions(%d): %v\n", len(info.GetPartitionIds()), info.GetPartitionIds())
+	fmt.Fprintf(sb, "S3 Location: %s\n", emptyAsNA(info.GetS3Location()))
+	fmt.Fprintf(sb, "Pending Start Time: %s\n", formatUnixMillis(info.GetPendingStartTime()))
+	fmt.Fprintf(sb, "Compaction Expire Time: %s\n", formatUnixSeconds(info.GetCompactionExpireTime()))
+	fmt.Fprintf(sb, "Pin IDs(%d): %v\n", len(info.GetPinIds()), info.GetPinIds())
+	fmt.Fprintf(sb, "Pin Expire At Ms(%d):\n", len(info.GetPinExpireAtMs()))
+
+	pinIDs := make([]int64, 0, len(info.GetPinExpireAtMs()))
+	for pinID := range info.GetPinExpireAtMs() {
+		pinIDs = append(pinIDs, pinID)
+	}
+	slices.Sort(pinIDs)
+	for _, pinID := range pinIDs {
+		expireAt := info.GetPinExpireAtMs()[pinID]
+		fmt.Fprintf(sb, "  - %d: %s\n", pinID, formatUnixMillis(expireAt))
+	}
+}
+
+func cloneInt64Map(src map[int64]int64) map[int64]int64 {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[int64]int64, len(src))
+	maps.Copy(dst, src)
+	return dst
+}
+
+func formatHybridTS(ts int64) string {
+	if ts <= 0 {
+		return "N/A"
+	}
+	t, logical := utils.ParseTS(uint64(ts))
+	return fmt.Sprintf("%s (logical=%d)", t.Format(tsPrintFormat), logical)
+}
+
+func formatUnixMillis(ts int64) string {
+	if ts <= 0 {
+		return "N/A"
+	}
+	return time.UnixMilli(ts).Format(tsPrintFormat)
+}
+
+func formatUnixSeconds(ts uint64) string {
+	if ts == 0 {
+		return "N/A"
+	}
+	return time.Unix(int64(ts), 0).Format(tsPrintFormat)
+}
+
+func emptyAsNA(value string) string {
+	if value == "" {
+		return "N/A"
+	}
+	return value
+}


### PR DESCRIPTION
Add snapshot models, selectors, and show output so Birdwatcher can inspect data coord snapshot metadata by collection, snapshot ID, and state.

Include selector tests for prefix/key-aware loading and surface IsImporting in segment output for easier metadata inspection.