### PR TITLE
enhance: Support filtering segments by storageVersion in show segment

### DIFF
--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -25,6 +25,7 @@ type SegmentParam struct {
 	Detail              bool   `name:"detail" default:"false" desc:"flags indicating whether printing detail binlog info"`
 	State               string `name:"state" default:"" desc:"target segment state"`
 	Level               string `name:"level" default:"" desc:"target segment level"`
+	StorageVersion      int64  `name:"storageVersion" default:"-1" desc:"segment storage version to filter (0/1=v1, 2=v2), -1 for all"`
 }
 
 type segStats struct {
@@ -46,7 +47,8 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 			(p.PartitionID == 0 || segment.PartitionID == p.PartitionID) &&
 			(p.SegmentID == 0 || segment.ID == p.SegmentID) &&
 			(p.State == "" || strings.EqualFold(segment.State.String(), p.State)) &&
-			(p.Level == "" || strings.EqualFold(segment.Level.String(), p.Level))
+			(p.Level == "" || strings.EqualFold(segment.Level.String(), p.Level)) &&
+			(p.StorageVersion == -1 || segment.GetStorageVersion() == p.StorageVersion)
 	})
 	if err != nil {
 		fmt.Println("failed to list segments", err.Error())
@@ -59,6 +61,7 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 	var growing, sealed, flushed, dropped int
 	var small, other int
 	var smallCnt, otherCnt int64
+	storageVersionCount := make(map[int64]int)
 
 	collectionID2SegStats := make(map[int64]*segStats)
 	collectionID2Segments := lo.GroupBy(segments, func(s *models.Segment) int64 {
@@ -77,6 +80,7 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 			if info.State != commonpb.SegmentState_Dropped {
 				totalRC += info.NumOfRows
 				healthy++
+				storageVersionCount[info.GetStorageVersion()]++
 			}
 			switch info.State {
 			case commonpb.SegmentState_Growing:
@@ -142,6 +146,12 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 	fmt.Printf("--- Growing: %d, Sealed: %d, Flushed: %d, Dropped: %d\n", growing, sealed, flushed, dropped)
 	fmt.Printf("--- Small Segments: %d, row count: %d\t Other Segments: %d, row count: %d\n", small, smallCnt, other, otherCnt)
 	fmt.Printf("--- Total Segments: %d, row count: %d\n", healthy, totalRC)
+
+	storageVersions := lo.Keys(storageVersionCount)
+	sort.Slice(storageVersions, func(i, j int) bool { return storageVersions[i] < storageVersions[j] })
+	for _, v := range storageVersions {
+		fmt.Printf("--- StorageVersion %d: %d segments\n", v, storageVersionCount[v])
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Backport storage-version support for `show segment` to the `v1.1.x` release line. `main` already has this; `v1.1.x` displayed the storage version per segment but had no way to filter or aggregate by it. This PR adds:

- a `--storageVersion N` flag to filter segments by storage format version (default `-1` = all); and
- a per-storage-version count breakdown in the summary footer.

Storage v1 reports the value `0`, v2 reports `2`.

## Usage

```
# default output: summary footer now prints one line per storage version
show segment
# ...
# --- Total Segments: 44, row count: 46002
# --- StorageVersion 0: 4 segments      # still on v1
# --- StorageVersion 2: 40 segments     # already on v2

# filter to only the segments still on v1, and read the count
show segment --storageVersion 0 --format statistics
# --- Total Segments: 4, ...
```

To track a v1 → v2 segment storage migration, watch the `StorageVersion 0` count fall to 0.

## Verification

Tested against a live etcd with mixed v1/v2 segments:
- `show segment` → breakdown `StorageVersion 0: 4`, `StorageVersion 2: 40`, reconciling with `Total Segments: 44`.
- `show segment --storageVersion 0` → returns only the 4 v1 segments.
- `show segment --storageVersion 2` → returns only the v2 segments.
- non-existent version (e.g. `1`, `99`) → 0 segments.
