### PR TITLE
enhance: recreate field indexes with safety checks

### DIFF
--- a/internal/ops/recreate_index.go
+++ b/internal/ops/recreate_index.go
@@ -1,0 +1,380 @@
+package ops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	"github.com/milvus-io/milvus/client/v3/milvusclient"
+)
+
+// recreateIndexRecoveryLoadTimeout bounds only the recovery LoadCollection RPC.
+// Once Milvus accepts that RPC, loading continues asynchronously on the server.
+const recreateIndexRecoveryLoadTimeout = 30 * time.Second
+
+type RecreateIndexParams struct {
+	Collection         string `yaml:"collection"`
+	Field              string `yaml:"field"`
+	IndexName          string `yaml:"index_name,omitempty"`
+	AutoIndex          bool   `yaml:"auto_index,omitempty"`
+	ReleaseAndLoad     bool   `yaml:"release_and_load,omitempty"`
+	ConfirmDefaultLoad bool   `yaml:"confirm_default_load,omitempty"`
+	DryRun             bool   `yaml:"dry_run,omitempty"`
+}
+
+func (p *RecreateIndexParams) Execute(ctx context.Context, rc *RunContext) (result any, err error) {
+	if rc.Client == nil {
+		return nil, errNoClient("recreate_index")
+	}
+	if strings.TrimSpace(p.Collection) == "" || strings.TrimSpace(p.Field) == "" {
+		return nil, fmt.Errorf("recreate_index: `collection` and `field` required")
+	}
+
+	indexNames, err := rc.Client.ListIndexes(ctx,
+		milvusclient.NewListIndexOption(p.Collection).WithFieldName(p.Field))
+	if err != nil {
+		return nil, fmt.Errorf("list indexes for %s.%s: %w", p.Collection, p.Field, err)
+	}
+
+	indexName, err := selectIndexName(indexNames, p.IndexName)
+	if err != nil {
+		return nil, fmt.Errorf("recreate_index: %w", err)
+	}
+
+	description, err := rc.Client.DescribeIndex(ctx,
+		milvusclient.NewDescribeIndexOption(p.Collection, indexName))
+	if err != nil {
+		return nil, fmt.Errorf("describe index %q: %w", indexName, err)
+	}
+	if description.Index == nil {
+		return nil, fmt.Errorf("describe index %q returned no index definition", indexName)
+	}
+
+	sourceParams := description.Params()
+	createParams, err := buildRecreateIndexParams(sourceParams, p.AutoIndex)
+	if err != nil {
+		return nil, fmt.Errorf("index %q: %w", indexName, err)
+	}
+
+	loadState, err := rc.Client.GetLoadState(ctx, milvusclient.NewGetLoadStateOption(p.Collection))
+	if err != nil {
+		return nil, fmt.Errorf("get load state for collection %q: %w", p.Collection, err)
+	}
+
+	encodedCreateParams := formatIndexParams(createParams)
+	fmt.Fprintf(rc.Out(), "recreate index plan\n")
+	fmt.Fprintf(rc.Out(), "  collection: %s\n", p.Collection)
+	fmt.Fprintf(rc.Out(), "  field: %s\n", p.Field)
+	fmt.Fprintf(rc.Out(), "  index: %s\n", indexName)
+	fmt.Fprintf(rc.Out(), "  auto index: %t\n", p.AutoIndex)
+	fmt.Fprintf(rc.Out(), "  release and load: %t\n", p.ReleaseAndLoad)
+	fmt.Fprintf(rc.Out(), "  default load confirmed: %t\n", p.ConfirmDefaultLoad)
+	fmt.Fprintf(rc.Out(), "  source params: %s\n", formatIndexParams(sourceParams))
+	fmt.Fprintf(rc.Out(), "  create params: %s\n", encodedCreateParams)
+	fmt.Fprintf(rc.Out(), "  load state: %s\n", formatLoadState(loadState.State))
+
+	if p.DryRun {
+		indexParamsWarning := legacyIndexParamsWarning(sourceParams, p.AutoIndex)
+		if indexParamsWarning != "" {
+			fmt.Fprintf(rc.Out(), "WARNING: %s\n", indexParamsWarning)
+		}
+		loadWarning := defaultLoadBehaviorWarning(p.ReleaseAndLoad)
+		if loadWarning != "" {
+			fmt.Fprintf(rc.Out(), "WARNING: %s\n", loadWarning)
+		}
+		loadStateWarning := loadedCollectionWarning(loadState.State, p.ReleaseAndLoad)
+		if loadStateWarning != "" {
+			fmt.Fprintf(rc.Out(), "WARNING: %s\n", loadStateWarning)
+		}
+		fmt.Fprintln(rc.Out(), "dry-run: nothing changed")
+		fmt.Fprintf(rc.Out(), "next: %s\n", recreateIndexDryRunNextStep(loadState.State, p.ReleaseAndLoad, p.ConfirmDefaultLoad))
+		result := map[string]any{
+			"collection":           p.Collection,
+			"field":                p.Field,
+			"index":                indexName,
+			"auto_index":           p.AutoIndex,
+			"release_and_load":     p.ReleaseAndLoad,
+			"confirm_default_load": p.ConfirmDefaultLoad,
+			"source_params":        sourceParams,
+			"create_params":        createParams,
+			"dry_run":              true,
+		}
+		if indexParamsWarning != "" {
+			result["warning"] = indexParamsWarning
+		}
+		if loadWarning != "" {
+			result["load_warning"] = loadWarning
+		}
+		if loadStateWarning != "" {
+			result["load_state_warning"] = loadStateWarning
+		}
+		return result, nil
+	}
+
+	if p.ReleaseAndLoad && !p.ConfirmDefaultLoad {
+		return nil, fmt.Errorf("--release-and-load uses server-default LoadCollection settings; " +
+			"pass --confirm-default-load to acknowledge the load behavior before executing")
+	}
+	if !p.ReleaseAndLoad && loadState.State != entity.LoadStateNotLoad {
+		return nil, fmt.Errorf("collection %q must be released before recreating index %q; current load state is %s; "+
+			"release it manually or pass --release-and-load --confirm-default-load",
+			p.Collection, indexName, formatLoadState(loadState.State))
+	}
+	reloadOnFailure := false
+	defer func() {
+		if !reloadOnFailure {
+			return
+		}
+
+		fmt.Fprintf(rc.Out(), "requesting collection %s reload after recreate failure\n", p.Collection)
+		if reloadErr := reloadCollectionAfterFailure(ctx, rc, p.Collection); reloadErr != nil {
+			restoreErr := fmt.Errorf("restore collection %q after recreate failure: %w", p.Collection, reloadErr)
+			if err == nil {
+				err = restoreErr
+				return
+			}
+			err = errors.Join(err, restoreErr)
+			return
+		}
+		fmt.Fprintf(rc.Out(), "collection %s reload requested after recreate failure\n", p.Collection)
+	}()
+	if p.ReleaseAndLoad {
+		fmt.Fprintf(rc.Out(), "releasing collection %s\n", p.Collection)
+		if err := rc.Client.ReleaseCollection(ctx, milvusclient.NewReleaseCollectionOption(p.Collection)); err != nil {
+			return nil, fmt.Errorf("release collection %q before recreating index %q: %w", p.Collection, indexName, err)
+		}
+		reloadOnFailure = true
+		fmt.Fprintf(rc.Out(), "collection %s released\n", p.Collection)
+	}
+
+	if err := rc.Client.DropIndex(ctx, milvusclient.NewDropIndexOption(p.Collection, indexName)); err != nil {
+		return nil, fmt.Errorf("drop index %q: %w", indexName, err)
+	}
+
+	indexDefinition := index.NewGenericIndex(indexName, createParams)
+	createOption := milvusclient.NewCreateIndexOption(p.Collection, p.Field, indexDefinition).
+		WithIndexName(indexName)
+	task, err := rc.Client.CreateIndex(ctx, createOption)
+	if err != nil {
+		return nil, fmt.Errorf("create index %q after it was dropped: %w; recreate with params %s",
+			indexName, err, encodedCreateParams)
+	}
+	if err := task.Await(ctx); err != nil {
+		return nil, fmt.Errorf("wait for recreated index %q: %w; recreate with params %s",
+			indexName, err, encodedCreateParams)
+	}
+
+	recreated, err := rc.Client.DescribeIndex(ctx,
+		milvusclient.NewDescribeIndexOption(p.Collection, indexName))
+	if err != nil {
+		return nil, fmt.Errorf("verify recreated index %q: %w", indexName, err)
+	}
+	if recreated.Index == nil {
+		return nil, fmt.Errorf("verify recreated index %q: describe returned no index definition", indexName)
+	}
+	if !recreatedIndexParamsMatch(createParams, recreated.Params(), p.AutoIndex) {
+		return nil, fmt.Errorf("recreated index %q does not match requested user index parameters: want %s, got %s",
+			indexName, encodedCreateParams, formatIndexParams(recreated.Params()))
+	}
+	if p.ReleaseAndLoad {
+		reloadOnFailure = false
+		fmt.Fprintf(rc.Out(), "loading collection %s\n", p.Collection)
+		if err := loadCollectionAndWait(ctx, rc, p.Collection); err != nil {
+			return nil, fmt.Errorf("index %q was recreated, but failed to load collection: %w", indexName, err)
+		}
+		fmt.Fprintf(rc.Out(), "collection %s loaded\n", p.Collection)
+	}
+
+	fmt.Fprintf(rc.Out(), "index %s recreated on %s.%s\n", indexName, p.Collection, p.Field)
+	return map[string]any{
+		"collection":           p.Collection,
+		"field":                p.Field,
+		"index":                indexName,
+		"auto_index":           p.AutoIndex,
+		"release_and_load":     p.ReleaseAndLoad,
+		"confirm_default_load": p.ConfirmDefaultLoad,
+		"source_params":        sourceParams,
+		"create_params":        createParams,
+		"dry_run":              false,
+	}, nil
+}
+
+func loadCollectionAndWait(ctx context.Context, rc *RunContext, collection string) error {
+	loadTask, err := rc.Client.LoadCollection(ctx, milvusclient.NewLoadCollectionOption(collection))
+	if err != nil {
+		return fmt.Errorf("start loading collection %q: %w", collection, err)
+	}
+	if err := loadTask.Await(ctx); err != nil {
+		return fmt.Errorf("wait for collection %q to load: %w", collection, err)
+	}
+	return nil
+}
+
+// reloadCollectionAfterFailure submits recovery with a context detached from
+// command cancellation. If the command is still active, it also waits for the
+// load to finish. After cancellation, a successful submission is sufficient:
+// Milvus continues the accepted LoadCollection request asynchronously.
+func reloadCollectionAfterFailure(ctx context.Context, rc *RunContext, collection string) error {
+	recoveryCtx, cancel := newRecoveryLoadContext(ctx)
+	loadTask, err := rc.Client.LoadCollection(recoveryCtx, milvusclient.NewLoadCollectionOption(collection))
+	cancel()
+	if err != nil {
+		return fmt.Errorf("start loading collection %q: %w", collection, err)
+	}
+
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err := loadTask.Await(ctx); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("wait for collection %q to load: %w", collection, err)
+	}
+	return nil
+}
+
+func newRecoveryLoadContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), recreateIndexRecoveryLoadTimeout)
+}
+
+func buildRecreateIndexParams(sourceParams map[string]string, autoIndex bool) (map[string]string, error) {
+	if !autoIndex {
+		if len(sourceParams) == 0 {
+			return nil, fmt.Errorf("has no user index parameters; refusing to drop it")
+		}
+		if _, ok := sourceParams[index.IndexTypeKey]; !ok {
+			return nil, fmt.Errorf("has no %q parameter; refusing to drop it", index.IndexTypeKey)
+		}
+		return maps.Clone(sourceParams), nil
+	}
+
+	createParams := map[string]string{
+		index.IndexTypeKey: string(index.AUTOINDEX),
+	}
+	if metricType := strings.TrimSpace(sourceParams[index.MetricTypeKey]); metricType != "" {
+		createParams[index.MetricTypeKey] = metricType
+	}
+	return createParams, nil
+}
+
+// recreatedIndexParamsMatch allows Milvus to add its default metric when an
+// AUTOINDEX request omitted metric_type, but rejects any other unexpected key.
+func recreatedIndexParamsMatch(expected, actual map[string]string, autoIndex bool) bool {
+	if !autoIndex || expected[index.MetricTypeKey] != "" {
+		return maps.Equal(expected, actual)
+	}
+
+	if actual[index.IndexTypeKey] != string(index.AUTOINDEX) {
+		return false
+	}
+	for key := range actual {
+		if key != index.IndexTypeKey && key != index.MetricTypeKey {
+			return false
+		}
+	}
+	return true
+}
+
+// legacyIndexParamsWarning detects the fallback representation returned when
+// legacy index metadata has no UserIndexParams. In that case DescribeIndex
+// exposes AUTOINDEX plus metric_type and cannot recover the physical params.
+func legacyIndexParamsWarning(sourceParams map[string]string, autoIndex bool) string {
+	if autoIndex || !strings.EqualFold(strings.TrimSpace(sourceParams[index.IndexTypeKey]), string(index.AUTOINDEX)) {
+		return ""
+	}
+	for key := range sourceParams {
+		if key != index.IndexTypeKey && key != index.MetricTypeKey {
+			return ""
+		}
+	}
+	return "DescribeIndex returned only AUTOINDEX user parameters; the public API cannot distinguish a genuine " +
+		"AUTOINDEX from legacy metadata with missing user parameters, so the original physical index parameters " +
+		"may not be recoverable; verify the raw index metadata before executing"
+}
+
+func defaultLoadBehaviorWarning(releaseAndLoad bool) string {
+	if !releaseAndLoad {
+		return ""
+	}
+	return "--release-and-load uses server-default LoadCollection settings for both the normal reload and " +
+		"failure recovery; it does not preserve the previous replica count, resource groups, load fields, or " +
+		"skip-dynamic-field setting; confirm this load behavior with --confirm-default-load before executing with --run"
+}
+
+func loadedCollectionWarning(state entity.LoadStateCode, releaseAndLoad bool) string {
+	if releaseAndLoad || state == entity.LoadStateNotLoad {
+		return ""
+	}
+	return fmt.Sprintf("collection is %s; execution requires a manual release or "+
+		"--release-and-load --confirm-default-load", formatLoadState(state))
+}
+
+func recreateIndexDryRunNextStep(state entity.LoadStateCode, releaseAndLoad, confirmLoad bool) string {
+	switch {
+	case !releaseAndLoad && state != entity.LoadStateNotLoad:
+		return "release the collection manually, or add --release-and-load --confirm-default-load; then rerun with --run"
+	case releaseAndLoad && !confirmLoad:
+		return "after accepting the server-default load behavior, rerun with --run --confirm-default-load"
+	default:
+		return "after reviewing the plan and warnings, rerun with --run"
+	}
+}
+
+func selectIndexName(indexNames []string, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	names := append([]string(nil), indexNames...)
+	sort.Strings(names)
+
+	if requested != "" {
+		for _, name := range names {
+			if name == requested {
+				return name, nil
+			}
+		}
+		return "", fmt.Errorf("index %q does not belong to the requested field; available indexes: %v", requested, names)
+	}
+
+	switch len(names) {
+	case 0:
+		return "", fmt.Errorf("no index found for the requested field")
+	case 1:
+		return names[0], nil
+	default:
+		return "", fmt.Errorf("multiple indexes found for the requested field; specify --index-name from %v", names)
+	}
+}
+
+func formatIndexParams(params map[string]string) string {
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Sprintf("%v", params)
+	}
+	return string(encoded)
+}
+
+func formatLoadState(state entity.LoadStateCode) string {
+	switch state {
+	case entity.LoadStateLoading:
+		return "Loading"
+	case entity.LoadStateLoaded:
+		return "Loaded"
+	case entity.LoadStateUnloading:
+		return "Unloading"
+	case entity.LoadStateNotLoad:
+		return "NotLoad"
+	default:
+		return fmt.Sprintf("Unknown(%d)", state)
+	}
+}
+
+func init() {
+	Register("recreate_index", func() Op { return &RecreateIndexParams{} })
+}

