### PR TITLE
chore: Bump version to v1.2.1 (v1.2.x)

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -6,5 +6,5 @@ import "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("1.2.0")
+	Version = semver.MustParse("1.2.1")
 }


### PR DESCRIPTION
Version bump so a build from `v1.2.x` reports `Birdwatcher Version 1.2.1`, ahead of tagging v1.2.1.

v1.2.0 shipped `show vchannel-health` with the defect fixed in #528: a dropped channel's reserved checkpoint value became the reference the command measured every other vchannel against, so every healthy vchannel was reported FROZEN.

One line, same shape as #526.