### PR TITLE
fix: abort repair index_metric_type write on proto.Marshal failure

### DIFF
--- a/states/etcd/repair/index_metric.go
+++ b/states/etcd/repair/index_metric.go
@@ -122,10 +122,9 @@ func writeRepairedIndex(cli kv.MetaKV, basePath string, index *indexpb.FieldInde
 
 	bs, err := proto.Marshal(index)
 	if err != nil {
-		fmt.Println("failed to marshal segment info", err.Error())
+		return fmt.Errorf("failed to marshal repaired index %d: %w", index.GetIndexInfo().GetIndexID(), err)
 	}
-	err = cli.Save(context.Background(), p, string(bs))
-	return err
+	return cli.Save(context.Background(), p, string(bs))
 }
 
 func printIndexV2(index *indexpb.FieldIndex) {

--- a/states/etcd/repair/index_metric_test.go
+++ b/states/etcd/repair/index_metric_test.go
@@ -1,0 +1,65 @@
+package repair
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/birdwatcher/states/kv"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+)
+
+type saveRecordingKV struct {
+	kv.MetaKV
+	saveKeys   []string
+	saveValues []string
+}
+
+func (k *saveRecordingKV) Save(ctx context.Context, key, value string) error {
+	k.saveKeys = append(k.saveKeys, key)
+	k.saveValues = append(k.saveValues, value)
+	return nil
+}
+
+func TestWriteRepairedIndex(t *testing.T) {
+	t.Run("marshal failure does not write to etcd", func(t *testing.T) {
+		cli := &saveRecordingKV{}
+		index := &indexpb.FieldIndex{
+			IndexInfo: &indexpb.IndexInfo{
+				CollectionID: 100,
+				IndexID:      200,
+				// invalid UTF-8 makes proto.Marshal fail.
+				IndexName: "\xff\xfe\x00\x80invalid",
+			},
+		}
+
+		err := writeRepairedIndex(cli, "by-dev/meta", index)
+
+		require.Error(t, err)
+		assert.Empty(t, cli.saveKeys, "Save must not be called when marshaling fails")
+	})
+
+	t.Run("valid index is saved", func(t *testing.T) {
+		cli := &saveRecordingKV{}
+		index := &indexpb.FieldIndex{
+			IndexInfo: &indexpb.IndexInfo{
+				CollectionID: 100,
+				IndexID:      200,
+				IndexName:    "index_name",
+			},
+		}
+
+		err := writeRepairedIndex(cli, "by-dev/meta", index)
+
+		require.NoError(t, err)
+		require.Len(t, cli.saveKeys, 1)
+		assert.Equal(t, "by-dev/meta/field-index/100/200", cli.saveKeys[0])
+
+		saved := &indexpb.FieldIndex{}
+		require.NoError(t, proto.Unmarshal([]byte(cli.saveValues[0]), saved))
+		assert.Equal(t, index.GetIndexInfo().GetIndexName(), saved.GetIndexInfo().GetIndexName())
+	})
+}

--- a/states/etcd/repair/segment.go
+++ b/states/etcd/repair/segment.go
@@ -246,8 +246,7 @@ func writeRepairedSegment(cli kv.MetaKV, basePath string, segment *datapb.Segmen
 
 	bs, err := proto.Marshal(segment)
 	if err != nil {
-		fmt.Println("failed to marshal segment info", err.Error())
+		return fmt.Errorf("failed to marshal repaired segment %d: %w", segment.GetID(), err)
 	}
-	err = cli.Save(context.Background(), p, string(bs))
-	return err
+	return cli.Save(context.Background(), p, string(bs))
 }

--- a/states/etcd/repair/segment_test.go
+++ b/states/etcd/repair/segment_test.go
@@ -1,0 +1,49 @@
+package repair
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+func TestWriteRepairedSegment(t *testing.T) {
+	t.Run("marshal failure does not write to etcd", func(t *testing.T) {
+		cli := &saveRecordingKV{}
+		segment := &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: 100,
+			PartitionID:  10,
+			// invalid UTF-8 makes proto.Marshal fail.
+			InsertChannel: "\xff\xfe\x00\x80invalid",
+		}
+
+		err := writeRepairedSegment(cli, "by-dev/meta", segment)
+
+		require.Error(t, err)
+		assert.Empty(t, cli.saveKeys, "Save must not be called when marshaling fails")
+	})
+
+	t.Run("valid segment is saved", func(t *testing.T) {
+		cli := &saveRecordingKV{}
+		segment := &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			InsertChannel: "ch-0",
+		}
+
+		err := writeRepairedSegment(cli, "by-dev/meta", segment)
+
+		require.NoError(t, err)
+		require.Len(t, cli.saveKeys, 1)
+		assert.Equal(t, "by-dev/meta/datacoord-meta/s/100/10/1", cli.saveKeys[0])
+
+		saved := &datapb.SegmentInfo{}
+		require.NoError(t, proto.Unmarshal([]byte(cli.saveValues[0]), saved))
+		assert.Equal(t, segment.GetInsertChannel(), saved.GetInsertChannel())
+	})
+}


### PR DESCRIPTION
## What

`repair index_metric_type` can report success while writing a corrupted, unreadable value to etcd.

`writeRepairedIndex` prints the marshal error but doesn't return on it, so execution falls through to `cli.Save` with whatever `proto.Marshal` produced:

```go
bs, err := proto.Marshal(index)
if err != nil {
	fmt.Println("failed to marshal segment info", err.Error())
}
err = cli.Save(context.Background(), p, string(bs))
return err
```

I checked what `bs` actually looks like on a marshal failure (invalid UTF-8 in a string field is the easiest way to trigger one). It isn't empty, it's a non-empty buffer that fails to round-trip:

```
marshal err: string field contains invalid UTF-8 bytes: [10 17 8 42 26 11 255 254 0 128 105 110 118 97 108 105 100]
unmarshal err: proto: cannot parse invalid wire-format data
```

So `Save` writes that buffer to etcd, `Save` itself succeeds, and `writeRepairedIndex` returns `nil`. The command reports the repair as done. The next thing that tries to read that key, birdwatcher or indexcoord, fails to unmarshal it with no link back to the repair run that put it there.

`writeRepairedSegment` in `segment.go` has the identical pattern. It's currently unreachable, since its caller `RepairSegmentCommand` has its body commented out, but I fixed it at the same time so the bug doesn't resurface if that command gets finished later.

## Fix

Return the marshal error immediately instead of printing it and continuing to `Save`, in both functions.

## Test

Added `index_metric_test.go` and `segment_test.go` with a small `Save`-recording `kv.MetaKV` mock. Each covers two cases: a marshal-failure input (invalid UTF-8) asserting `Save` is never called and an error comes back, and a normal input asserting the saved bytes round-trip to the original values.

```
go test ./states/etcd/repair/... -run 'TestWriteRepairedIndex|TestWriteRepairedSegment' -v
--- PASS: TestWriteRepairedIndex (0.00s)
    --- PASS: TestWriteRepairedIndex/marshal_failure_does_not_write_to_etcd (0.00s)
    --- PASS: TestWriteRepairedIndex/valid_index_is_saved (0.00s)
--- PASS: TestWriteRepairedSegment (0.00s)
    --- PASS: TestWriteRepairedSegment/marshal_failure_does_not_write_to_etcd (0.00s)
    --- PASS: TestWriteRepairedSegment/valid_segment_is_saved (0.00s)
```

Also ran the full `states/etcd/repair` package suite, `go vet`, and `gofmt -l`; all clean.

Fixes #515.
