### PR TITLE
fix: skip L0 segments in storage v1 binlog schema check

### DIFF
--- a/states/healthz/storage_v1_binlog_schema_mismatch.go
+++ b/states/healthz/storage_v1_binlog_schema_mismatch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
 	metakv "github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 )
 
 type StorageV1BinlogSchemaMismatch struct {
@@ -41,6 +42,9 @@ func (i *StorageV1BinlogSchemaMismatch) Check(ctx context.Context, client metakv
 
 	var results []*HealthzCheckReport
 	for _, segment := range segments {
+		if segment.GetLevel() == datapb.SegmentLevel_L0 {
+			continue
+		}
 		if segment.GetStorageVersion() != 0 && segment.GetStorageVersion() != 1 {
 			continue
 		}

--- a/states/healthz/storage_v1_binlog_schema_mismatch_test.go
+++ b/states/healthz/storage_v1_binlog_schema_mismatch_test.go
@@ -76,6 +76,8 @@ func TestStorageV1BinlogSchemaMismatchCheck(t *testing.T) {
 
 		segmentKey(basePath, collectionID, partitionID, 3):     healthzProtoValue(t, &datapb.SegmentInfo{ID: 3, CollectionID: collectionID, PartitionID: partitionID, StorageVersion: 2}),
 		binlogKey(basePath, collectionID, partitionID, 3, 100): healthzProtoValue(t, &datapb.FieldBinlog{FieldID: 100}),
+
+		segmentKey(basePath, collectionID, partitionID, 4): healthzProtoValue(t, &datapb.SegmentInfo{ID: 4, CollectionID: collectionID, PartitionID: partitionID, StorageVersion: 0, Level: datapb.SegmentLevel_L0}),
 	}}
 
 	item := newStorageV1BinlogSchemaMismatch()


### PR DESCRIPTION
L0 segments contain delta logs instead of insert binlogs and should not be validated against collection schema fields.

Add a regression test to ensure L0 segments are ignored.