### PR TITLE
enhance: add object store abstraction for OSS reads

### DIFF
--- a/oss/object_store.go
+++ b/oss/object_store.go
@@ -1,0 +1,133 @@
+package oss
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/minio/minio-go/v7"
+
+	"github.com/milvus-io/birdwatcher/models"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+)
+
+type ObjectStore interface {
+	Open(ctx context.Context, key string, opts ...OpenOption) (storagecommon.ReadSeeker, error)
+	Stat(ctx context.Context, key string) (*models.FsStat, error)
+	List(ctx context.Context, prefix string, recursive bool) (<-chan ObjectInfo, error)
+}
+
+type ObjectInfo struct {
+	Key   string
+	Size  int64
+	IsDir bool
+	Err   error
+}
+
+type ResolvedObjectStore struct {
+	Store      ObjectStore
+	BucketName string
+	RootPath   string
+}
+
+type openSettings struct {
+	rangeSet bool
+	start    int64
+	end      int64
+}
+
+type OpenOption func(*openSettings)
+
+func WithOpenRange(start, end int64) OpenOption {
+	return func(settings *openSettings) {
+		settings.rangeSet = true
+		settings.start = start
+		settings.end = end
+	}
+}
+
+func ResolveObjectKey(rootPath, logicalPath string) string {
+	resolved := strings.TrimSpace(logicalPath)
+	if resolved == "" {
+		return ""
+	}
+	if strings.Contains(resolved, "ROOT_PATH") {
+		resolved = strings.ReplaceAll(resolved, "ROOT_PATH", strings.Trim(rootPath, "/"))
+	}
+	resolved = strings.TrimPrefix(resolved, "/")
+	if resolved == "" {
+		return ""
+	}
+	resolved = path.Clean(resolved)
+	if resolved == "." {
+		return ""
+	}
+	return resolved
+}
+
+type minioObjectStore struct {
+	client *minio.Client
+	bucket string
+}
+
+func NewMinioObjectStore(client *MinioClient) ObjectStore {
+	return &minioObjectStore{client: client.Client, bucket: client.BucketName}
+}
+
+func NewMinioObjectStoreWithBucket(client *minio.Client, bucketName string) ObjectStore {
+	return &minioObjectStore{client: client, bucket: bucketName}
+}
+
+func MinioClientFromObjectStore(store ObjectStore) (*minio.Client, bool) {
+	compat, ok := store.(*minioObjectStore)
+	if !ok {
+		return nil, false
+	}
+	return compat.client, true
+}
+
+func (s *minioObjectStore) Open(ctx context.Context, key string, opts ...OpenOption) (storagecommon.ReadSeeker, error) {
+	settings := &openSettings{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(settings)
+		}
+	}
+
+	getOpts := minio.GetObjectOptions{}
+	if settings.rangeSet {
+		if settings.start < 0 || settings.end < settings.start {
+			return nil, errors.New("invalid open range")
+		}
+		if err := getOpts.SetRange(settings.start, settings.end); err != nil {
+			return nil, err
+		}
+	}
+	return s.client.GetObject(ctx, s.bucket, key, getOpts)
+}
+
+func (s *minioObjectStore) Stat(ctx context.Context, key string) (*models.FsStat, error) {
+	info, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &models.FsStat{Size: info.Size}, nil
+}
+
+func (s *minioObjectStore) List(ctx context.Context, prefix string, recursive bool) (<-chan ObjectInfo, error) {
+	source := s.client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{Prefix: prefix, Recursive: recursive})
+	result := make(chan ObjectInfo)
+	go func() {
+		defer close(result)
+		for info := range source {
+			result <- ObjectInfo{
+				Key:   info.Key,
+				Size:  info.Size,
+				IsDir: strings.HasSuffix(info.Key, "/"),
+				Err:   info.Err,
+			}
+		}
+	}()
+	return result, nil
+}