--- a/internal/ops/recreate_index_test.go
+++ b/internal/ops/recreate_index_test.go
@@ -1,0 +1,223 @@
+package ops
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+)
+
+func TestNewRecoveryLoadContextIgnoresParentCancellation(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+
+	recoveryCtx, cancelRecovery := newRecoveryLoadContext(parent)
+	defer cancelRecovery()
+
+	require.NoError(t, recoveryCtx.Err())
+	deadline, ok := recoveryCtx.Deadline()
+	require.True(t, ok)
+	remaining := time.Until(deadline)
+	assert.Positive(t, remaining)
+	assert.LessOrEqual(t, remaining, recreateIndexRecoveryLoadTimeout)
+}
+
+func TestBuildRecreateIndexParams(t *testing.T) {
+	sourceParams := map[string]string{
+		index.IndexTypeKey:  "HNSW",
+		index.MetricTypeKey: "COSINE",
+		"M":                 "32",
+		"efConstruction":    "360",
+		"mmap.enabled":      "true",
+	}
+
+	t.Run("preserve current params", func(t *testing.T) {
+		params, err := buildRecreateIndexParams(sourceParams, false)
+		require.NoError(t, err)
+		assert.Equal(t, sourceParams, params)
+
+		params["M"] = "64"
+		assert.Equal(t, "32", sourceParams["M"])
+	})
+
+	t.Run("convert to auto index", func(t *testing.T) {
+		params, err := buildRecreateIndexParams(sourceParams, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			index.IndexTypeKey:  string(index.AUTOINDEX),
+			index.MetricTypeKey: "COSINE",
+		}, params)
+	})
+
+	t.Run("convert without metric type", func(t *testing.T) {
+		params, err := buildRecreateIndexParams(map[string]string{
+			index.IndexTypeKey: "INVERTED",
+		}, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			index.IndexTypeKey: string(index.AUTOINDEX),
+		}, params)
+	})
+
+	t.Run("convert empty params to auto index", func(t *testing.T) {
+		params, err := buildRecreateIndexParams(nil, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			index.IndexTypeKey: string(index.AUTOINDEX),
+		}, params)
+	})
+
+	t.Run("reject empty params in preserve mode", func(t *testing.T) {
+		_, err := buildRecreateIndexParams(nil, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no user index parameters")
+	})
+
+	t.Run("reject missing index type in preserve mode", func(t *testing.T) {
+		_, err := buildRecreateIndexParams(map[string]string{
+			index.MetricTypeKey: "L2",
+		}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), index.IndexTypeKey)
+	})
+}
+
+func TestRecreatedIndexParamsMatch(t *testing.T) {
+	autoIndexParams := map[string]string{
+		index.IndexTypeKey: string(index.AUTOINDEX),
+	}
+
+	assert.True(t, recreatedIndexParamsMatch(autoIndexParams, autoIndexParams, true))
+	assert.True(t, recreatedIndexParamsMatch(autoIndexParams, map[string]string{
+		index.IndexTypeKey:  string(index.AUTOINDEX),
+		index.MetricTypeKey: "L2",
+	}, true))
+	assert.False(t, recreatedIndexParamsMatch(autoIndexParams, map[string]string{
+		index.IndexTypeKey: "HNSW",
+	}, true))
+	assert.False(t, recreatedIndexParamsMatch(autoIndexParams, map[string]string{
+		index.IndexTypeKey: string(index.AUTOINDEX),
+		"M":                "32",
+	}, true))
+	assert.False(t, recreatedIndexParamsMatch(autoIndexParams, map[string]string{
+		index.IndexTypeKey:  string(index.AUTOINDEX),
+		index.MetricTypeKey: "L2",
+	}, false))
+}
+
+func TestLegacyIndexParamsWarning(t *testing.T) {
+	ambiguousParams := map[string]string{
+		index.IndexTypeKey:  string(index.AUTOINDEX),
+		index.MetricTypeKey: "L2",
+	}
+
+	assert.Contains(t, legacyIndexParamsWarning(ambiguousParams, false), "cannot distinguish")
+	assert.Empty(t, legacyIndexParamsWarning(ambiguousParams, true))
+	assert.Empty(t, legacyIndexParamsWarning(map[string]string{
+		index.IndexTypeKey:  "HNSW",
+		index.MetricTypeKey: "L2",
+	}, false))
+	assert.Empty(t, legacyIndexParamsWarning(map[string]string{
+		index.IndexTypeKey:  string(index.AUTOINDEX),
+		index.MetricTypeKey: "L2",
+		"mmap.enabled":      "true",
+	}, false))
+}
+
+func TestDefaultLoadBehaviorWarning(t *testing.T) {
+	warning := defaultLoadBehaviorWarning(true)
+	assert.Contains(t, warning, "server-default LoadCollection settings")
+	assert.Contains(t, warning, "replica count")
+	assert.Contains(t, warning, "resource groups")
+	assert.Contains(t, warning, "--confirm-default-load")
+	assert.Contains(t, warning, "before executing with --run")
+	assert.Empty(t, defaultLoadBehaviorWarning(false))
+}
+
+func TestLoadedCollectionWarning(t *testing.T) {
+	assert.Contains(t, loadedCollectionWarning(entity.LoadStateLoaded, false), "--release-and-load")
+	assert.Empty(t, loadedCollectionWarning(entity.LoadStateNotLoad, false))
+	assert.Empty(t, loadedCollectionWarning(entity.LoadStateLoaded, true))
+}
+
+func TestRecreateIndexDryRunNextStep(t *testing.T) {
+	assert.Contains(t,
+		recreateIndexDryRunNextStep(entity.LoadStateLoaded, false, false),
+		"--release-and-load --confirm-default-load",
+	)
+	assert.Contains(t,
+		recreateIndexDryRunNextStep(entity.LoadStateLoaded, true, false),
+		"--run --confirm-default-load",
+	)
+	assert.Equal(t,
+		"after reviewing the plan and warnings, rerun with --run",
+		recreateIndexDryRunNextStep(entity.LoadStateNotLoad, false, false),
+	)
+}
+
+func TestSelectIndexName(t *testing.T) {
+	t.Run("single index", func(t *testing.T) {
+		name, err := selectIndexName([]string{"vector_idx"}, "")
+		require.NoError(t, err)
+		assert.Equal(t, "vector_idx", name)
+	})
+
+	t.Run("explicit index", func(t *testing.T) {
+		name, err := selectIndexName([]string{"scalar_idx", "vector_idx"}, "vector_idx")
+		require.NoError(t, err)
+		assert.Equal(t, "vector_idx", name)
+	})
+
+	t.Run("missing index", func(t *testing.T) {
+		_, err := selectIndexName(nil, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no index found")
+	})
+
+	t.Run("ambiguous indexes", func(t *testing.T) {
+		_, err := selectIndexName([]string{"z_idx", "a_idx"}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "[a_idx z_idx]")
+	})
+
+	t.Run("explicit index not on field", func(t *testing.T) {
+		_, err := selectIndexName([]string{"vector_idx"}, "other_idx")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong")
+	})
+}
+
+func TestFormatIndexParams(t *testing.T) {
+	assert.Equal(t,
+		`{"index_type":"AUTOINDEX","metric_type":"COSINE"}`,
+		formatIndexParams(map[string]string{
+			"metric_type": "COSINE",
+			"index_type":  "AUTOINDEX",
+		}),
+	)
+}
+
+func TestFormatLoadState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state entity.LoadStateCode
+		want  string
+	}{
+		{name: "loading", state: entity.LoadStateLoading, want: "Loading"},
+		{name: "loaded", state: entity.LoadStateLoaded, want: "Loaded"},
+		{name: "unloading", state: entity.LoadStateUnloading, want: "Unloading"},
+		{name: "not loaded", state: entity.LoadStateNotLoad, want: "NotLoad"},
+		{name: "unknown", state: entity.LoadStateCode(99), want: "Unknown(99)"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, formatLoadState(test.state))
+		})
+	}
+}

