### PR TITLE
enhance: Add per-storageVersion segment count breakdown to show segment

### DIFF
--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -121,12 +121,13 @@ func (rs *Segments) printAsJSON() string {
 	}
 
 	type SummaryJSON struct {
-		Growing      int   `json:"growing"`
-		Sealed       int   `json:"sealed"`
-		Flushed      int   `json:"flushed"`
-		Dropped      int   `json:"dropped"`
-		TotalHealthy int   `json:"total_healthy"`
-		TotalRows    int64 `json:"total_rows"`
+		Growing              int           `json:"growing"`
+		Sealed               int           `json:"sealed"`
+		Flushed              int           `json:"flushed"`
+		Dropped              int           `json:"dropped"`
+		TotalHealthy         int           `json:"total_healthy"`
+		TotalRows            int64         `json:"total_rows"`
+		StorageVersionCounts map[int64]int `json:"storage_version_counts"`
 	}
 
 	type OutputJSON struct {
@@ -136,6 +137,7 @@ func (rs *Segments) printAsJSON() string {
 
 	var growing, sealed, flushed, dropped, healthy int
 	var totalRC int64
+	storageVersionCount := make(map[int64]int)
 
 	output := OutputJSON{
 		Segments: make([]SegmentJSON, 0, len(rs.segments)),
@@ -145,6 +147,7 @@ func (rs *Segments) printAsJSON() string {
 		if info.State != commonpb.SegmentState_Dropped {
 			totalRC += info.NumOfRows
 			healthy++
+			storageVersionCount[info.GetStorageVersion()]++
 		}
 		switch info.State {
 		case commonpb.SegmentState_Growing:
@@ -172,12 +175,13 @@ func (rs *Segments) printAsJSON() string {
 	}
 
 	output.Summary = SummaryJSON{
-		Growing:      growing,
-		Sealed:       sealed,
-		Flushed:      flushed,
-		Dropped:      dropped,
-		TotalHealthy: healthy,
-		TotalRows:    totalRC,
+		Growing:              growing,
+		Sealed:               sealed,
+		Flushed:              flushed,
+		Dropped:              dropped,
+		TotalHealthy:         healthy,
+		TotalRows:            totalRC,
+		StorageVersionCounts: storageVersionCount,
 	}
 
 	return framework.MarshalJSON(output)
@@ -192,6 +196,7 @@ func (rs *Segments) printDefault() string {
 	var growing, sealed, flushed, dropped int
 	var small, other int
 	var smallCnt, otherCnt int64
+	storageVersionCount := make(map[int64]int)
 
 	collectionID2SegStats := make(map[int64]*segStats)
 	collectionID2Segments := lo.GroupBy(rs.segments, func(s *models.Segment) int64 {
@@ -209,6 +214,7 @@ func (rs *Segments) printDefault() string {
 			if info.State != commonpb.SegmentState_Dropped {
 				totalRC += info.NumOfRows
 				healthy++
+				storageVersionCount[info.GetStorageVersion()]++
 			}
 			switch info.State {
 			case commonpb.SegmentState_Growing:
@@ -273,6 +279,12 @@ func (rs *Segments) printDefault() string {
 	fmt.Fprintf(sb, "--- Growing: %d, Sealed: %d, Flushed: %d, Dropped: %d\n", growing, sealed, flushed, dropped)
 	fmt.Fprintf(sb, "--- Small Segments: %d, row count: %d\t Other Segments: %d, row count: %d\n", small, smallCnt, other, otherCnt)
 	fmt.Fprintf(sb, "--- Total Segments: %d, row count: %d\n", healthy, totalRC)
+
+	storageVersions := lo.Keys(storageVersionCount)
+	sort.Slice(storageVersions, func(i, j int) bool { return storageVersions[i] < storageVersions[j] })
+	for _, v := range storageVersions {
+		fmt.Fprintf(sb, "--- StorageVersion %d: %d segments\n", v, storageVersionCount[v])
+	}
 	return sb.String()
 }
 


### PR DESCRIPTION
## Summary

Add a per-storage-version count breakdown to the `show segment` summary, in both the default and JSON output. `main` already supports the `--storageVersion` filter; this adds the aggregate count so migration progress can be read at a glance without scanning per-segment lines.

## Usage

```
# default output: summary footer now prints one line per storage version
show segment
# ...
# --- Total Segments: 44, row count: 46002
# --- StorageVersion 0: 4 segments      # still on v1
# --- StorageVersion 2: 40 segments     # already on v2

# JSON output: summary includes storage_version_counts
show segment --format json
# "summary": { ..., "storage_version_counts": { "0": 4, "2": 40 } }

# combine with the existing filter to list only one version
show segment --storageVersion 0
```

To track a v1 → v2 segment storage migration, watch the `StorageVersion 0` count fall to 0.

## Verification

Tested against a live etcd with mixed v1/v2 segments:
- `show segment` → `StorageVersion 0: 4`, `StorageVersion 2: 40`, reconciling with `Total Segments: 44`.
- `show segment --storageVersion 0` → 4 segments; `--storageVersion 2` → 40 segments.
- `show segment --format json` → `"storage_version_counts": {"0": 4, "2": 40}`.
