### PR TITLE
enhance: Add per-segment deltalog count/size breakdown to show segment (v1.1.x)

### DIFF
--- a/states/etcd/show/segment.go
+++ b/states/etcd/show/segment.go
@@ -33,11 +33,26 @@ type segStats struct {
 	binlogLogSize map[int64]int64
 	// field id => mem size
 	binlogMemSize map[int64]int64
+	deltaLogCount int64
 	deltaLogSize  int64
 	deltaMemSize  int64
 	deltaEntryNum int64
 	statsLogSize  int64
 	statsMemSize  int64
+}
+
+// segmentDeltaStats returns the deltalog file count, log size, mem size and
+// entry number of a single segment from its meta.
+func segmentDeltaStats(info *models.Segment) (count, logSize, memSize, entriesNum int64) {
+	for _, delta := range info.GetDeltalogs() {
+		count += int64(len(delta.Binlogs))
+		for _, l := range delta.Binlogs {
+			logSize += l.LogSize
+			memSize += l.MemSize
+			entriesNum += l.EntriesNum
+		}
+	}
+	return count, logSize, memSize, entriesNum
 }
 
 // SegmentCommand returns show segments command.
@@ -128,6 +143,15 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 						}
 					}
 				}
+			case "delta":
+				count, logSize, memSize, entriesNum := segmentDeltaStats(info)
+				stats := collectionID2SegStats[collectionID]
+				stats.deltaLogCount += count
+				stats.deltaLogSize += logSize
+				stats.deltaMemSize += memSize
+				stats.deltaEntryNum += entriesNum
+				fmt.Printf("SegmentID: %d PartitionID: %d State: %s, Level: %s, DeltaLog Count: %d, DeltaLog Size: %s, Mem Size: %s, Delta Entries: %d\n",
+					info.ID, info.PartitionID, info.State.String(), info.Level.String(), count, hrSize(logSize), hrSize(memSize), entriesNum)
 			default:
 				err := fmt.Errorf("unsupport format:%s", p.Format)
 				return err
@@ -136,11 +160,17 @@ func (c *ComponentShow) SegmentCommand(ctx context.Context, p *SegmentParam) err
 		if p.Format == "statistics" {
 			outputStats("Collection", collectionID2SegStats[collectionID])
 		}
+		if p.Format == "delta" {
+			outputDeltaStats("Collection", collectionID2SegStats[collectionID])
+		}
 		fmt.Printf("\n")
 	}
 
 	if p.Format == "statistics" {
 		outputStats("Total", lo.Values(collectionID2SegStats)...)
+	}
+	if p.Format == "delta" {
+		outputDeltaStats("Total", lo.Values(collectionID2SegStats)...)
 	}
 
 	fmt.Printf("--- Growing: %d, Sealed: %d, Flushed: %d, Dropped: %d\n", growing, sealed, flushed, dropped)
@@ -183,6 +213,18 @@ func outputStats(scope string, stats ...*segStats) {
 	fmt.Printf("--- %s binlog size: %s, mem size: %s\n", scope, hrSize(totalBinlogLogSize), hrSize(totalBinlogMemSize))
 	fmt.Printf("--- %s deltalog size: %s, mem size: %s, delta entry number: %d\n", scope, hrSize(totalDeltaLogSize), hrSize(totalDeltaMemSize), totalDeltaEntryNum)
 	fmt.Printf("--- %s statslog size: %s, mem size: %s\n", scope, hrSize(totalStatsLogSize), hrSize(totalStatsMemSize))
+}
+
+func outputDeltaStats(scope string, stats ...*segStats) {
+	var totalCount, totalLogSize, totalMemSize, totalEntryNum int64
+	for _, s := range stats {
+		totalCount += s.deltaLogCount
+		totalLogSize += s.deltaLogSize
+		totalMemSize += s.deltaMemSize
+		totalEntryNum += s.deltaEntryNum
+	}
+	fmt.Printf("--- %s deltalog count: %d, size: %s, mem size: %s, delta entry number: %d\n",
+		scope, totalCount, hrSize(totalLogSize), hrSize(totalMemSize), totalEntryNum)
 }
 
 func hrSize(size int64) string {

--- a/states/etcd/show/segment_test.go
+++ b/states/etcd/show/segment_test.go
@@ -1,0 +1,43 @@
+package show
+
+import (
+	"testing"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+func mockSegmentWithDelta(id int64, deltaLogs []*datapb.Binlog) *models.Segment {
+	info := &datapb.SegmentInfo{
+		ID:           id,
+		CollectionID: 1,
+		PartitionID:  1,
+	}
+	return models.NewSegment(info, "", func() ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+		var deltalogs []*datapb.FieldBinlog
+		if len(deltaLogs) > 0 {
+			deltalogs = []*datapb.FieldBinlog{{Binlogs: deltaLogs}}
+		}
+		return nil, nil, deltalogs, nil
+	})
+}
+
+func TestSegmentDeltaStats(t *testing.T) {
+	segment := mockSegmentWithDelta(101, []*datapb.Binlog{
+		{LogID: 1, LogSize: 1024, MemorySize: 2048, EntriesNum: 10},
+		{LogID: 2, LogSize: 1024, MemorySize: 2048, EntriesNum: 20},
+	})
+
+	count, logSize, memSize, entriesNum := segmentDeltaStats(segment)
+	if count != 2 || logSize != 2048 || memSize != 4096 || entriesNum != 30 {
+		t.Errorf("unexpected delta stats: count=%d logSize=%d memSize=%d entriesNum=%d",
+			count, logSize, memSize, entriesNum)
+	}
+
+	empty := mockSegmentWithDelta(102, nil)
+	count, logSize, memSize, entriesNum = segmentDeltaStats(empty)
+	if count != 0 || logSize != 0 || memSize != 0 || entriesNum != 0 {
+		t.Errorf("expected zero delta stats, got: count=%d logSize=%d memSize=%d entriesNum=%d",
+			count, logSize, memSize, entriesNum)
+	}
+}


### PR DESCRIPTION
## Summary

Backport of #504 to `v1.1.x`. Add a new `delta` format to `show segment` that prints one compact line per segment with its deltalog file count, log size, mem size and delta entry number, plus per-collection and total summaries. Useful for spotting delete backlog / L0 compaction pressure at a glance without dumping the full `--format table --detail` output.

`v1.1.x` `show segment` has no JSON output path, so only the `delta` format is added here (the main-branch PR also extends the JSON output).

## Usage

```
# compact per-segment delta view
show segment --collection 12345 --format delta
# SegmentID: 101 PartitionID: 1 State: Flushed, Level: L1, DeltaLog Count: 2, DeltaLog Size: 2.0 KB, Mem Size: 4.0 KB, Delta Entries: 30
# SegmentID: 102 PartitionID: 1 State: Flushed, Level: L1, DeltaLog Count: 0, DeltaLog Size: 0.0 Bytes, Mem Size: 0.0 Bytes, Delta Entries: 0
# --- Collection deltalog count: 2, size: 2.0 KB, mem size: 4.0 KB, delta entry number: 30
# --- Total deltalog count: 2, size: 2.0 KB, mem size: 4.0 KB, delta entry number: 30

# dump to a file via olc mode
birdwatcher -olc "#connect --etcd ...,show segment --collection 12345 --format delta" > delta_report.txt
```

All numbers come from the datacoord meta in etcd; no object storage access is needed.

## Verification

- Project builds cleanly.
- Added a unit test for the per-segment delta stats helper (`states/etcd/show/segment_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
