### PR TITLE
chore: Bump version to v1.2.0 (v1.2.x)

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -6,5 +6,5 @@ import "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("1.1.1")
+	Version = semver.MustParse("1.2.0")
 }


### PR DESCRIPTION
Prepares the `v1.2.0` release on `v1.2.x`.

`common.Version` still reads `1.1.1` on this branch, and it is what the binary
prints on startup and for `version`. Every previous release bumped it in a
separate commit before the tag was pushed (v1.1.0, v1.1.1, v1.1.2), so this
follows the same order.

Verified locally: `gofmt` clean, the tree builds, and a binary built from this
branch reports `Birdwatcher Version 1.2.0`.