### PR TITLE
fix: honor --dstNodes in balance-segment (v1.1.x)

### DIFF
--- a/states/mgrpc/querycoord.go
+++ b/states/mgrpc/querycoord.go
@@ -38,7 +38,7 @@ type BalanceSegmentParam struct {
 	CollectionID        int64   `name:"collection" default:"0"`
 	SegmentIDs          []int64 `name:"segment" desc:"segment ids to balance"`
 	SourceNodes         []int64 `name:"srcNodes" desc:"from querynode ids"`
-	DstNodes            int64   `name:"dstNode" desc:"to querynode ids"`
+	DstNodes            []int64 `name:"dstNodes" desc:"to querynode ids, empty means let querycoord pick"`
 }
 
 func (s *queryCoordState) BalanceSegmentCommand(ctx context.Context, p *BalanceSegmentParam) error {
@@ -49,6 +49,8 @@ func (s *queryCoordState) BalanceSegmentCommand(ctx context.Context, p *BalanceS
 		CollectionID:     p.CollectionID,
 		SealedSegmentIDs: p.SegmentIDs,
 		SourceNodeIDs:    p.SourceNodes,
+		// Empty DstNodeIDs makes querycoord pick a target among all nodes of the replica.
+		DstNodeIDs: p.DstNodes,
 	}
 
 	resp, err := s.client.LoadBalance(ctx, req)


### PR DESCRIPTION
Backport of #508 to `v1.1.x`.

`BalanceSegmentCommand` parsed the destination flag into `p.DstNodes` but never put it into the `LoadBalanceRequest`, so the flag was silently ignored and querycoord always fell back to picking a destination among all nodes of the replica (`DstNodeIDs` empty means "any RW node").

Populate `DstNodeIDs` from the flag. Per review feedback on #508, `DstNodes` is `[]int64` with flag `--dstNodes`, mirroring `SourceNodes` / `--srcNodes` and the repeated `DstNodeIDs` field in the proto; an empty value keeps the previous auto-select behaviour.

Cherry-picked from 1d01527.
