### PR TITLE
chore: Bump version to v1.2.2 (v1.2.x)

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -6,5 +6,5 @@ import "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("1.2.1")
+	Version = semver.MustParse("1.2.2")
 }


### PR DESCRIPTION
Version bump so a build from `v1.2.x` reports `Birdwatcher Version 1.2.2`, ahead of tagging v1.2.2.

v1.2.1 predates `repair vchannel-registration` (#532), which is the reason for cutting this one. Keeping the reported version in step with the tag matters for support: an output pasted into a ticket has to identify which build produced it.

One line, same shape as #526 and #529.