--- a/states/autocomplete/auto_complete.go
+++ b/states/autocomplete/auto_complete.go
@@ -25,6 +25,7 @@ type acCandidate interface {
 // cmdCandidate wraps cobra.Command as acCandidate.
 type cmdCandidate struct {
 	*cobra.Command
+	ctx ValueSuggestionContext
 }
 
 func (c *cmdCandidate) cmdName() string {
@@ -70,10 +71,10 @@ func (c *cmdCandidate) NextCandidates(_ cComp, _ []acCandidate) []acCandidate {
 
 	result := make([]acCandidate, 0, len(cmdFlags)+len(subCommands))
 	for _, cmd := range subCommands {
-		result = append(result, &cmdCandidate{Command: cmd})
+		result = append(result, &cmdCandidate{Command: cmd, ctx: c.ctx})
 	}
 	for _, flag := range cmdFlags {
-		result = append(result, &flagCandidate{Flag: flag})
+		result = append(result, &flagCandidate{Flag: flag, ctx: c.ctx})
 	}
 	result = append(result, c.args()...)
 
@@ -91,6 +92,7 @@ func (c *cmdCandidate) Suggest(target cComp) map[string]string {
 // flagCandidate wraps pflag.Flag as acCandidate.
 type flagCandidate struct {
 	*pflag.Flag
+	ctx ValueSuggestionContext
 }
 
 // Match implements acCandidate.
@@ -113,7 +115,7 @@ func (c *flagCandidate) Suggest(target cComp) map[string]string {
 		isEqualsForm := strings.Contains(target.raw, "=")
 		if target.cValue != "" || isEqualsForm {
 			result := make(map[string]string)
-			for _, v := range getValueSuggestions(c.Flag, target.cValue) {
+			for _, v := range getValueSuggestions(c.Flag, target.cValue, c.ctx) {
 				if isEqualsForm {
 					// Include --flag= prefix so go-prompt replaces the whole word correctly
 					result[fmt.Sprintf("--%s=%s", c.Name, v)] = ""
@@ -142,6 +144,7 @@ func (c *flagCandidate) NextCandidates(matched cComp, current []acCandidate) []a
 		return []acCandidate{&flagValueCandidate{
 			flag:               c.Flag,
 			previousCandidates: current,
+			ctx:                c.ctx,
 		}}
 	}
 	return current
@@ -152,6 +155,7 @@ func (c *flagCandidate) NextCandidates(matched cComp, current []acCandidate) []a
 type flagValueCandidate struct {
 	flag               *pflag.Flag
 	previousCandidates []acCandidate
+	ctx                ValueSuggestionContext
 }
 
 // Match implements acCandidate. Matches any command-type input (flag values appear as bare words).
@@ -167,7 +171,7 @@ func (c *flagValueCandidate) NextCandidates(_ cComp, _ []acCandidate) []acCandid
 // Suggest implements acCandidate. Returns value suggestions filtered by prefix.
 func (c *flagValueCandidate) Suggest(target cComp) map[string]string {
 	result := make(map[string]string)
-	for _, v := range getValueSuggestions(c.flag, target.cTag) {
+	for _, v := range getValueSuggestions(c.flag, target.cTag, c.ctx) {
 		result[v] = ""
 	}
 	return result
@@ -186,7 +190,7 @@ func hasValueSuggestions(flag *pflag.Flag) bool {
 }
 
 // getValueSuggestions returns value suggestions for a flag filtered by prefix.
-func getValueSuggestions(flag *pflag.Flag, partial string) []string {
+func getValueSuggestions(flag *pflag.Flag, partial string, ctx ValueSuggestionContext) []string {
 	if values, ok := flag.Annotations["values"]; ok {
 		var result []string
 		for _, v := range values {
@@ -198,6 +202,9 @@ func getValueSuggestions(flag *pflag.Flag, partial string) []string {
 	}
 	if names, ok := flag.Annotations["valuesSuggester"]; ok && len(names) > 0 {
 		if s, ok := GetValueSuggester(names[0]); ok {
+			if contextual, ok := s.(ContextValueSuggester); ok {
+				return contextual.SuggestWithContext(partial, ctx)
+			}
 			return s.Suggest(partial)
 		}
 	}
@@ -212,6 +219,7 @@ func SuggestInputCommands(input string, commands []*cobra.Command) map[string]st
 }
 
 func findCmdSuggestions(comps []cComp, commands []*cobra.Command) map[string]string {
+	ctx := ValueSuggestionContext{FlagValues: collectFlagValues(comps)}
 	// no suggestion if input is empty
 	if len(comps) == 0 {
 		return map[string]string{}
@@ -220,7 +228,7 @@ func findCmdSuggestions(comps []cComp, commands []*cobra.Command) map[string]str
 	// wraps commands into cmdCandidates
 	var candidates []acCandidate
 	for _, cmd := range commands {
-		candidates = append(candidates, &cmdCandidate{Command: cmd})
+		candidates = append(candidates, &cmdCandidate{Command: cmd, ctx: ctx})
 	}
 
 	if debugSuggestion {
@@ -267,6 +275,16 @@ loop:
 	}
 
 	return result
+}
+
+func collectFlagValues(comps []cComp) map[string]string {
+	values := make(map[string]string)
+	for _, comp := range comps {
+		if comp.cType == cmdCompFlag && comp.cTag != "" {
+			values[comp.cTag] = comp.cValue
+		}
+	}
+	return values
 }
 
 func printCandidates(candidates []acCandidate) {

--- a/states/autocomplete/auto_complete_test.go
+++ b/states/autocomplete/auto_complete_test.go
@@ -2,6 +2,7 @@ package autocomplete
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -132,6 +133,41 @@ func TestNamedValueSuggester(t *testing.T) {
 		result := SuggestInputCommands("paint --color r", commands)
 		assert.Contains(t, result, "red")
 	})
+}
+
+func TestContextValueSuggester(t *testing.T) {
+	RegisterValueSuggester("test-fields", ContextValueSuggestFunc(func(partial string, ctx ValueSuggestionContext) []string {
+		if ctx.FlagValues["collection"] != "books" {
+			return nil
+		}
+		values := []string{"book_id", "book_vector"}
+		var result []string
+		for _, value := range values {
+			if strings.HasPrefix(value, partial) {
+				result = append(result, value)
+			}
+		}
+		return result
+	}))
+	defer UnregisterValueSuggester("test-fields")
+
+	recreateCmd := &cobra.Command{Use: "recreate"}
+	indexCmd := makeCmd("index", func(fs *pflag.FlagSet) {
+		fs.Bool("auto-index", false, "use AUTOINDEX")
+		fs.String("collection", "", "collection name")
+		fs.String("field", "", "field name")
+		_ = fs.SetAnnotation("field", "valuesSuggester", []string{"test-fields"})
+	})
+	recreateCmd.AddCommand(indexCmd)
+
+	result := SuggestInputCommands(
+		"recreate index --auto-index --collection books --field book_",
+		[]*cobra.Command{recreateCmd},
+	)
+	assert.Equal(t, map[string]string{
+		"book_id":     "",
+		"book_vector": "",
+	}, result)
 }
 
 func TestValueSuggesterRegistry(t *testing.T) {

--- a/states/autocomplete/input.go
+++ b/states/autocomplete/input.go
@@ -1,6 +1,7 @@
 package autocomplete
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
@@ -22,9 +23,13 @@ func parseInput(input string) inputResult {
 		// next part is flag value
 		// just set last comp cValue
 		if currentFlagValue {
-			comps[len(comps)-1].cValue = part
+			if !strings.HasPrefix(part, "-") || isNegativeNumber(part) {
+				comps[len(comps)-1].cValue = part
+				currentFlagValue = false
+				continue
+			}
+			// A new flag means the previous flag was boolean or omitted its value.
 			currentFlagValue = false
-			continue
 		}
 		// is flag
 		if strings.HasPrefix(part, "-") {
@@ -76,4 +81,12 @@ func parseInput(input string) inputResult {
 		parts: comps,
 		state: is,
 	}
+}
+
+func isNegativeNumber(value string) bool {
+	if !strings.HasPrefix(value, "-") {
+		return false
+	}
+	_, err := strconv.ParseFloat(value, 64)
+	return err == nil
 }

--- a/states/autocomplete/suggester.go
+++ b/states/autocomplete/suggester.go
@@ -13,6 +13,33 @@ type ValueSuggestFunc func(partial string) []string
 // Suggest implements ValueSuggester.
 func (f ValueSuggestFunc) Suggest(partial string) []string { return f(partial) }
 
+// ValueSuggestionContext contains values already supplied for sibling flags.
+// Context-aware suggesters can use them to resolve dependent resources, such
+// as fields within the collection selected by --collection.
+type ValueSuggestionContext struct {
+	FlagValues map[string]string
+}
+
+// ContextValueSuggester extends ValueSuggester with sibling flag values while
+// preserving compatibility with existing prefix-only suggesters.
+type ContextValueSuggester interface {
+	ValueSuggester
+	SuggestWithContext(partial string, ctx ValueSuggestionContext) []string
+}
+
+// ContextValueSuggestFunc adapts a context-aware suggestion function.
+type ContextValueSuggestFunc func(partial string, ctx ValueSuggestionContext) []string
+
+// Suggest implements ValueSuggester for callers without suggestion context.
+func (f ContextValueSuggestFunc) Suggest(partial string) []string {
+	return f(partial, ValueSuggestionContext{})
+}
+
+// SuggestWithContext implements ContextValueSuggester.
+func (f ContextValueSuggestFunc) SuggestWithContext(partial string, ctx ValueSuggestionContext) []string {
+	return f(partial, ctx)
+}
+
 var (
 	suggestRegistry = map[string]ValueSuggester{}
 	mutex           sync.RWMutex

--- a/states/milvusctl/connect.go
+++ b/states/milvusctl/connect.go
@@ -3,9 +3,20 @@ package milvusctl
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/states/autocomplete"
 	"github.com/milvus-io/milvus/client/v3/milvusclient"
+)
+
+const (
+	milvusCollectionSuggester = "milvus-collection"
+	milvusFieldSuggester      = "milvus-field"
+	milvusIndexSuggester      = "milvus-index"
+	milvusSuggestionTimeout   = 2 * time.Second
 )
 
 type ConnectMilvusParam struct {
@@ -52,6 +63,9 @@ func (s *MilvusctlState) Label() string {
 }
 
 func (s *MilvusctlState) Close() {
+	autocomplete.UnregisterValueSuggester(milvusCollectionSuggester)
+	autocomplete.UnregisterValueSuggester(milvusFieldSuggester)
+	autocomplete.UnregisterValueSuggester(milvusIndexSuggester)
 	if s.client != nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -64,4 +78,78 @@ func (s *MilvusctlState) SetupCommands() {
 
 	s.MergeFunctionCommands(cmd, s)
 	s.UpdateState(cmd, s, s.SetupCommands)
+
+	autocomplete.RegisterValueSuggester(milvusCollectionSuggester,
+		autocomplete.ContextValueSuggestFunc(s.suggestCollections))
+	autocomplete.RegisterValueSuggester(milvusFieldSuggester,
+		autocomplete.ContextValueSuggestFunc(s.suggestFields))
+	autocomplete.RegisterValueSuggester(milvusIndexSuggester,
+		autocomplete.ContextValueSuggestFunc(s.suggestIndexes))
+}
+
+func (s *MilvusctlState) suggestCollections(partial string, _ autocomplete.ValueSuggestionContext) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), milvusSuggestionTimeout)
+	defer cancel()
+	names, err := s.client.ListCollections(ctx, milvusclient.NewListCollectionOption())
+	if err != nil {
+		return nil
+	}
+	return filterMilvusSuggestions(names, partial)
+}
+
+func (s *MilvusctlState) suggestFields(partial string, suggestCtx autocomplete.ValueSuggestionContext) []string {
+	collection := strings.TrimSpace(suggestCtx.FlagValues["collection"])
+	if collection == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), milvusSuggestionTimeout)
+	defer cancel()
+	coll, err := s.client.DescribeCollection(ctx, milvusclient.NewDescribeCollectionOption(collection))
+	if err != nil || coll.Schema == nil {
+		return nil
+	}
+	names := make([]string, 0, len(coll.Schema.Fields))
+	for _, field := range coll.Schema.Fields {
+		if field != nil {
+			names = append(names, field.Name)
+		}
+	}
+	return filterMilvusSuggestions(names, partial)
+}
+
+func (s *MilvusctlState) suggestIndexes(partial string, suggestCtx autocomplete.ValueSuggestionContext) []string {
+	collection := strings.TrimSpace(suggestCtx.FlagValues["collection"])
+	if collection == "" {
+		return nil
+	}
+
+	option := milvusclient.NewListIndexOption(collection)
+	if field := strings.TrimSpace(suggestCtx.FlagValues["field"]); field != "" {
+		option = option.WithFieldName(field)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), milvusSuggestionTimeout)
+	defer cancel()
+	names, err := s.client.ListIndexes(ctx, option)
+	if err != nil {
+		return nil
+	}
+	return filterMilvusSuggestions(names, partial)
+}
+
+func filterMilvusSuggestions(values []string, partial string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if !strings.HasPrefix(value, partial) {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }

--- a/states/milvusctl/data.go
+++ b/states/milvusctl/data.go
@@ -133,3 +133,31 @@ func (s *MilvusctlState) CreateIndexCommand(ctx context.Context, p *CreateIndexP
 		},
 	})
 }
+
+// -----------------------------------------------------------------------------
+// recreate index
+
+type RecreateIndexParam struct {
+	framework.ExecutionParam `use:"recreate index" desc:"drop and recreate a field index (dry-run by default)"`
+	Collection               string `name:"collection" default:"" desc:"collection name" valuesSuggester:"milvus-collection"`
+	Field                    string `name:"field" default:"" desc:"field name" valuesSuggester:"milvus-field"`
+	IndexName                string `name:"index-name" default:"" desc:"index name (required when the field has multiple indexes)" valuesSuggester:"milvus-index"`
+	AutoIndex                bool   `name:"auto-index" default:"false" desc:"recreate with AUTOINDEX and preserve only the current metric type"`
+	ReleaseAndLoad           bool   `name:"release-and-load" default:"false" desc:"release before dropping the index and reload with server-default settings after recreation"`
+	ConfirmDefaultLoad       bool   `name:"confirm-default-load" default:"false" desc:"acknowledge that reload uses server-default settings"`
+}
+
+func (s *MilvusctlState) RecreateIndexCommand(ctx context.Context, p *RecreateIndexParam) error {
+	if p.Collection == "" || p.Field == "" {
+		return fmt.Errorf("--collection and --field are required")
+	}
+	return s.executeOp(ctx, &ops.RecreateIndexParams{
+		Collection:         p.Collection,
+		Field:              p.Field,
+		IndexName:          p.IndexName,
+		AutoIndex:          p.AutoIndex,
+		ReleaseAndLoad:     p.ReleaseAndLoad,
+		ConfirmDefaultLoad: p.ConfirmDefaultLoad,
+		DryRun:             p.IsDryRun(),
+	})
+}


### PR DESCRIPTION
issue: #261

## What changed

- Add a dry-run-first `recreate index` command for a collection field.
- Select the existing index explicitly when a field has multiple indexes.
- Preserve the original index name and reported user parameters by default,
  or recreate it with AUTOINDEX through `--auto-index`.
- Optionally release before dropping and reload after recreation through
  `--release-and-load`.
- Add context-aware completion for collection, field, and index names.

## Safety behavior

- Refuse destructive execution while the collection is loaded unless
  release/reload was explicitly requested.
- Require `--confirm-default-load` because automatic reload uses server-default
  settings and cannot preserve the previous replica count, resource groups,
  load fields, or dynamic-field behavior.
- Warn during dry-run when `DescribeIndex` exposes only legacy fallback
  parameters that might not reproduce the original physical index.
- Attempt to reload a released collection if index recreation fails.
- Verify the recreated index parameters before reporting success.

## Validation

- `gofmt` on all changed Go files
- `git diff --check`
- `go vet ./states/autocomplete ./internal/ops ./states/milvusctl`
- `go build ./states/autocomplete ./internal/ops ./states/milvusctl`
- `go build -o /tmp/birdwatcher-recreate-index cmd/birdwatcher/main.go`

Unit tests were not run because the local Milvus binary required by the
mandatory reset workflow is unavailable.