--- a/states/app_state.go
+++ b/states/app_state.go
@@ -26,7 +26,8 @@ type ApplicationState struct {
 	// config stores configuration items
 	config *configs.Config
 
-	extensions []Extension
+	extensions          []Extension
+	objectStoreProvider ObjectStoreProvider
 }
 
 func (app *ApplicationState) Ctx() (context.Context, context.CancelFunc) {
@@ -115,6 +116,7 @@ func (app *ApplicationState) SetupCommands() {
 	cmd := app.core.GetCmd()
 
 	app.core.UpdateState(cmd, app, app.SetupCommands)
+	app.objectStoreProvider = resolveObjectStoreProvider(app.objectStoreProvider, app.extensions)
 	for _, ext := range app.extensions {
 		provider, ok := ext.(ApplicationFunctionCommandProvider)
 		if !ok {

--- a/states/binlog.go
+++ b/states/binlog.go
@@ -3,20 +3,19 @@ package states
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	binlogv1 "github.com/milvus-io/birdwatcher/storage/binlog/v1"
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 )
 
 // ScanBinlogs scans provided segment with delete record excluded.
-func (s *InstanceState) ScanBinlogs(ctx context.Context, minioClient *minio.Client, bucketName string, rootPath string, collection *models.Collection, segment *models.Segment,
+func (s *InstanceState) ScanBinlogs(ctx context.Context, store oss.ObjectStore, rootPath string, collection *models.Collection, segment *models.Segment,
 	selectField func(fieldID int64) bool, fn func(map[int64]*binlogv1.BinlogReader),
 ) {
 	pkField, has := lo.Find(collection.GetProto().Schema.Fields, func(field *schemapb.FieldSchema) bool {
@@ -40,8 +39,8 @@ func (s *InstanceState) ScanBinlogs(ctx context.Context, minioClient *minio.Clie
 				continue
 			}
 			binlog := fieldBinlog.Binlogs[idx]
-			filePath := strings.ReplaceAll(binlog.LogPath, "ROOT_PATH", rootPath)
-			object, err := minioClient.GetObject(ctx, bucketName, filePath, minio.GetObjectOptions{})
+			filePath := oss.ResolveObjectKey(rootPath, binlog.LogPath)
+			object, err := store.Open(ctx, filePath)
 			if err != nil {
 				fmt.Println(err.Error())
 				return

--- a/states/check_partition_key.go
+++ b/states/check_partition_key.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/gosuri/uilive"
-	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/birdwatcher/framework"
@@ -48,18 +47,18 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 		return err
 	}
 
-	var minioClient *minio.Client
-	var bucketName, rootPath string
+	var rootPath string
 
 	params := []oss.MinioConnectParam{}
 	if p.MinioAddress != "" {
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, rootPath, err = s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return err
 	}
+	rootPath = resolvedStore.RootPath
 
 	type suspectCollection struct {
 		collection   *models.Collection
@@ -177,12 +176,12 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 					}
 					pqWriter = binlogv1.NewParquetWriter(susCol.collection)
 				}
-				deltalog, err := s.DownloadDeltalogs(ctx, minioClient, bucketName, rootPath, susCol.collection, segment)
+				deltalog, err := s.DownloadDeltalogs(ctx, resolvedStore.Store, rootPath, susCol.collection, segment)
 				if err != nil {
 					return err
 				}
 
-				s.ScanBinlogs(ctx, minioClient, bucketName, rootPath, susCol.collection, segment, selector, func(readers map[int64]*binlogv1.BinlogReader) {
+				s.ScanBinlogs(ctx, resolvedStore.Store, rootPath, susCol.collection, segment, selector, func(readers map[int64]*binlogv1.BinlogReader) {
 					targetIndex := partIdx[segment.PartitionID]
 					iter, err := NewBinlogIterator(susCol.collection, readers)
 					if err != nil {
@@ -283,7 +282,7 @@ func (s *InstanceState) CheckPartitionKeyCommand(ctx context.Context, p *CheckPa
 	return nil
 }
 
-func (s *InstanceState) DownloadDeltalogs(ctx context.Context, client *minio.Client, bucket, rootPath string, collection *models.Collection, segment *models.Segment) (*storage.DeltaData, error) {
+func (s *InstanceState) DownloadDeltalogs(ctx context.Context, store oss.ObjectStore, rootPath string, collection *models.Collection, segment *models.Segment) (*storage.DeltaData, error) {
 	pkField, has := lo.Find(collection.GetProto().Schema.Fields, func(field *schemapb.FieldSchema) bool {
 		return field.IsPrimaryKey
 	})
@@ -293,8 +292,8 @@ func (s *InstanceState) DownloadDeltalogs(ctx context.Context, client *minio.Cli
 	data := storage.NewDeltaData(pkField.DataType, 0)
 	for _, delFieldBinlog := range segment.GetDeltalogs() {
 		for _, binlog := range delFieldBinlog.Binlogs {
-			filePath := strings.ReplaceAll(binlog.LogPath, "ROOT_PATH", rootPath)
-			result, err := client.GetObject(ctx, bucket, filePath, minio.GetObjectOptions{})
+			filePath := oss.ResolveObjectKey(rootPath, binlog.LogPath)
+			result, err := store.Open(ctx, filePath)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue

--- a/states/download_pk.go
+++ b/states/download_pk.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -51,19 +50,15 @@ func (s *InstanceState) DownloadPKCommand(ctx context.Context, p *DownloadPKPara
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return err
 	}
 
-	return s.downloadPKs(ctx, minioClient, bucketName, rootPath, p.CollectionID, pkField.FieldID, segments, s.writeLogfile)
+	return s.downloadPKs(ctx, resolvedStore.Store, resolvedStore.RootPath, p.CollectionID, pkField.FieldID, segments)
 }
 
-func (s *InstanceState) writeLogfile(ctx context.Context, obj *minio.Object) error {
-	return nil
-}
-
-func (s *InstanceState) downloadPKs(ctx context.Context, cli *minio.Client, bucketName, rootPath string, collID int64, pkID int64, segments []*models.Segment, handler func(context.Context, *minio.Object) error) error {
+func (s *InstanceState) downloadPKs(ctx context.Context, store oss.ObjectStore, rootPath string, collID int64, pkID int64, segments []*models.Segment) error {
 	folder := fmt.Sprintf("dlpks_%s", time.Now().Format("20060102150406"))
 	err := os.Mkdir(folder, 0o777)
 	if err != nil {
@@ -86,10 +81,10 @@ func (s *InstanceState) downloadPKs(ctx context.Context, cli *minio.Client, buck
 			}
 
 			for _, binlog := range fieldBinlog.Binlogs {
-				logPath := strings.ReplaceAll(binlog.LogPath, "ROOT_PATH", rootPath)
-				obj, err := cli.GetObject(ctx, bucketName, logPath, minio.GetObjectOptions{})
+				logPath := oss.ResolveObjectKey(rootPath, binlog.LogPath)
+				obj, err := store.Open(ctx, logPath)
 				if err != nil {
-					fmt.Println("failed to download file", bucketName, logPath)
+					fmt.Println("failed to download file", logPath)
 					return err
 				}
 

--- a/states/download_segment.go
+++ b/states/download_segment.go
@@ -38,14 +38,14 @@ func (s *InstanceState) DownloadSegmentCommand(ctx context.Context, p *DownloadS
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, _, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return err
 	}
 
 	folder := fmt.Sprintf("dlsegment_%s", time.Now().Format("20060102150406"))
 	for _, segment := range segments {
-		err := downloadSegment(ctx, minioClient, bucketName, segment, folder)
+		err := downloadSegment(ctx, resolvedStore.Store, resolvedStore.RootPath, segment, folder)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func (s *InstanceState) DownloadSegmentCommand(ctx context.Context, p *DownloadS
 	return nil
 }
 
-func downloadSegment(ctx context.Context, minioClient *minio.Client, bucketName string, segment *models.Segment, folderPath string) error {
+func downloadSegment(ctx context.Context, store oss.ObjectStore, rootPath string, segment *models.Segment, folderPath string) error {
 	p := path.Join(folderPath, fmt.Sprintf("%d", segment.ID))
 	if _, err := os.Stat(p); errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(p, os.ModePerm)
@@ -75,13 +75,14 @@ func downloadSegment(ctx context.Context, minioClient *minio.Client, bucketName 
 		}
 
 		for _, binlog := range fieldBinlog.Binlogs {
-			obj, err := minioClient.GetObject(ctx, bucketName, binlog.LogPath, minio.GetObjectOptions{})
+			logPath := oss.ResolveObjectKey(rootPath, binlog.LogPath)
+			obj, err := store.Open(ctx, logPath)
 			if err != nil {
-				fmt.Printf("failed to download file bucket=\"%s\", filePath = \"%s\", err: %s\n", bucketName, binlog.LogPath, err.Error())
+				fmt.Printf("failed to download file filePath = \"%s\", err: %s\n", logPath, err.Error())
 				return err
 			}
 
-			name := path.Base(binlog.LogPath)
+			name := path.Base(logPath)
 
 			f, err := os.Create(path.Join(folder, name))
 			if err != nil {

--- a/states/etcd/show/json_stats.go
+++ b/states/etcd/show/json_stats.go
@@ -10,10 +10,10 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/minio/minio-go/v7"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/birdwatcher/states/ossutil"
 )
@@ -55,17 +55,14 @@ func (c *ComponentShow) JSONStatsCommand(ctx context.Context, p *JSONStatsParam)
 	var notBuiltSegIDs []int64
 
 	var (
-		mclient    *minio.Client
-		bucketName string
-		rootPath   string
-		ossReady   bool
+		store    oss.ObjectStore
+		rootPath string
+		ossReady bool
 	)
 
 	for _, seg := range segments {
-		// only segments matching the high-level filters are considered
 		total++
 
-		// determine built status according to field filter
 		builtForSegment := false
 		if p.FieldID != 0 {
 			if seg.JsonKeyStats != nil {
@@ -73,10 +70,8 @@ func (c *ComponentShow) JSONStatsCommand(ctx context.Context, p *JSONStatsParam)
 					builtForSegment = true
 				}
 			}
-		} else {
-			if len(seg.JsonKeyStats) > 0 {
-				builtForSegment = true
-			}
+		} else if len(seg.JsonKeyStats) > 0 {
+			builtForSegment = true
 		}
 
 		if !builtForSegment {
@@ -85,7 +80,6 @@ func (c *ComponentShow) JSONStatsCommand(ctx context.Context, p *JSONStatsParam)
 		}
 
 		built++
-
 		printedHeader := false
 		for fieldID, keyStats := range seg.JsonKeyStats {
 			if p.FieldID != 0 && p.FieldID != fieldID {
@@ -95,66 +89,57 @@ func (c *ComponentShow) JSONStatsCommand(ctx context.Context, p *JSONStatsParam)
 				fmt.Printf("Segment %d (Collection %d, Partition %d) JsonKeyStats:\n", seg.ID, seg.CollectionID, seg.PartitionID)
 				printedHeader = true
 			}
-			if p.Detail {
-				fmt.Printf("  field[%d]: version=%d files=%d mem=%d build=%d format=%d\n",
-					fieldID,
-					keyStats.GetVersion(),
-					len(keyStats.GetFiles()),
-					keyStats.GetMemorySize(),
-					keyStats.GetBuildID(),
-					keyStats.GetJsonKeyStatsDataFormat(),
-				)
-				shreddingPath := fmt.Sprintf("ROOT_PATH/json_stats/%d/%d/%d/%d/%d/%d/%d/shredding_data/0/0",
-					keyStats.GetJsonKeyStatsDataFormat(),
-					keyStats.GetBuildID(),
-					keyStats.GetVersion(),
-					seg.CollectionID,
-					seg.PartitionID,
-					seg.ID,
-					fieldID)
-				if !ossReady {
-					cli, bucket, root, err := ossutil.GetMinioClientFromCfg(ctx, c.client, c.metaPath)
-					if err != nil {
-						fmt.Printf("      [s3] skip reading (init error): %s\n", err.Error())
-					} else {
-						mclient, bucketName, rootPath = cli, bucket, root
-						ossReady = true
-					}
+
+			fmt.Printf("  field[%d]: version=%d files=%d mem=%d build=%d format=%d\n",
+				fieldID,
+				keyStats.GetVersion(),
+				len(keyStats.GetFiles()),
+				keyStats.GetMemorySize(),
+				keyStats.GetBuildID(),
+				keyStats.GetJsonKeyStatsDataFormat(),
+			)
+			if !p.Detail {
+				continue
+			}
+
+			shreddingPath := fmt.Sprintf("ROOT_PATH/json_stats/%d/%d/%d/%d/%d/%d/%d/shredding_data/0/0",
+				keyStats.GetJsonKeyStatsDataFormat(),
+				keyStats.GetBuildID(),
+				keyStats.GetVersion(),
+				seg.CollectionID,
+				seg.PartitionID,
+				seg.ID,
+				fieldID)
+			if !ossReady {
+				resolvedStore, err := ossutil.GetObjectStoreFromCfg(ctx, c.client, c.metaPath)
+				if err != nil {
+					fmt.Printf("      [s3] skip reading (init error): %s\n", err.Error())
+				} else {
+					store, rootPath = resolvedStore.Store, resolvedStore.RootPath
+					ossReady = true
 				}
-				if ossReady {
-					objKey := strings.ReplaceAll(shreddingPath, "ROOT_PATH", rootPath)
-					// Try reading meta.json first (new format)
-					// meta.json path: ROOT_PATH/json_stats/%d/%d/%d/%d/%d/%d/%d/meta.json
-					metaPath := fmt.Sprintf("ROOT_PATH/json_stats/%d/%d/%d/%d/%d/%d/%d/meta.json",
-						keyStats.GetJsonKeyStatsDataFormat(),
-						keyStats.GetBuildID(),
-						keyStats.GetVersion(),
-						seg.CollectionID,
-						seg.PartitionID,
-						seg.ID,
-						fieldID)
-					metaKey := strings.ReplaceAll(metaPath, "ROOT_PATH", rootPath)
-					if !readJSONMeta(ctx, mclient, bucketName, metaKey, p) {
-						// parquet footer summary
-						readParquetFooterSummary(ctx, mclient, bucketName, objKey)
-						// Fall back to reading from parquet metadata (old format)
-						readParquetMeta(ctx, mclient, bucketName, objKey, p)
-					}
-				}
-			} else {
-				fmt.Printf("  field[%d]: version=%d files=%d mem=%d build=%d format=%d\n",
-					fieldID,
-					keyStats.GetVersion(),
-					len(keyStats.GetFiles()),
-					keyStats.GetMemorySize(),
-					keyStats.GetBuildID(),
-					keyStats.GetJsonKeyStatsDataFormat(),
-				)
+			}
+			if !ossReady {
+				continue
+			}
+
+			objKey := oss.ResolveObjectKey(rootPath, shreddingPath)
+			metaPath := fmt.Sprintf("ROOT_PATH/json_stats/%d/%d/%d/%d/%d/%d/%d/meta.json",
+				keyStats.GetJsonKeyStatsDataFormat(),
+				keyStats.GetBuildID(),
+				keyStats.GetVersion(),
+				seg.CollectionID,
+				seg.PartitionID,
+				seg.ID,
+				fieldID)
+			metaKey := oss.ResolveObjectKey(rootPath, metaPath)
+			if !readJSONMeta(ctx, store, metaKey, p) {
+				readParquetFooterSummary(ctx, store, objKey)
+				readParquetMeta(ctx, store, objKey, p)
 			}
 		}
 	}
 
-	// summary
 	if total > 0 {
 		percent := float64(built) * 100.0 / float64(total)
 		fmt.Printf("\n--- JsonKeyStats built: %d/%d (%.2f%%)\n", built, total, percent)
@@ -167,45 +152,30 @@ func (c *ComponentShow) JSONStatsCommand(ctx context.Context, p *JSONStatsParam)
 }
 
 // readParquetFooterSummary reads last 8 bytes of parquet to show metadata length and magic
-func readParquetFooterSummary(ctx context.Context, client *minio.Client, bucket, key string) {
-	// Try stat on the exact key first
-	stat, err := client.StatObject(ctx, bucket, key, minio.StatObjectOptions{})
-	if err != nil || stat.Size < 8 {
-		// Treat as prefix, list first object under it
-		prefix := key
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
-		ch := client.ListObjects(ctx, bucket, minio.ListObjectsOptions{Prefix: prefix, Recursive: true})
-		objInfo, ok := <-ch
-		if !ok || objInfo.Err != nil {
-			fmt.Printf("      [parquet] stat failed: %v, key=%s\n", err, key)
-			return
-		}
-		key = objInfo.Key
-		stat.Size = objInfo.Size
-		fmt.Printf("      [parquet] using first object under prefix: %s\n", key)
-		if stat.Size < 8 {
-			fmt.Printf("      [parquet] file too small for footer, size=%d, key=%s\n", stat.Size, key)
-			return
-		}
+func readParquetFooterSummary(ctx context.Context, store oss.ObjectStore, key string) {
+	key, size, err := resolveParquetKey(ctx, store, key)
+	if err != nil {
+		fmt.Printf("      [parquet] stat failed: %v, key=%s\n", err, key)
+		return
 	}
-	// read last 8 bytes: <metadata_len uint32 little-endian><'PAR1'>
-	opts := minio.GetObjectOptions{}
-	opts.SetRange(stat.Size-8, stat.Size-1)
-	obj, err := client.GetObject(ctx, bucket, key, opts)
+	if size < 8 {
+		fmt.Printf("      [parquet] file too small for footer, size=%d, key=%s\n", size, key)
+		return
+	}
+	obj, err := store.Open(ctx, key, oss.WithOpenRange(size-8, size-1))
 	if err != nil {
 		fmt.Printf("      [parquet] read footer failed: %s, key=%s\n", err.Error(), key)
 		return
 	}
-	defer obj.Close()
+	if closer, ok := obj.(io.Closer); ok {
+		defer closer.Close()
+	}
 	buf := make([]byte, 8)
 	n, err := io.ReadFull(obj, buf)
 	if n != 8 {
 		fmt.Printf("      [parquet] read footer bytes failed: %v, n=%d, key=%s\n", err, n, key)
 		return
 	}
-	// io.ReadFull returns EOF when exactly filled; accept it
 	magic := string(buf[4:8])
 	metaLen := uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16 | uint32(buf[3])<<24
 	fmt.Printf("      [parquet] footer: meta_len=%d magic=%s, key=%s\n", metaLen, magic, key)
@@ -220,12 +190,14 @@ type jsonStatsMeta struct {
 }
 
 // readJSONMeta reads the meta.json file from S3 and prints layout information
-func readJSONMeta(ctx context.Context, client *minio.Client, bucket, metaKey string, p *JSONStatsParam) bool {
-	obj, err := client.GetObject(ctx, bucket, metaKey, minio.GetObjectOptions{})
+func readJSONMeta(ctx context.Context, store oss.ObjectStore, metaKey string, p *JSONStatsParam) bool {
+	obj, err := store.Open(ctx, metaKey)
 	if err != nil {
 		return false
 	}
-	defer obj.Close()
+	if closer, ok := obj.(io.Closer); ok {
+		defer closer.Close()
+	}
 
 	data, err := io.ReadAll(obj)
 	if err != nil {
@@ -252,7 +224,6 @@ func readJSONMeta(ctx context.Context, client *minio.Client, bucket, metaKey str
 func printLayoutTypeMap(mm map[string]string, p *JSONStatsParam) {
 	var nonSharedKeys []string
 	sharedCount := 0
-	// separate shared and non-shared keys
 	for k, val := range mm {
 		if p.KeyPrefix != "" && !strings.HasPrefix(k, p.KeyPrefix) {
 			continue
@@ -264,7 +235,6 @@ func printLayoutTypeMap(mm map[string]string, p *JSONStatsParam) {
 		}
 	}
 
-	// print shared keys if enabled
 	if p.PrintShared {
 		fmt.Printf("        shared keys: ")
 		first := true
@@ -286,7 +256,6 @@ func printLayoutTypeMap(mm map[string]string, p *JSONStatsParam) {
 			fmt.Println("(none)")
 		}
 	}
-	// print non-shared keys in one line
 	if len(nonSharedKeys) > 0 {
 		fmt.Printf("        non-shared keys: %s\n", strings.Join(nonSharedKeys, ", "))
 	}
@@ -295,11 +264,14 @@ func printLayoutTypeMap(mm map[string]string, p *JSONStatsParam) {
 		sharedCount, len(nonSharedKeys), totalCount)
 }
 
-func readParquetMeta(ctx context.Context, client *minio.Client, bucket, key string, p *JSONStatsParam) {
-	obj, err := client.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
+func readParquetMeta(ctx context.Context, store oss.ObjectStore, key string, p *JSONStatsParam) {
+	obj, err := store.Open(ctx, key)
 	if err != nil {
 		fmt.Printf("      [parquet] get object failed: %s, key=%s\n", err.Error(), key)
 		return
+	}
+	if closer, ok := obj.(io.Closer); ok {
+		defer closer.Close()
 	}
 	pqReader, err := file.NewParquetReader(obj)
 	if err != nil {
@@ -309,11 +281,10 @@ func readParquetMeta(ctx context.Context, client *minio.Client, bucket, key stri
 
 	arrReader, err := pqarrow.NewFileReader(pqReader, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
 	if err != nil {
-		fmt.Printf("      [parquet] open pq	 file reader failed: %s, key=%s\n", err.Error(), key)
+		fmt.Printf("      [parquet] open pq\t file reader failed: %s, key=%s\n", err.Error(), key)
 		return
 	}
 
-	// Print schema elements
 	if p.ShowSchema {
 		schema, err := arrReader.Schema()
 		if err != nil {
@@ -329,18 +300,14 @@ func readParquetMeta(ctx context.Context, client *minio.Client, bucket, key stri
 	}
 
 	kvMetaData := pqReader.MetaData().KeyValueMetadata()
-
-	// Print all metadata keys and values (except key_layout_type_map which is handled separately)
 	if kvMetaData != nil && kvMetaData.Len() > 0 {
 		fmt.Printf("      [parquet] metadata entries: %d\n", kvMetaData.Len())
 		for i := 0; i < kvMetaData.Len(); i++ {
 			key := kvMetaData.Keys()[i]
 			val := kvMetaData.Values()[i]
-			// Skip key_layout_type_map as it's processed separately below
 			if key == "key_layout_type_map" {
 				continue
 			}
-			// Special handling: row_group_metadata -> count groups by ';'
 			if key == "row_group_metadata" {
 				parts := strings.Split(val, ";")
 				cnt := 0
@@ -365,4 +332,31 @@ func readParquetMeta(ctx context.Context, client *minio.Client, bucket, key stri
 		}
 		printLayoutTypeMap(mm, p)
 	}
+}
+
+func resolveParquetKey(ctx context.Context, store oss.ObjectStore, key string) (string, int64, error) {
+	stat, err := store.Stat(ctx, key)
+	if err == nil {
+		return key, stat.Size, nil
+	}
+
+	prefix := key
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	ch, listErr := store.List(ctx, prefix, true)
+	if listErr != nil {
+		return key, 0, err
+	}
+	for objInfo := range ch {
+		if objInfo.Err != nil {
+			return key, 0, objInfo.Err
+		}
+		if objInfo.IsDir {
+			continue
+		}
+		fmt.Printf("      [parquet] using first object under prefix: %s\n", objInfo.Key)
+		return objInfo.Key, objInfo.Size, nil
+	}
+	return key, 0, err
 }

--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -65,7 +65,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 	}
 
 	cli := kv.NewTiKV(tikvCli)
-	kvState := getKVConnectedState(app.core, cli, cp.TiKVAddr, app.config, app.extensions)
+	kvState := getKVConnectedState(app.core, cli, cp.TiKVAddr, app.config, app.extensions, app.objectStoreProvider)
 	if !cp.Dry {
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
@@ -86,7 +86,7 @@ func (app *ApplicationState) connectTiKV(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(tikvTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
+		app.SetTagNext(tikvTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions, app.objectStoreProvider))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to metastore connected state
@@ -157,7 +157,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 	}
 
 	cli := kv.NewEtcdKV(etcdCli)
-	kvState := getKVConnectedState(app.core, cli, cp.EtcdAddr, app.config, app.extensions)
+	kvState := getKVConnectedState(app.core, cli, cp.EtcdAddr, app.config, app.extensions, app.objectStoreProvider)
 	if !cp.Dry {
 		// ping etcd
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
@@ -173,7 +173,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 		fmt.Fprintln(os.Stderr, "Using meta path:", fmt.Sprintf("%s/%s/", cp.RootPath, metaPath))
 
 		// use rootPath as instanceName
-		app.SetTagNext(etcdTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions))
+		app.SetTagNext(etcdTag, GetInstanceState(app.core, cli, cp.RootPath, cp.MetaPath, kvState, app.config, app.extensions, app.objectStoreProvider))
 	} else {
 		fmt.Fprintln(os.Stderr, "using dry mode, ignore rootPath and metaPath")
 		// rootPath empty fall back to etcd connected state
@@ -261,11 +261,12 @@ func (app *ApplicationState) getTLSConfig(cp *ConnectParams) (*tls.Config, error
 
 type kvConnectedState struct {
 	*framework.CmdState
-	client     kv.MetaKV
-	addr       string
-	candidates []string
-	config     *configs.Config
-	extensions []Extension
+	client              kv.MetaKV
+	addr                string
+	candidates          []string
+	config              *configs.Config
+	extensions          []Extension
+	objectStoreProvider ObjectStoreProvider
 }
 
 // SetupCommands setups the command.
@@ -277,20 +278,21 @@ func (s *kvConnectedState) SetupCommands() {
 }
 
 // GetKVConnectedState returns kvConnectedState for unknown instance
-func GetKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
+func GetKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension, objectStoreProvider ObjectStoreProvider) framework.State {
 	state := &kvConnectedState{
-		CmdState:   parent.Spawn(fmt.Sprintf("MetaStore(%s)", addr)),
-		client:     cli,
-		addr:       addr,
-		config:     config,
-		extensions: extensions,
+		CmdState:            parent.Spawn(fmt.Sprintf("MetaStore(%s)", addr)),
+		client:              cli,
+		addr:                addr,
+		config:              config,
+		extensions:          extensions,
+		objectStoreProvider: objectStoreProvider,
 	}
 
 	return state
 }
 
-func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension) framework.State {
-	return GetKVConnectedState(parent, cli, addr, config, extensions)
+func getKVConnectedState(parent *framework.CmdState, cli kv.MetaKV, addr string, config *configs.Config, extensions []Extension, objectStoreProvider ObjectStoreProvider) framework.State {
+	return GetKVConnectedState(parent, cli, addr, config, extensions, objectStoreProvider)
 }
 
 type FindMilvusParam struct {
@@ -341,7 +343,7 @@ func (s *kvConnectedState) UseCommand(ctx context.Context, p *UseParam) error {
 
 	fmt.Fprintf(os.Stderr, "Using meta path: %s/%s/\n", p.instanceName, p.MetaPath)
 
-	s.SetNext(etcdTag, GetInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config, s.extensions))
+	s.SetNext(etcdTag, GetInstanceState(s.CmdState, s.client, p.instanceName, p.MetaPath, s, s.config, s.extensions, nil))
 	return nil
 }
 

--- a/states/etcd_connect_export_test.go
+++ b/states/etcd_connect_export_test.go
@@ -15,7 +15,7 @@ func TestGetKVConnectedStateReturnsMetastoreState(t *testing.T) {
 	core := framework.NewCmdState("[core]", config)
 	client := metakv.NewFileAuditKV(nil, nil)
 
-	state := GetKVConnectedState(core, client, "scout:2379", config, nil)
+	state := GetKVConnectedState(core, client, "scout:2379", config, nil, nil)
 	require.NotNil(t, state)
 	require.Contains(t, state.Label(), "MetaStore(scout:2379)")
 }

--- a/states/extensions.go
+++ b/states/extensions.go
@@ -1,10 +1,13 @@
 package states
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	"github.com/milvus-io/birdwatcher/configs"
 	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/kv"
 )
 
@@ -45,4 +48,35 @@ type InstanceCobraCommandProvider interface {
 
 type InstanceFunctionCommandProvider interface {
 	InstanceFunctionCommands(ctx InstanceContext) []any
+}
+
+type ObjectStoreProvider interface {
+	GetObjectStore(ctx context.Context, instanceCtx InstanceContext, params ...oss.MinioConnectParam) (*oss.ResolvedObjectStore, error)
+}
+
+type ObjectStoreProviderExtension interface {
+	ObjectStoreProvider() ObjectStoreProvider
+}
+
+func WithObjectStoreProvider(provider ObjectStoreProvider) Option {
+	return func(app *ApplicationState) {
+		app.objectStoreProvider = provider
+	}
+}
+
+func resolveObjectStoreProvider(existing ObjectStoreProvider, exts []Extension) ObjectStoreProvider {
+	if existing != nil {
+		return existing
+	}
+	for _, ext := range exts {
+		provider, ok := ext.(ObjectStoreProviderExtension)
+		if !ok {
+			continue
+		}
+		resolved := provider.ObjectStoreProvider()
+		if resolved != nil {
+			return resolved
+		}
+	}
+	return nil
 }

--- a/states/garbage_collect.go
+++ b/states/garbage_collect.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/manifoldco/promptui"
-	"github.com/minio/minio-go/v7"
 	"github.com/spf13/cobra"
 
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/birdwatcher/states/kv"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -52,7 +52,7 @@ func getGarbageCollectCmd(cli kv.MetaKV, basePath string) *cobra.Command {
 				fmt.Printf("bucket %s not exists\n", bucketName)
 				return
 			}
-			garbageCollect(cli, basePath, minioClient, minioRootPath, bucketName)
+			garbageCollect(cli, basePath, oss.NewMinioObjectStoreWithBucket(minioClient, bucketName), minioRootPath)
 		},
 	}
 
@@ -66,7 +66,7 @@ const (
 	deltaLogPrefix  = `delta_log`
 )
 
-func garbageCollect(cli kv.MetaKV, basePath string, minioClient *minio.Client, minioRootPath string, bucketName string) {
+func garbageCollect(cli kv.MetaKV, basePath string, store oss.ObjectStore, minioRootPath string) {
 	segments, err := common.ListSegments(context.TODO(), cli, basePath, func(*models.Segment) bool { return true })
 	if err != nil {
 		fmt.Println("failed to list segments:", err.Error())
@@ -125,10 +125,16 @@ func garbageCollect(cli kv.MetaKV, basePath string, minioClient *minio.Client, m
 
 	counter := 0
 	for idx, prefix := range prefixes {
-		for info := range minioClient.ListObjects(context.TODO(), bucketName, minio.ListObjectsOptions{
-			Prefix:    prefix,
-			Recursive: true,
-		}) {
+		ch, err := store.List(context.TODO(), prefix, true)
+		if err != nil {
+			fmt.Fprintf(w, "failed to list prefix %q: %s\n", prefix, err.Error())
+			continue
+		}
+		for info := range ch {
+			if info.Err != nil {
+				fmt.Fprintf(w, "failed to list object under %q: %s\n", prefix, info.Err.Error())
+				continue
+			}
 			fmt.Println(info.Key)
 			counter++
 			fmt.Fprintf(w, "Processing path: \"%s\"", info.Key)

--- a/states/inspect_parquet.go
+++ b/states/inspect_parquet.go
@@ -133,16 +133,17 @@ func (s *InstanceState) inspectSegmentParquet(ctx context.Context, p *InspectPar
 	if p.MinioAddress != "" {
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
-	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return err
 	}
+	rootPath := resolvedStore.RootPath
 
 	if segment.GetStorageVersion() >= 3 {
 		if segment.GetManifestPath() == "" {
 			return errors.Newf("segment %d storage version is %d but got empty manifest", segment.GetID(), segment.GetStorageVersion())
 		}
-		return inspectV3SegmentParquet(ctx, minioClient, bucketName, rootPath, segment, p)
+		return inspectV3SegmentParquet(ctx, resolvedStore.Store, rootPath, segment, p)
 	}
 
 	for _, fieldBinlog := range segment.GetBinlogs() {
@@ -150,9 +151,9 @@ func (s *InstanceState) inspectSegmentParquet(ctx context.Context, p *InspectPar
 			continue
 		}
 		for _, binlog := range fieldBinlog.Binlogs {
-			logPath := strings.ReplaceAll(binlog.LogPath, "ROOT_PATH", rootPath)
+			logPath := oss.ResolveObjectKey(rootPath, binlog.LogPath)
 			fmt.Printf("\n===== Field %d | %s =====\n", fieldBinlog.FieldID, logPath)
-			if err := inspectRemoteBinlog(ctx, minioClient, bucketName, logPath, segment.StorageVersion, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
+			if err := inspectRemoteBinlog(ctx, resolvedStore.Store, logPath, segment.StorageVersion, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
 				fmt.Printf("failed to inspect %s: %s\n", logPath, err.Error())
 			}
 		}
@@ -178,6 +179,7 @@ func (s *InstanceState) inspectExternalCollectionParquet(ctx context.Context, p 
 	if err != nil {
 		return err
 	}
+	externalStore := oss.NewMinioObjectStoreWithBucket(externalMinioClient, externalBucketName)
 
 	fmt.Printf("External Collection %d: name=%s\n", proto.GetID(), proto.GetSchema().GetName())
 	fmt.Printf("External Source: %s\n", proto.GetSchema().GetExternalSource())
@@ -190,20 +192,20 @@ func (s *InstanceState) inspectExternalCollectionParquet(ctx context.Context, p 
 		}
 		fmt.Printf("Mode: external-file\n")
 		fmt.Printf("Object: %s\n", objectKey)
-		return inspectRemoteParquetObject(ctx, externalMinioClient, externalBucketName, objectKey, p.MetadataOnly, p.SampleRows, p.ShowRowGroups)
+		return inspectRemoteParquetObject(ctx, externalStore, objectKey, p.MetadataOnly, p.SampleRows, p.ShowRowGroups)
 	}
 
-	manifestMinioClient, manifestBucketName, manifestRootPath, err := s.GetMinioClientFromCfg(ctx, oss.WithSkipCheckBucket(p.SkipBucketCheck))
+	manifestStore, err := s.GetObjectStore(ctx, oss.WithSkipCheckBucket(p.SkipBucketCheck))
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Mode: manifest-segment\n")
-	fmt.Printf("Manifest Storage: bucket=%s rootPath=%s\n", manifestBucketName, manifestRootPath)
-	return s.inspectExternalManifestSegmentParquet(ctx, manifestMinioClient, manifestBucketName, manifestRootPath, externalMinioClient, externalBucketName, externalRootPath, location, collection, p)
+	fmt.Printf("Manifest Storage: bucket=%s rootPath=%s\n", manifestStore.BucketName, manifestStore.RootPath)
+	return s.inspectExternalManifestSegmentParquet(ctx, manifestStore.Store, manifestStore.RootPath, externalStore, location, collection, p)
 }
 
-func (s *InstanceState) inspectExternalManifestSegmentParquet(ctx context.Context, manifestMinioClient *minio.Client, manifestBucketName, manifestRootPath string, externalMinioClient *minio.Client, externalBucketName, externalRootPath string, location externalSourceLocation, collection *models.Collection, p *InspectParquetParam) error {
+func (s *InstanceState) inspectExternalManifestSegmentParquet(ctx context.Context, manifestStore oss.ObjectStore, manifestRootPath string, externalStore oss.ObjectStore, location externalSourceLocation, collection *models.Collection, p *InspectParquetParam) error {
 	segments, err := common.ListSegments(ctx, s.client, s.basePath, func(seg *models.Segment) bool {
 		return seg.ID == p.ManifestSegmentID
 	})
@@ -222,11 +224,10 @@ func (s *InstanceState) inspectExternalManifestSegmentParquet(ctx context.Contex
 	}
 
 	fmt.Printf("Manifest Segment: %d\n", segment.GetID())
-	return inspectExternalManifestParquet(ctx, manifestMinioClient, manifestBucketName, manifestRootPath, externalMinioClient, externalBucketName, externalRootPath, location, segment, p)
+	return inspectExternalManifestParquet(ctx, manifestStore, manifestRootPath, externalStore, location, segment, p)
 }
 
-func inspectExternalManifestParquet(ctx context.Context, manifestMinioClient *minio.Client, manifestBucketName, manifestRootPath string, externalMinioClient *minio.Client, externalBucketName, externalRootPath string, location externalSourceLocation, segment *models.Segment, p *InspectParquetParam) error {
-	_ = externalRootPath
+func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.ObjectStore, manifestRootPath string, externalStore oss.ObjectStore, location externalSourceLocation, segment *models.Segment, p *InspectParquetParam) error {
 	rawManifest := segment.GetManifestPath()
 	fmt.Printf("Manifest Raw: %s\n", rawManifest)
 
@@ -238,16 +239,15 @@ func inspectExternalManifestParquet(ctx context.Context, manifestMinioClient *mi
 		return errors.Wrap(err, "parse manifest path JSON")
 	}
 
-	manifestBasePath := strings.ReplaceAll(manifestRef.BasePath, "ROOT_PATH", manifestRootPath)
+	manifestBasePath := oss.ResolveObjectKey(manifestRootPath, manifestRef.BasePath)
 	manifestPath := path.Join(manifestBasePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
 	fmt.Printf("Manifest File: %s\n", manifestPath)
 
-	obj, err := manifestMinioClient.GetObject(ctx, manifestBucketName, manifestPath, minio.GetObjectOptions{})
+	obj, err := manifestStore.Open(ctx, manifestPath)
 	if err != nil {
 		return errors.Wrap(err, "get manifest object")
 	}
 	m, err := parseManifest(obj)
-	obj.Close()
 	if err != nil {
 		return errors.Wrap(err, "parse manifest")
 	}
@@ -269,7 +269,7 @@ func inspectExternalManifestParquet(ctx context.Context, manifestMinioClient *mi
 				continue
 			}
 			fmt.Printf("\n----- File %s (rows: [%d, %d)) -----\n", filePath, f.StartIndex, f.EndIndex)
-			if err := inspectRemoteParquetObject(ctx, externalMinioClient, externalBucketName, filePath, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
+			if err := inspectRemoteParquetObject(ctx, externalStore, filePath, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
 				fmt.Printf("failed to inspect %s: %s\n", filePath, err.Error())
 			}
 		}
@@ -308,7 +308,7 @@ func resolveExternalManifestObjectKey(location externalSourceLocation, manifestB
 	return path.Join(location.RootPath, trimmed), nil
 }
 
-func inspectV3SegmentParquet(ctx context.Context, minioClient *minio.Client, bucketName, rootPath string, segment *models.Segment, p *InspectParquetParam) error {
+func inspectV3SegmentParquet(ctx context.Context, store oss.ObjectStore, rootPath string, segment *models.Segment, p *InspectParquetParam) error {
 	rawManifest := segment.GetManifestPath()
 	fmt.Printf("Manifest Raw: %s\n", rawManifest)
 
@@ -320,16 +320,15 @@ func inspectV3SegmentParquet(ctx context.Context, minioClient *minio.Client, buc
 		return errors.Wrap(err, "parse manifest path JSON")
 	}
 
-	basePath := strings.ReplaceAll(manifestRef.BasePath, "ROOT_PATH", rootPath)
+	basePath := oss.ResolveObjectKey(rootPath, manifestRef.BasePath)
 	manifestPath := path.Join(basePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
 	fmt.Printf("Manifest File: %s\n", manifestPath)
 
-	obj, err := minioClient.GetObject(ctx, bucketName, manifestPath, minio.GetObjectOptions{})
+	obj, err := store.Open(ctx, manifestPath)
 	if err != nil {
 		return errors.Wrap(err, "get manifest object")
 	}
 	m, err := parseManifest(obj)
-	obj.Close()
 	if err != nil {
 		return errors.Wrap(err, "parse manifest")
 	}
@@ -345,9 +344,9 @@ func inspectV3SegmentParquet(ctx context.Context, minioClient *minio.Client, buc
 		}
 		fmt.Printf("\n===== Column Group #%d | columns=%v format=%s =====\n", i, cg.Columns, cg.Format)
 		for _, f := range cg.Files {
-			filePath := path.Join(basePath, "_data", strings.ReplaceAll(f.Path, "ROOT_PATH", rootPath))
+			filePath := path.Join(basePath, "_data", oss.ResolveObjectKey(rootPath, f.Path))
 			fmt.Printf("\n----- File %s (rows: [%d, %d)) -----\n", filePath, f.StartIndex, f.EndIndex)
-			if err := inspectRemoteBinlog(ctx, minioClient, bucketName, filePath, 2, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
+			if err := inspectRemoteBinlog(ctx, store, filePath, 2, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
 				fmt.Printf("failed to inspect %s: %s\n", filePath, err.Error())
 			}
 		}
@@ -355,12 +354,14 @@ func inspectV3SegmentParquet(ctx context.Context, minioClient *minio.Client, buc
 	return nil
 }
 
-func inspectRemoteParquetObject(ctx context.Context, minioClient *minio.Client, bucketName, objectKey string, metadataOnly bool, sampleRows int64, showRowGroups bool) error {
-	obj, err := minioClient.GetObject(ctx, bucketName, objectKey, minio.GetObjectOptions{})
+func inspectRemoteParquetObject(ctx context.Context, store oss.ObjectStore, objectKey string, metadataOnly bool, sampleRows int64, showRowGroups bool) error {
+	obj, err := store.Open(ctx, objectKey)
 	if err != nil {
 		return err
 	}
-	defer obj.Close()
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
 
 	pqReader, err := file.NewParquetReader(obj)
 	if err != nil {
@@ -371,12 +372,11 @@ func inspectRemoteParquetObject(ctx context.Context, minioClient *minio.Client, 
 	return printParquetFile(ctx, pqReader, path.Base(objectKey), metadataOnly, sampleRows, showRowGroups)
 }
 
-func inspectRemoteBinlog(ctx context.Context, minioClient *minio.Client, bucketName, logPath string, storageVersion int64, metadataOnly bool, sampleRows int64, showRowGroups bool) error {
-	obj, err := minioClient.GetObject(ctx, bucketName, logPath, minio.GetObjectOptions{})
+func inspectRemoteBinlog(ctx context.Context, store oss.ObjectStore, logPath string, storageVersion int64, metadataOnly bool, sampleRows int64, showRowGroups bool) error {
+	obj, err := store.Open(ctx, logPath)
 	if err != nil {
 		return err
 	}
-	defer obj.Close()
 
 	pqReader, err := openBinlogParquet(obj, storageVersion)
 	if err != nil {

--- a/states/instance.go
+++ b/states/instance.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/milvus-io/birdwatcher/configs"
 	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd"
 	"github.com/milvus-io/birdwatcher/states/etcd/remove"
 	"github.com/milvus-io/birdwatcher/states/etcd/repair"
 	"github.com/milvus-io/birdwatcher/states/etcd/set"
 	"github.com/milvus-io/birdwatcher/states/etcd/show"
 	metakv "github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/birdwatcher/states/ossutil"
 )
 
 // InstanceState provides command for single milvus instance.
@@ -31,10 +33,11 @@ type InstanceState struct {
 	client       metakv.MetaKV
 	auditFile    *os.File
 
-	etcdState  framework.State
-	config     *configs.Config
-	basePath   string
-	extensions []Extension
+	etcdState           framework.State
+	config              *configs.Config
+	basePath            string
+	extensions          []Extension
+	objectStoreProvider ObjectStoreProvider
 }
 
 func (s *InstanceState) Close() {
@@ -145,7 +148,20 @@ func (s *InstanceState) DryModeCommand(ctx context.Context, p *DryModeParam) {
 	s.SetNext(etcdTag, s.etcdState)
 }
 
-func GetInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config, extensions []Extension) framework.State {
+func (s *InstanceState) GetObjectStore(ctx context.Context, params ...oss.MinioConnectParam) (*oss.ResolvedObjectStore, error) {
+	if s.objectStoreProvider != nil {
+		resolved, err := s.objectStoreProvider.GetObjectStore(ctx, s, params...)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != nil {
+			return resolved, nil
+		}
+	}
+	return ossutil.GetObjectStoreFromCfg(ctx, s.client, s.basePath, params...)
+}
+
+func GetInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceName, metaPath string, etcdState framework.State, config *configs.Config, extensions []Extension, objectStoreProvider ObjectStoreProvider) framework.State {
 	var kv metakv.MetaKV
 	name := fmt.Sprintf("audit_%s.log", time.Now().Format("2006_0102_150405"))
 	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -170,10 +186,11 @@ func GetInstanceState(parent *framework.CmdState, cli metakv.MetaKV, instanceNam
 		client:          kv,
 		auditFile:       file,
 
-		etcdState:  etcdState,
-		config:     config,
-		basePath:   basePath,
-		extensions: extensions,
+		etcdState:           etcdState,
+		config:              config,
+		basePath:            basePath,
+		extensions:          extensions,
+		objectStoreProvider: objectStoreProvider,
 	}
 
 	return state

--- a/states/minio.go
+++ b/states/minio.go
@@ -7,16 +7,9 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/manifoldco/promptui"
 	"github.com/minio/minio-go/v7"
-	"github.com/samber/lo"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/milvus-io/birdwatcher/framework"
-	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
-	"github.com/milvus-io/birdwatcher/states/etcd/common"
-	"github.com/milvus-io/birdwatcher/states/mgrpc"
-	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
 )
 
 type TestMinioCfgParam struct {
@@ -39,121 +32,15 @@ func (s *InstanceState) TestMinioCfgCommand(ctx context.Context, p *TestMinioCfg
 }
 
 func (s *InstanceState) GetMinioClientFromCfg(ctx context.Context, params ...oss.MinioConnectParam) (client *minio.Client, bucketName, rootPath string, err error) {
-	sessions, err := common.ListSessions(ctx, s.client, s.basePath)
+	resolved, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return nil, "", "", err
 	}
-
-	session, found := lo.Find(sessions, func(session *models.Session) bool {
-		return session.ServerName == "rootcoord" || session.ServerName == "mixcoord"
-	})
-
-	if !found {
-		return nil, "", "", errors.New("rootcoord session not found")
+	client, ok := oss.MinioClientFromObjectStore(resolved.Store)
+	if !ok {
+		return nil, "", "", errors.New("resolved object store is not backed by minio client")
 	}
-
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	}
-
-	conn, err := grpc.DialContext(ctx, session.Address, opts...)
-	if err != nil {
-		return nil, "", "", errors.New("find to connect to rootcoord")
-	}
-	source := rootcoordpb.NewRootCoordClient(conn)
-
-	configurations, err := mgrpc.GetConfiguration(ctx, source, session.ServerID)
-	if err != nil {
-		return nil, "", "", err
-	}
-
-	var cloudProvider string
-	var addr string
-	var port string
-	var ak, sk string
-	var useIAM string
-	var useSSL string
-	var region string
-	var roleARN string
-	var roleSessionName string
-	var externalID string
-	var loadFrequency string
-	var aliyunRoleAuthMode string
-
-	for _, config := range configurations {
-		switch config.GetKey() {
-		case "minio.cloudprovider":
-			cloudProvider = config.GetValue()
-		case "minio.address":
-			addr = config.GetValue()
-		case "minio.port":
-			port = config.GetValue()
-		case "minio.region":
-			region = config.GetValue()
-		case "minio.bucketname":
-			bucketName = config.GetValue()
-		case "minio.rootpath":
-			rootPath = config.GetValue()
-		case "minio.secretaccesskey":
-			sk = config.GetValue()
-		case "minio.accesskeyid":
-			ak = config.GetValue()
-		case "minio.useiam":
-			useIAM = config.GetValue()
-		case "minio.usessl":
-			useSSL = config.GetValue()
-		case "minio.rolearn":
-			roleARN = config.GetValue()
-		case "minio.rolesessionname":
-			roleSessionName = config.GetValue()
-		case "minio.externalid":
-			externalID = config.GetValue()
-		case "minio.loadfrequency":
-			loadFrequency = config.GetValue()
-		case "minio.aliyunroleauthmode":
-			aliyunRoleAuthMode = config.GetValue()
-		}
-	}
-
-	mp := oss.MinioClientParam{
-		CloudProvider:      cloudProvider,
-		Region:             region,
-		Addr:               addr,
-		Port:               port,
-		AK:                 ak,
-		SK:                 sk,
-		RoleARN:            roleARN,
-		RoleSessionName:    roleSessionName,
-		ExternalID:         externalID,
-		AliyunRoleAuthMode: aliyunRoleAuthMode,
-		BucketName:         bucketName,
-		RootPath:           rootPath,
-	}
-	if useIAM == "true" {
-		mp.UseIAM = true
-	}
-	if useSSL == "true" {
-		mp.UseSSL = true
-	}
-	if loadFrequency != "" {
-		value, err := strconv.Atoi(loadFrequency)
-		if err != nil {
-			return nil, "", "", errors.Wrapf(err, "invalid minio.loadfrequency: %s", loadFrequency)
-		}
-		mp.LoadFrequency = value
-	}
-
-	for _, param := range params {
-		param(&mp)
-	}
-
-	mClient, err := oss.NewMinioClient(ctx, mp)
-	if err != nil {
-		return nil, "", "", err
-	}
-
-	return mClient.Client, bucketName, rootPath, nil
+	return client, resolved.BucketName, resolved.RootPath, nil
 }
 
 func (s *InstanceState) GetMinioClientFromPrompt(ctx context.Context) (client *minio.Client, bucketName, rootPath string, err error) {

--- a/states/ossutil/minio_cfg.go
+++ b/states/ossutil/minio_cfg.go
@@ -14,91 +14,50 @@ import (
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/birdwatcher/states/kv"
 	"github.com/milvus-io/birdwatcher/states/mgrpc"
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
 )
 
-// GetMinioClientFromCfg fetches object storage configuration from any available component and builds a minio client.
-// It mirrors the behavior used by scan-binlog, while avoiding import cycles.
-func GetMinioClientFromCfg(ctx context.Context, cli kv.MetaKV, basePath string, params ...oss.MinioConnectParam) (*minio.Client, string, string, error) {
-	sessions, err := common.ListSessions(ctx, cli, basePath)
-	if err != nil {
-		return nil, "", "", err
-	}
-
+func NewMinioClientParamFromConfigurations(configurations []*commonpb.KeyValuePair) (oss.MinioClientParam, error) {
 	var cloudProvider, addr, port, ak, sk, useIAM, useSSL, region, bucketName, rootPath string
 	var roleARN, roleSessionName, externalID, loadFrequency, aliyunRoleAuthMode string
-	found := false
-	for _, session := range sessions {
-		opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock()}
-		conn, err := grpc.DialContext(ctx, session.Address, opts...)
-		if err != nil {
-			continue
+
+	for _, kv := range configurations {
+		switch kv.GetKey() {
+		case "minio.cloudprovider":
+			cloudProvider = kv.GetValue()
+		case "minio.address":
+			addr = kv.GetValue()
+		case "minio.port":
+			port = kv.GetValue()
+		case "minio.region":
+			region = kv.GetValue()
+		case "minio.bucketname":
+			bucketName = kv.GetValue()
+		case "minio.rootpath":
+			rootPath = kv.GetValue()
+		case "minio.secretaccesskey":
+			sk = kv.GetValue()
+		case "minio.accesskeyid":
+			ak = kv.GetValue()
+		case "minio.useiam":
+			useIAM = kv.GetValue()
+		case "minio.usessl":
+			useSSL = kv.GetValue()
+		case "minio.rolearn":
+			roleARN = kv.GetValue()
+		case "minio.rolesessionname":
+			roleSessionName = kv.GetValue()
+		case "minio.externalid":
+			externalID = kv.GetValue()
+		case "minio.loadfrequency":
+			loadFrequency = kv.GetValue()
+		case "minio.aliyunroleauthmode":
+			aliyunRoleAuthMode = kv.GetValue()
 		}
-		var source mgrpc.ConfigurationSource
-		switch strings.ToLower(session.ServerName) {
-		case "rootcoord":
-			source = rootcoordpb.NewRootCoordClient(conn)
-		case "datacoord":
-			source = datapb.NewDataCoordClient(conn)
-		case "indexcoord":
-			source = indexpb.NewIndexCoordClient(conn)
-		case "querycoord":
-			source = querypb.NewQueryCoordClient(conn)
-		case "datanode":
-			source = datapb.NewDataNodeClient(conn)
-		case "querynode":
-			source = querypb.NewQueryNodeClient(conn)
-		default:
-			continue
-		}
-		items, err := mgrpc.GetConfiguration(ctx, source, session.ServerID)
-		if err != nil || len(items) == 0 {
-			continue
-		}
-		for _, kv := range items {
-			switch kv.GetKey() {
-			case "minio.cloudprovider":
-				cloudProvider = kv.GetValue()
-			case "minio.address":
-				addr = kv.GetValue()
-			case "minio.port":
-				port = kv.GetValue()
-			case "minio.region":
-				region = kv.GetValue()
-			case "minio.bucketname":
-				bucketName = kv.GetValue()
-			case "minio.rootpath":
-				rootPath = kv.GetValue()
-			case "minio.secretaccesskey":
-				sk = kv.GetValue()
-			case "minio.accesskeyid":
-				ak = kv.GetValue()
-			case "minio.useiam":
-				useIAM = kv.GetValue()
-			case "minio.usessl":
-				useSSL = kv.GetValue()
-			case "minio.rolearn":
-				roleARN = kv.GetValue()
-			case "minio.rolesessionname":
-				roleSessionName = kv.GetValue()
-			case "minio.externalid":
-				externalID = kv.GetValue()
-			case "minio.loadfrequency":
-				loadFrequency = kv.GetValue()
-			case "minio.aliyunroleauthmode":
-				aliyunRoleAuthMode = kv.GetValue()
-			}
-		}
-		if bucketName != "" && addr != "" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, "", "", fmt.Errorf("minio configuration not found from any component")
 	}
 
 	mp := oss.MinioClientParam{
@@ -122,16 +81,95 @@ func GetMinioClientFromCfg(ctx context.Context, cli kv.MetaKV, basePath string, 
 	if loadFrequency != "" {
 		value, err := strconv.Atoi(loadFrequency)
 		if err != nil {
-			return nil, "", "", fmt.Errorf("invalid minio.loadfrequency: %s: %w", loadFrequency, err)
+			return oss.MinioClientParam{}, fmt.Errorf("invalid minio.loadfrequency: %s: %w", loadFrequency, err)
 		}
 		mp.LoadFrequency = value
 	}
+	return mp, nil
+}
+
+func NewResolvedObjectStore(ctx context.Context, mp oss.MinioClientParam, params ...oss.MinioConnectParam) (*oss.ResolvedObjectStore, error) {
 	for _, p := range params {
-		p(&mp)
+		if p != nil {
+			p(&mp)
+		}
 	}
 	m, err := oss.NewMinioClient(ctx, mp)
 	if err != nil {
+		return nil, err
+	}
+	return &oss.ResolvedObjectStore{
+		Store:      oss.NewMinioObjectStore(m),
+		BucketName: m.BucketName,
+		RootPath:   m.RootPath,
+	}, nil
+}
+
+func NewResolvedObjectStoreFromConfigurations(ctx context.Context, configurations []*commonpb.KeyValuePair, params ...oss.MinioConnectParam) (*oss.ResolvedObjectStore, error) {
+	mp, err := NewMinioClientParamFromConfigurations(configurations)
+	if err != nil {
+		return nil, err
+	}
+	return NewResolvedObjectStore(ctx, mp, params...)
+}
+
+func GetObjectStoreFromCfg(ctx context.Context, cli kv.MetaKV, basePath string, params ...oss.MinioConnectParam) (*oss.ResolvedObjectStore, error) {
+	sessions, err := common.ListSessions(ctx, cli, basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, session := range sessions {
+		opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock()}
+		conn, err := grpc.DialContext(ctx, session.Address, opts...)
+		if err != nil {
+			continue
+		}
+		var source mgrpc.ConfigurationSource
+		switch strings.ToLower(session.ServerName) {
+		case "rootcoord", "mixcoord":
+			source = rootcoordpb.NewRootCoordClient(conn)
+		case "datacoord":
+			source = datapb.NewDataCoordClient(conn)
+		case "indexcoord":
+			source = indexpb.NewIndexCoordClient(conn)
+		case "querycoord":
+			source = querypb.NewQueryCoordClient(conn)
+		case "datanode":
+			source = datapb.NewDataNodeClient(conn)
+		case "querynode":
+			source = querypb.NewQueryNodeClient(conn)
+		default:
+			conn.Close()
+			continue
+		}
+		items, err := mgrpc.GetConfiguration(ctx, source, session.ServerID)
+		conn.Close()
+		if err != nil || len(items) == 0 {
+			continue
+		}
+		mp, err := NewMinioClientParamFromConfigurations(items)
+		if err != nil {
+			return nil, err
+		}
+		if mp.BucketName == "" || mp.Addr == "" {
+			continue
+		}
+		return NewResolvedObjectStore(ctx, mp, params...)
+	}
+	return nil, fmt.Errorf("minio configuration not found from any component")
+}
+
+// GetMinioClientFromCfg fetches object storage configuration from any available component and builds a minio client.
+// It mirrors the behavior used by scan-binlog, while avoiding import cycles.
+func GetMinioClientFromCfg(ctx context.Context, cli kv.MetaKV, basePath string, params ...oss.MinioConnectParam) (*minio.Client, string, string, error) {
+	resolved, err := GetObjectStoreFromCfg(ctx, cli, basePath, params...)
+	if err != nil {
 		return nil, "", "", err
 	}
-	return m.Client, bucketName, rootPath, nil
+	client, ok := oss.MinioClientFromObjectStore(resolved.Store)
+	if !ok {
+		return nil, "", "", fmt.Errorf("resolved object store is not backed by minio client")
+	}
+	return client, resolved.BucketName, resolved.RootPath, nil
 }

--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
-	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
 
@@ -91,11 +90,12 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		fmt.Println("Failed to create client,", err.Error())
 		return err
 	}
+	rootPath := resolvedStore.RootPath
 
 	fmt.Printf("=== start to execute \"%s\" task with filter expresion: \"%s\" ===\n", p.Action, p.Expr)
 	fmt.Printf("=== worker num: %d, skip delete: %t ===\n", p.WorkerNum, p.IgnoreDelete)
@@ -121,8 +121,8 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	}
 
 	getObject := func(binlogPath string) (storagecommon.ReadSeeker, error) {
-		logPath := strings.ReplaceAll(binlogPath, "ROOT_PATH", rootPath)
-		return minioClient.GetObject(ctx, bucketName, logPath, minio.GetObjectOptions{})
+		logPath := oss.ResolveObjectKey(rootPath, binlogPath)
+		return resolvedStore.Store.Open(ctx, logPath)
 	}
 
 	l0Segments := lo.Filter(segments, func(segment *models.Segment, _ int) bool {

--- a/states/scan_deltalog.go
+++ b/states/scan_deltalog.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/expr-lang/expr"
-	"github.com/minio/minio-go/v7"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -78,11 +77,12 @@ func (s *InstanceState) ScanDeltalogCommand(ctx context.Context, p *ScanDeltalog
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		fmt.Println("Failed to create client,", err.Error())
 		return err
 	}
+	rootPath := resolvedStore.RootPath
 
 	fmt.Printf("=== start to execute \"%s\" task with filter expresion: \"%s\" ===\n", p.Action, p.Expr)
 
@@ -107,9 +107,9 @@ func (s *InstanceState) ScanDeltalogCommand(ctx context.Context, p *ScanDeltalog
 		}
 	}
 
-	getObject := func(binlogPath string) (*minio.Object, error) {
-		logPath := strings.ReplaceAll(binlogPath, "ROOT_PATH", rootPath)
-		return minioClient.GetObject(ctx, bucketName, logPath, minio.GetObjectOptions{})
+	getObject := func(binlogPath string) (storagecommon.ReadSeeker, error) {
+		logPath := oss.ResolveObjectKey(rootPath, binlogPath)
+		return resolvedStore.Store.Open(ctx, logPath)
 	}
 	for _, segment := range segments {
 		for _, fieldBinlogs := range segment.GetDeltalogs() {

--- a/states/segment_anaylsis.go
+++ b/states/segment_anaylsis.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/birdwatcher/states/storage"
 )
@@ -49,13 +50,14 @@ func (app *ApplicationState) StorageAnalysisCommand(ctx context.Context, p *Stor
 			fmt.Println("fieldID:", fieldBinlog.FieldID)
 			var size int64
 			for _, binlog := range fieldBinlog.Binlogs {
-				info, err := minio.Stat(ctx, binlog.LogPath)
+				logPath := oss.ResolveObjectKey(minio.RootPath(), binlog.LogPath)
+				info, err := minio.Stat(ctx, logPath)
 				if err != nil {
 					fmt.Println("failed to stats", err.Error())
 					continue
 				}
 				if p.Detail {
-					fmt.Printf("Binlog %s size %s\n", binlog.LogPath, hrSize(info.Size))
+					fmt.Printf("Binlog %s size %s\n", logPath, hrSize(info.Size))
 				}
 				size += info.Size
 			}

--- a/states/show_manifest.go
+++ b/states/show_manifest.go
@@ -12,9 +12,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
-
-	"github.com/minio/minio-go/v7"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -64,10 +61,11 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 		params = append(params, oss.WithMinioAddr(p.MinioAddress))
 	}
 
-	minioClient, bucketName, rootPath, err := s.GetMinioClientFromCfg(ctx, params...)
+	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("failed to create minio client: %w", err)
 	}
+	rootPath := resolvedStore.RootPath
 
 	for _, seg := range manifestSegments {
 		rawManifest := seg.GetManifestPath()
@@ -85,18 +83,17 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 			continue
 		}
 
-		basePath := strings.ReplaceAll(manifestRef.BasePath, "ROOT_PATH", rootPath)
+		basePath := oss.ResolveObjectKey(rootPath, manifestRef.BasePath)
 		manifestPath := path.Join(basePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
 		fmt.Printf("Manifest File: %s\n", manifestPath)
 
-		obj, err := minioClient.GetObject(ctx, bucketName, manifestPath, minio.GetObjectOptions{})
+		obj, err := resolvedStore.Store.Open(ctx, manifestPath)
 		if err != nil {
 			fmt.Printf("Error getting object: %v\n\n", err)
 			continue
 		}
 
 		manifest, err := parseManifest(obj)
-		obj.Close()
 		if err != nil {
 			fmt.Printf("Error parsing manifest: %v\n\n", err)
 			continue

--- a/states/storage/fs.go
+++ b/states/storage/fs.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/minio/minio-go/v7"
 
 	"github.com/milvus-io/birdwatcher/framework"
 )
@@ -77,14 +76,17 @@ func (s *OSSState) LsCommand(ctx context.Context, p *LsParam) error {
 	} else {
 		base = s.getBase()
 	}
-	ch := s.client.Client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
-		Prefix:    base,
-		Recursive: false,
-	})
+	ch, err := s.store.List(ctx, base, false)
+	if err != nil {
+		return err
+	}
 
 	dc := color.New(color.FgCyan)
 	fc := color.New(color.FgGreen)
 	for info := range ch {
+		if info.Err != nil {
+			return info.Err
+		}
 		name := strings.TrimPrefix(info.Key, base)
 		c := fc
 		isDirectory := false
@@ -139,12 +141,11 @@ func (s *OSSState) CdCommand(ctx context.Context, p *CdParam) error {
 
 	// Validate the target directory exists by listing with the resolved prefix
 	listPrefix := toListingPrefix(resolved)
-	ch := s.client.Client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
-		Prefix:    listPrefix,
-		Recursive: false,
-	})
+	ch, err := s.store.List(ctx, listPrefix, false)
+	if err != nil {
+		return err
+	}
 
-	// Check if any object exists under this prefix
 	info, ok := <-ch
 	if !ok || info.Err != nil {
 		return fmt.Errorf("folder %s not exists", p.prefix)

--- a/states/storage/minio.go
+++ b/states/storage/minio.go
@@ -6,8 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/minio/minio-go/v7"
-
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/autocomplete"
@@ -17,8 +15,9 @@ type OSSState struct {
 	*framework.CmdState
 
 	connectParam oss.MinioClientParam
-	client       *oss.MinioClient
+	store        oss.ObjectStore
 	bucket       string
+	rootPath     string
 	prefix       string
 }
 
@@ -43,6 +42,10 @@ func (s *OSSState) Label() string {
 
 func (s *OSSState) Close() {
 	autocomplete.UnregisterValueSuggester(minioPathSuggester)
+}
+
+func (s *OSSState) RootPath() string {
+	return s.rootPath
 }
 
 func (s *OSSState) suggestPaths(partial string) []string {
@@ -84,10 +87,10 @@ func (s *OSSState) suggestPaths(partial string) []string {
 	ctx, cancel := s.Ctx()
 	defer cancel()
 
-	ch := s.client.Client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
-		Prefix:    listPrefix,
-		Recursive: false,
-	})
+	ch, err := s.store.List(ctx, listPrefix, false)
+	if err != nil {
+		return nil
+	}
 
 	var results []string
 	for info := range ch {
@@ -144,10 +147,11 @@ func ConnectOSS(ctx context.Context, p *ConnectOSSParam, parent *framework.CmdSt
 	}
 
 	return &OSSState{
-		client:       mClient,
+		store:        oss.NewMinioObjectStore(mClient),
 		bucket:       p.Bucket,
+		rootPath:     mp.RootPath,
 		connectParam: mp,
-		prefix:       mp.RootPath, // set current dir to rootPath if provided
+		prefix:       mp.RootPath,
 		CmdState:     parent.Spawn(fmt.Sprintf("OSS[%s](%s/%s)", p.CloudProvider, p.Bucket, p.RootPath)),
 	}, nil
 }

--- a/states/storage/ops.go
+++ b/states/storage/ops.go
@@ -9,22 +9,13 @@ import (
 	"path"
 	"strings"
 
-	"github.com/minio/minio-go/v7"
-
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 )
 
 func (s *OSSState) Stat(ctx context.Context, path string) (*models.FsStat, error) {
-	info, err := s.client.Client.StatObject(ctx, s.bucket, path, minio.StatObjectOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	result := &models.FsStat{
-		Size: info.Size,
-	}
-	return result, nil
+	return s.store.Stat(ctx, oss.ResolveObjectKey(s.rootPath, path))
 }
 
 type GetParam struct {
@@ -51,15 +42,13 @@ func (s *OSSState) GetCommand(ctx context.Context, p *GetParam) error {
 		return errors.New("cannot download root")
 	}
 
-	// List objects under the resolved path to find matching files
 	base := toListingPrefix(resolved)
-	ch := s.client.Client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
-		Prefix:    base,
-		Recursive: true,
-	})
+	ch, err := s.store.List(ctx, base, true)
+	if err != nil {
+		return err
+	}
 
-	// Also check if the resolved path is an exact file (not a directory)
-	_, err := s.client.Client.StatObject(ctx, s.bucket, resolved, minio.StatObjectOptions{})
+	_, err = s.store.Stat(ctx, resolved)
 	isFile := err == nil
 
 	if isFile {
@@ -72,7 +61,7 @@ func (s *OSSState) GetCommand(ctx context.Context, p *GetParam) error {
 		if info.Err != nil {
 			return fmt.Errorf("list objects error: %w", info.Err)
 		}
-		if strings.HasSuffix(info.Key, "/") {
+		if info.IsDir || strings.HasSuffix(info.Key, "/") {
 			continue
 		}
 		if err := s.downloadFile(ctx, info.Key, p.TargetDir); err != nil {
@@ -89,11 +78,13 @@ func (s *OSSState) GetCommand(ctx context.Context, p *GetParam) error {
 }
 
 func (s *OSSState) downloadFile(ctx context.Context, key string, targetDir string) error {
-	obj, err := s.client.Client.GetObject(ctx, s.bucket, key, minio.GetObjectOptions{})
+	obj, err := s.store.Open(ctx, key)
 	if err != nil {
 		return fmt.Errorf("get object %s failed: %w", key, err)
 	}
-	defer obj.Close()
+	if closer, ok := obj.(io.Closer); ok {
+		defer closer.Close()
+	}
 
 	fileName := path.Base(key)
 	localPath := fileName

--- a/states/verify_segment.go
+++ b/states/verify_segment.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 )
@@ -38,6 +39,7 @@ func (s *InstanceState) VerifySegmentCommnad(ctx context.Context, p *VerifySegme
 		fmt.Println("failed to get minio access", err.Error())
 		return err
 	}
+	store := oss.NewMinioObjectStoreWithBucket(minioClient, bucketName)
 
 	total := len(segments)
 	for idx, segment := range segments {
@@ -54,8 +56,8 @@ func (s *InstanceState) VerifySegmentCommnad(ctx context.Context, p *VerifySegme
 		for _, item := range items {
 			for _, fbl := range item.fieldBinlogs {
 				for _, l := range fbl.Binlogs {
-					logPath := strings.Replace(l.LogPath, "ROOT_PATH", p.RootPath, 1)
-					_, err := minioClient.StatObject(ctx, bucketName, logPath, minio.StatObjectOptions{})
+					logPath := oss.ResolveObjectKey(p.RootPath, l.LogPath)
+					_, err := store.Stat(ctx, logPath)
 					if err != nil {
 						errResp := minio.ToErrorResponse(err)
 						fmt.Println("failed to check ", logPath, err, errResp.Code)


### PR DESCRIPTION
Introduce a backend-neutral object store interface for read-only OSS access and route object-store commands through it. This centralizes storage config and ROOT_PATH resolution while keeping the default MinIO-backed behavior for existing workflows.