### PR TITLE
enhance: support ARN auth for external collection storage reads

### DIFF
--- a/docs/plans/2026-08-31-external-collection-arn-and-mixed-manifest.md
+++ b/docs/plans/2026-08-31-external-collection-arn-and-mixed-manifest.md
@@ -1,0 +1,149 @@
+# External Collection Object Store Credential Passing and Mixed Manifest Support
+
+**Goal:** Fix birdwatcher's `show manifest` / `scan-binlog` access to external collection data files. The ARN information required by external collections (`role_arn`, `external_id`, `session_name`, AK/SK, etc.) does **not** come from Milvus component configuration; it is attached to the collection schema (`external_source` URI + the `extfs` field of the `external_spec` JSON). This design unifies how these credentials are passed through and supports the mixed scenario where a single manifest contains both external data files and internal function-output files (e.g. sparse vectors generated from a varchar column).
+
+**Architecture:** Add a shared layer `states/ossutil/external.go` encapsulating external spec/source parsing, external object store client construction, and a **per-file** `ManifestPathResolver`. The three commands `show manifest`, `scan-binlog`, and `inspect-parquet --external` reuse this layer: they read the ARN credentials from the collection to build the external store, then route each file in the manifest to the internal or external store through the resolver.
+
+**Tech stack:** Go, minio-go/v7, Arrow/Parquet, Birdwatcher states/ossutil, Milvus `schemapb` / `etcdpb`.
+
+---
+
+## Background and Problem
+
+### Credential source mismatch
+
+- `show manifest` (`states/show_manifest.go`) and `scan-binlog` (`states/scan_binlog.go`) originally both created their object store client via `s.GetObjectStore(...)` (`states/instance.go:151`), which ultimately goes through `ossutil.GetObjectStoreFromCfg` (`states/ossutil/minio_cfg.go:116`). That pulls component configuration over gRPC and reads keys such as `minio.rolearn` / `minio.externalid` from **Milvus's own minio configuration**.
+- However, external collection data files live in the user's external bucket, and the credentials to access them (`role_arn`, `external_id`, `session_name`, AK/SK, `use_iam`, etc.) **exist only in the collection schema**:
+  - `schema.ExternalSource`: the external source URI, e.g. `oss://oss-cn-hangzhou.aliyuncs.com/bucket/root/...`
+  - `schema.ExternalSpec`: a JSON string, e.g. `{"format":"parquet","extfs":{"role_arn":"...","external_id":"...",...}}`
+- Consequently the original implementation cannot access the real data files of an external collection with the correct credentials.
+
+### Mixed manifest scenario
+
+External collections may declare functions (BM25 / embedding). Their output columns (e.g. sparse vectors) are computed by DataNode `ExecuteFunctionsForSegment` (milvus `internal/datanode/external/function_executor.go`) and written to **Milvus internal storage** (`{rootPath}/files/insert_log/.../_data/...`), then appended to the same manifest as a new column group. The result is a single manifest that contains both:
+- **External files**: absolute URIs (e.g. `s3://bucket/data.parquet`, `oss://endpoint/bucket/...`), requiring external bucket credentials;
+- **Internal files**: relative paths (e.g. `abc.parquet`, `bm25.3/0`), requiring Milvus configuration credentials.
+
+A design that routes "everything through the external store" will necessarily fail on mixed manifests.
+
+---
+
+## Key Facts (verified against milvus / milvus-storage code)
+
+1. **The manifest file itself always lives in Milvus internal storage.**
+   `createManifestForSegment` (milvus `internal/datanode/external/task_update.go:1062`) writes `{rootPath}/files/insert_log/{coll}/{part}/{seg}/_metadata/manifest-{ver}.avro`; `MarshalManifestPath` (`internal/storagev2/packed/ffi_common.go:355`) stores that base path into the `base_path` field of the segment's `ManifestPath` JSON.
+
+2. **Path storage/restore rules inside the manifest** (milvus-storage `cpp/src/manifest.cpp`)
+   - On write, `toRelativePaths(base_path)`: internal files (prefixed by `{base_path}/_data|_delta|_stats|_index|../lobs`) are trimmed to relative paths; external files keep their absolute URI as-is.
+   - On read, `ToAbsolutePaths(base_path)`: relative paths without a scheme are re-joined to `{base_path}/<dir>`; absolute URIs with a scheme are returned unchanged.
+
+3. **milvus-storage routes the storage backend per file** (`cpp/src/filesystem/fs.cpp`, `FilesystemCache::resolve_config`)
+   - Absolute URI (has a scheme) → matched against `extfs.*` properties by address+bucket → external FS (carrying ARN/external_id etc.);
+   - Path without a scheme (relative) → default `fs.*` → internal Milvus storage.
+   - In other words: **mixed manifests are natively supported; the discriminator is "is it an absolute URI"**.
+
+4. **Function output columns are written to internal storage.**
+   `ExecuteFunctionsForSegment` writes output packed files to `{rootPath}/files/insert_log/.../_data/...`, and BM25 stats to `{base_path}/_stats/bm25.{id}/0` (`function_executor.go:454`).
+
+---
+
+## Design
+
+### Core discriminator
+> **Path contains a scheme (`://`) → external; path is relative (no scheme) → internal.**
+
+This matches milvus-storage's native discriminator and does not depend on schema field mapping.
+
+### Part 1: Shared layer — `states/ossutil/external.go` (new)
+
+**Public API:**
+
+| Symbol | Description |
+| --- | --- |
+| `ExternalSourceSpec` | Parsed external spec; `extfs` keys aligned with milvus `specutil.ExtfsKey*`: `cloud_provider/region/role_arn/session_name/external_id/access_key_id/access_key_value/use_iam/iam_endpoint/bucket_name/storage_type/use_ssl/load_frequency/anonymous/aliyun_role_auth_mode` |
+| `ParseExternalSpec(raw)` | Parses the `schema.ExternalSpec` JSON; only the `parquet` format is supported |
+| `ExternalSourceLocation` | Parsed external source URI: `Scheme/Host/Bucket/RootPath` |
+| `ParseExternalSource(raw)` | Parses the `schema.ExternalSource` URI |
+| `InferCloudProviderFromScheme(scheme)` | Infers `oss/aws/gcp/tencent/huawei` |
+| `NewResolvedExternalObjectStore(ctx, source, spec, skipBucketCheck)` | Builds `*oss.ResolvedObjectStore` + location from external credentials; `RoleARN`/`ExternalID` etc. come from the collection, not configuration |
+| `NewResolvedExternalObjectStoreFromSchema(ctx, externalSource, externalSpec, skipBucketCheck)` | Convenience wrapper |
+| `NewResolvedExternalObjectStoreFromCollection(ctx, collection, skipBucketCheck)` | Builds from a collection model; errors if the collection is not external |
+| `FileBackend` | Enum `FileBackendInternal` / `FileBackendExternal` |
+| `ManifestPathResolver` | Per-file routing: `Resolve(filePath, dirPrefix) (store, key, backend, err)` |
+| `ResolveExternalObjectKey(location, externalFile)` | External file reference (absolute URI / `ROOT_PATH` / relative path) → object key |
+
+**`ManifestPathResolver.Resolve` routing logic:**
+- Contains `://` → `ResolveExternalObjectKey` → external store;
+- Contains `ROOT_PATH` → replaced with `location.RootPath` → external store;
+- Otherwise, relative path → `path.Join(manifestBasePath, dirPrefix, rel)` → internal store.
+- `dirPrefix` is taken per section as `_data` / `_delta` / `_stats` / `_index` / `../lobs`.
+
+### Part 2: `show manifest` (`states/show_manifest.go`)
+
+1. Resolve the collection: from `--collection`, or by looking up `CollectionID` from the first manifest segment.
+2. If `schema.GetExternalSource() != ""`: build the external store via `NewResolvedExternalObjectStoreFromCollection`; the manifest file itself is still read from the internal store (`s.GetObjectStore`).
+3. When printing, annotate every column group / delta / stats / index / lob file with `Backend: internal|external` and the final object key via `ManifestPathResolver.Resolve` (`printManifestWithResolver`).
+4. JSON output mode and non-external collection behavior remain unchanged.
+
+### Part 3: `scan-binlog` (`states/scan_binlog.go` + new `states/scan_binlog_external.go`)
+
+1. Detect an external collection (`isExternalCollection`); if so, build the external store + location.
+2. In `getObject`, for delta logs: when the path is external (`isExternalPath`: contains `://` or `ROOT_PATH`), route through `ResolveExternalObjectKey` to the external store; otherwise use the internal store.
+3. In `workFn`, external segments that have a manifest go through `scanExternalSegment`:
+   - Read the manifest from the internal store;
+   - Iterate column groups, selecting the store per file via the resolver;
+   - Read parquet (Arrow), mapping manifest column names to field IDs (`external_field`, or the field ID string / field name);
+   - Deserialize cells, set the PK, apply the filters (`loEntryFilter`/`deltalogFilter`/`exprFilter`), and feed the `scanTask`.
+   - Segments that are not external / have no manifest keep the original binlog iteration path.
+
+### Part 4: `inspect-parquet --external` (`states/inspect_parquet.go`)
+
+- Remove the local duplicated external parsing / client-construction implementations and delegate to `ossutil` (`parseExternalSpec`/`parseExternalSource`/`newExternalMinioClient`/`resolveExternalObjectKey` become thin wrappers or aliases, keeping existing call sites and tests unchanged).
+- `inspectExternalManifestParquet` switches to `ManifestPathResolver`: external column groups follow the original logic; internal column groups (function outputs) are read from the internal store, supporting per-file display of mixed column groups.
+
+---
+
+## File List
+
+**New files:**
+- `states/ossutil/external.go`
+- `states/ossutil/external_test.go`
+- `states/scan_binlog_external.go`
+
+**Modified files:**
+- `states/show_manifest.go`
+- `states/scan_binlog.go`
+- `states/inspect_parquet.go`
+
+---
+
+## Testing Strategy
+
+- `states/ossutil/external_test.go`:
+  - `ParseExternalSpec` with all `extfs` keys, empty spec, and rejection of an unsupported format;
+  - `ParseExternalSource` URI parsing;
+  - `ResolveExternalObjectKey` for relative path / already-rooted / full URI;
+  - `InferCloudProviderFromScheme`;
+  - **`ManifestPathResolver` mixed manifest**: external absolute URI, external `ROOT_PATH`, internal function-output file (`_data`), internal bm25 stats (`_stats`).
+- The existing external parsing tests in the `states` package's `inspect_parquet_test.go` remain green (preserved via thin wrappers).
+
+## Verification Commands
+
+```bash
+go build ./...
+go test ./states/ossutil/ ./states/
+gofmt -l states/ossutil/external.go states/ossutil/external_test.go states/scan_binlog_external.go states/show_manifest.go states/scan_binlog.go states/inspect_parquet.go
+go vet ./states/ ./states/ossutil/
+```
+
+Note: the repository `.golangci.yml` is in v2 format and cannot be parsed by the golangci-lint binary currently available in this environment (a tool-version mismatch, not a code issue); lint is therefore validated via `go vet` + `gofmt` plus a temporary v1 config. In `go test ./...`, the build failures in `states/etcd/show` and `states/milvusctl` are caused by untracked test files referencing nonexistent fields and are unrelated to this change.
+
+---
+
+## Risks and Compatibility
+
+1. **Non-external collection behavior is unchanged:** the resolver is only enabled when `ExternalSource != ""`; all other paths fully preserve the original logic.
+2. **milvus-table format:** its column group files may reference internal source manifests (property `milvusTableSourceManifestPathProperty`). The current resolver covers most cases via "no scheme = internal"; recognizing the milvus-table-specific property is left for follow-up.
+3. **`LoadFrequency` / auth mode:** when `use_iam`, `anonymous`, and AK/SK are all absent in the external spec, the resolver falls back to the IAM chain; Aliyun `role_arn` defaults to `oidc` (consistent with the existing inspect-parquet behavior).
+4. **LOB files:** the directory prefix is `../lobs`; the relative path up-traversal is normalized by `path.Join`.
+5. **Real cloud dependencies:** unit tests only cover parsing and routing and never issue real object store requests; real connectivity is left to manual verification.

--- a/states/inspect_parquet.go
+++ b/states/inspect_parquet.go
@@ -5,9 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"path"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -23,6 +21,7 @@ import (
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/birdwatcher/states/ossutil"
 	binlogv1 "github.com/milvus-io/birdwatcher/storage/binlog/v1"
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 )
@@ -76,22 +75,12 @@ func parseInspectStorageVersionOption(raw string) (inspectStorageVersionOption, 
 	return inspectStorageVersionOption{mode: inspectStorageVersionOverride, version: version}, nil
 }
 
-type externalSourceSpec struct {
-	Format             string
-	CloudProvider      string
-	Region             string
-	RoleARN            string
-	ExternalID         string
-	AliyunRoleAuthMode string
-	UseSSL             *bool
-}
+// externalSourceSpec is the parsed external collection specification.
+// It is an alias of ossutil.ExternalSourceSpec; kept for compatibility.
+type externalSourceSpec = ossutil.ExternalSourceSpec
 
-type externalSourceLocation struct {
-	Scheme   string
-	Host     string
-	Bucket   string
-	RootPath string
-}
+// externalSourceLocation is the parsed external_source URI.
+type externalSourceLocation = ossutil.ExternalSourceLocation
 
 func (s *InstanceState) InspectParquetCommand(ctx context.Context, p *InspectParquetParam) error {
 	if err := validateInspectParquetParam(p); err != nil {
@@ -321,55 +310,26 @@ func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.Objec
 		fieldFilter = strconv.FormatInt(p.FieldID, 10)
 	}
 
+	resolver := ossutil.NewManifestPathResolver(manifestStore, manifestBasePath, externalStore, location)
+
 	for i, cg := range m.ColumnGroups {
 		if fieldFilter != "" && !slices.Contains(cg.Columns, fieldFilter) {
 			continue
 		}
 		fmt.Printf("\n===== Column Group #%d | columns=%v format=%s =====\n", i, cg.Columns, cg.Format)
 		for _, f := range cg.Files {
-			filePath, err := resolveExternalManifestObjectKey(location, manifestRef.BasePath, f.Path)
+			store, filePath, backend, err := resolver.Resolve(f.Path, "_data")
 			if err != nil {
-				fmt.Printf("failed to resolve external file path %s: %s\n", f.Path, err.Error())
+				fmt.Printf("failed to resolve manifest file path %s: %s\n", f.Path, err.Error())
 				continue
 			}
-			fmt.Printf("\n----- File %s (rows: [%d, %d)) -----\n", filePath, f.StartIndex, f.EndIndex)
-			if err := inspectRemoteParquetObject(ctx, externalStore, filePath, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
+			fmt.Printf("\n----- File %s (rows: [%d, %d)) backend=%s -----\n", filePath, f.StartIndex, f.EndIndex, backend)
+			if err := inspectRemoteParquetObject(ctx, store, filePath, p.MetadataOnly, p.SampleRows, p.ShowRowGroups); err != nil {
 				fmt.Printf("failed to inspect %s: %s\n", filePath, err.Error())
 			}
 		}
 	}
 	return nil
-}
-
-func resolveExternalManifestObjectKey(location externalSourceLocation, manifestBasePath, rawPath string) (string, error) {
-	trimmed := strings.TrimSpace(rawPath)
-	if trimmed == "" {
-		return "", errors.New("manifest file path is empty")
-	}
-	if strings.Contains(trimmed, "://") {
-		return resolveExternalObjectKey(location, trimmed)
-	}
-	if strings.Contains(trimmed, "ROOT_PATH") {
-		replaced := strings.ReplaceAll(trimmed, "ROOT_PATH", location.RootPath)
-		return path.Clean(strings.TrimPrefix(replaced, "/")), nil
-	}
-	trimmed = strings.TrimPrefix(trimmed, "/")
-	if location.RootPath == "" {
-		return path.Clean(trimmed), nil
-	}
-	if trimmed == location.RootPath || strings.HasPrefix(trimmed, location.RootPath+"/") {
-		return path.Clean(trimmed), nil
-	}
-	if manifestBasePath != "" {
-		basePath := strings.TrimPrefix(strings.TrimSpace(manifestBasePath), "/")
-		if basePath != "" {
-			dataPath := path.Join(basePath, "_data", trimmed)
-			if strings.HasPrefix(dataPath, location.RootPath+"/") {
-				return path.Clean(dataPath), nil
-			}
-		}
-	}
-	return path.Join(location.RootPath, trimmed), nil
 }
 
 func inspectV3SegmentParquet(ctx context.Context, store oss.ObjectStore, rootPath string, segment *models.Segment, p *InspectParquetParam) error {
@@ -594,186 +554,37 @@ func arrowCellString(arr arrow.Array, idx int) string {
 }
 
 func parseExternalSpec(raw string) (externalSourceSpec, error) {
-	if strings.TrimSpace(raw) == "" {
-		return externalSourceSpec{}, nil
-	}
-
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return externalSourceSpec{}, errors.Wrap(err, "parse external spec")
-	}
-
-	spec := externalSourceSpec{
-		Format:             readMapString(payload, "format"),
-		AliyunRoleAuthMode: readMapString(payload, "aliyun_role_auth_mode"),
-	}
-	if spec.Format != "" && !strings.EqualFold(spec.Format, "parquet") {
-		return externalSourceSpec{}, errors.Newf("external collection format %s is not supported", spec.Format)
-	}
-
-	extfs, _ := payload["extfs"].(map[string]any)
-	if len(extfs) > 0 {
-		spec.CloudProvider = readMapString(extfs, "cloud_provider")
-		spec.Region = readMapString(extfs, "region")
-		spec.RoleARN = readMapString(extfs, "role_arn")
-		spec.ExternalID = readMapString(extfs, "external_id")
-		if spec.AliyunRoleAuthMode == "" {
-			spec.AliyunRoleAuthMode = readMapString(extfs, "aliyun_role_auth_mode")
-		}
-		if useSSL, ok := readMapBool(extfs, "use_ssl"); ok {
-			spec.UseSSL = &useSSL
-		}
-	}
-	return spec, nil
+	return ossutil.ParseExternalSpec(raw)
 }
 
 func parseExternalSource(raw string) (externalSourceLocation, error) {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return externalSourceLocation{}, errors.Wrap(err, "parse external source")
-	}
-	if u.Scheme == "" || u.Host == "" {
-		return externalSourceLocation{}, errors.Newf("invalid external source: %s", raw)
-	}
-	parts := strings.Split(strings.Trim(strings.TrimSpace(u.Path), "/"), "/")
-	if len(parts) == 0 || parts[0] == "" {
-		return externalSourceLocation{}, errors.Newf("external source %s does not include bucket", raw)
-	}
-	location := externalSourceLocation{
-		Scheme: u.Scheme,
-		Host:   u.Host,
-		Bucket: parts[0],
-	}
-	if len(parts) > 1 {
-		location.RootPath = path.Clean(filepath.Join(parts[1:]...))
-		if location.RootPath == "." {
-			location.RootPath = ""
-		}
-	}
-	return location, nil
+	return ossutil.ParseExternalSource(raw)
 }
 
 func newExternalMinioClient(ctx context.Context, source string, spec externalSourceSpec, skipBucketCheck bool) (*minio.Client, string, string, externalSourceLocation, error) {
-	location, err := parseExternalSource(source)
+	store, location, err := ossutil.NewResolvedExternalObjectStore(ctx, source, spec, skipBucketCheck)
 	if err != nil {
 		return nil, "", "", externalSourceLocation{}, err
 	}
-
-	provider := spec.CloudProvider
-	if provider == "" {
-		provider = inferCloudProviderFromScheme(location.Scheme)
+	client, ok := oss.MinioClientFromObjectStore(store.Store)
+	if !ok {
+		return nil, "", "", externalSourceLocation{}, errors.New("external object store is not backed by minio client")
 	}
-	if provider == "" {
-		return nil, "", "", externalSourceLocation{}, errors.Newf("unsupported external source scheme/provider: %s/%s", location.Scheme, spec.CloudProvider)
-	}
-
-	useSSL := true
-	if spec.UseSSL != nil {
-		useSSL = *spec.UseSSL
-	}
-
-	param := oss.MinioClientParam{
-		Addr:               location.Host,
-		UseSSL:             useSSL,
-		CloudProvider:      provider,
-		Region:             spec.Region,
-		RoleARN:            spec.RoleARN,
-		ExternalID:         spec.ExternalID,
-		BucketName:         location.Bucket,
-		RootPath:           location.RootPath,
-		AliyunRoleAuthMode: spec.AliyunRoleAuthMode,
-	}
-	if provider == oss.CloudProviderAliyun && param.RoleARN != "" && param.AliyunRoleAuthMode == "" {
-		param.AliyunRoleAuthMode = "oidc"
-	}
-	if param.RoleARN == "" {
-		param.UseIAM = true
-	}
-	oss.WithSkipCheckBucket(skipBucketCheck)(&param)
-
-	client, err := oss.NewMinioClient(ctx, param)
-	if err != nil {
-		return nil, "", "", externalSourceLocation{}, err
-	}
-	return client.Client, client.BucketName, client.RootPath, location, nil
+	return client, store.BucketName, store.RootPath, location, nil
 }
 
 func inferCloudProviderFromScheme(scheme string) string {
-	switch strings.ToLower(strings.TrimSpace(scheme)) {
-	case "oss":
-		return oss.CloudProviderAliyun
-	case "s3":
-		return oss.CloudProviderAWS
-	case "gs":
-		return oss.CloudProviderGCP
-	default:
-		return ""
-	}
+	return ossutil.InferCloudProviderFromScheme(scheme)
 }
 
 func resolveExternalObjectKey(location externalSourceLocation, externalFile string) (string, error) {
-	trimmed := strings.TrimSpace(externalFile)
-	if trimmed == "" {
-		return "", errors.New("external file path is empty")
-	}
-	if strings.Contains(trimmed, "ROOT_PATH") {
-		return strings.ReplaceAll(trimmed, "ROOT_PATH", location.RootPath), nil
-	}
-	if strings.Contains(trimmed, "://") {
-		u, err := url.Parse(trimmed)
-		if err != nil {
-			return "", errors.Wrap(err, "parse external file path")
-		}
-		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-		if len(parts) == 0 || parts[0] == "" {
-			return "", errors.Newf("external file path %s does not include bucket", trimmed)
-		}
-		if u.Host != location.Host {
-			return "", errors.Newf("external file host %s does not match external source host %s", u.Host, location.Host)
-		}
-		if parts[0] != location.Bucket {
-			return "", errors.Newf("external file bucket %s does not match external source bucket %s", parts[0], location.Bucket)
-		}
-		trimmed = filepath.Join(parts[1:]...)
-	}
-	trimmed = strings.TrimPrefix(trimmed, "/")
-	if location.RootPath == "" {
-		return path.Clean(trimmed), nil
-	}
-	if trimmed == location.RootPath || strings.HasPrefix(trimmed, location.RootPath+"/") {
-		return path.Clean(trimmed), nil
-	}
-	return path.Join(location.RootPath, trimmed), nil
+	return ossutil.ResolveExternalObjectKey(location, externalFile)
 }
 
 func readMapString(payload map[string]any, key string) string {
-	value, ok := payload[key]
-	if !ok || value == nil {
-		return ""
-	}
-	switch v := value.(type) {
-	case string:
-		return strings.TrimSpace(v)
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+	return ossutil.ReadMapString(payload, key)
 }
 
 func readMapBool(payload map[string]any, key string) (bool, bool) {
-	value, ok := payload[key]
-	if !ok || value == nil {
-		return false, false
-	}
-	switch v := value.(type) {
-	case bool:
-		return v, true
-	case string:
-		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
-		if err != nil {
-			return false, false
-		}
-		return parsed, true
-	default:
-		return false, false
-	}
+	return ossutil.ReadMapBool(payload, key)
 }

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -543,7 +543,7 @@ func ResolveExternalObjectKey(location ExternalSourceLocation, externalFile stri
 			if parts[0] != location.Bucket {
 				return "", fmt.Errorf("external file bucket %s does not match external source bucket %s", parts[0], location.Bucket)
 			}
-			trimmed = strings.Join(parts[1:], "/")
+			trimmed = path.Join(parts[1:]...)
 		}
 	}
 	trimmed = strings.TrimPrefix(trimmed, "/")

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -1,0 +1,401 @@
+package ossutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+)
+
+// ExternalSourceSpec is the parsed external collection specification
+// (schema.ExternalSpec). extfs keys mirror milvus
+// pkg/util/externalspec/specutil.ExtfsKey*.
+type ExternalSourceSpec struct {
+	Format             string
+	CloudProvider      string
+	Region             string
+	RoleARN            string
+	RoleSessionName    string
+	ExternalID         string
+	AliyunRoleAuthMode string
+	AK                 string
+	SK                 string
+	UseIAM             bool
+	IAMEndpoint        string
+	UseSSL             *bool
+	Anonymous          bool
+	BucketName         string
+	StorageType        string
+	LoadFrequency      int
+}
+
+// ExternalSourceLocation is the parsed external_source URI.
+type ExternalSourceLocation struct {
+	Scheme   string
+	Host     string
+	Bucket   string
+	RootPath string
+}
+
+// ParseExternalSpec parses the external spec JSON (schema.ExternalSpec).
+func ParseExternalSpec(raw string) (ExternalSourceSpec, error) {
+	if strings.TrimSpace(raw) == "" {
+		return ExternalSourceSpec{}, nil
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ExternalSourceSpec{}, fmt.Errorf("parse external spec: %w", err)
+	}
+
+	spec := ExternalSourceSpec{
+		Format:             ReadMapString(payload, "format"),
+		AliyunRoleAuthMode: ReadMapString(payload, "aliyun_role_auth_mode"),
+	}
+	if spec.Format != "" && !strings.EqualFold(spec.Format, "parquet") {
+		return ExternalSourceSpec{}, fmt.Errorf("external collection format %s is not supported", spec.Format)
+	}
+
+	extfs, _ := payload["extfs"].(map[string]any)
+	if len(extfs) > 0 {
+		spec.CloudProvider = ReadMapString(extfs, "cloud_provider")
+		spec.Region = ReadMapString(extfs, "region")
+		spec.RoleARN = ReadMapString(extfs, "role_arn")
+		spec.RoleSessionName = ReadMapString(extfs, "session_name")
+		spec.ExternalID = ReadMapString(extfs, "external_id")
+		spec.AK = ReadMapString(extfs, "access_key_id")
+		spec.SK = ReadMapString(extfs, "access_key_value")
+		spec.IAMEndpoint = ReadMapString(extfs, "iam_endpoint")
+		spec.BucketName = ReadMapString(extfs, "bucket_name")
+		spec.StorageType = ReadMapString(extfs, "storage_type")
+		if spec.AliyunRoleAuthMode == "" {
+			spec.AliyunRoleAuthMode = ReadMapString(extfs, "aliyun_role_auth_mode")
+		}
+		if useIAM, ok := ReadMapBool(extfs, "use_iam"); ok {
+			spec.UseIAM = useIAM
+		}
+		if anonymous, ok := ReadMapBool(extfs, "anonymous"); ok {
+			spec.Anonymous = anonymous
+		}
+		if useSSL, ok := ReadMapBool(extfs, "use_ssl"); ok {
+			spec.UseSSL = &useSSL
+		}
+		if lf := ReadMapString(extfs, "load_frequency"); lf != "" {
+			v, err := strconv.Atoi(lf)
+			if err != nil {
+				return ExternalSourceSpec{}, fmt.Errorf("invalid extfs.load_frequency %q: %w", lf, err)
+			}
+			spec.LoadFrequency = v
+		}
+	}
+	return spec, nil
+}
+
+// ParseExternalSource parses the external_source URI.
+func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ExternalSourceLocation{}, fmt.Errorf("parse external source: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return ExternalSourceLocation{}, fmt.Errorf("invalid external source: %s", raw)
+	}
+	parts := strings.Split(strings.Trim(strings.TrimSpace(u.Path), "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return ExternalSourceLocation{}, fmt.Errorf("external source %s does not include bucket", raw)
+	}
+	location := ExternalSourceLocation{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Bucket: parts[0],
+	}
+	if len(parts) > 1 {
+		location.RootPath = path.Clean(filepath.Join(parts[1:]...))
+		if location.RootPath == "." {
+			location.RootPath = ""
+		}
+	}
+	return location, nil
+}
+
+// InferCloudProviderFromScheme infers the cloud provider from the URI scheme.
+func InferCloudProviderFromScheme(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case "oss":
+		return oss.CloudProviderAliyun
+	case "s3", "aws", "minio":
+		return oss.CloudProviderAWS
+	case "gs", "gcs":
+		return oss.CloudProviderGCP
+	case "cos":
+		return oss.CloudProviderTencent
+	case "obs":
+		return oss.CloudProviderHuawei
+	default:
+		return ""
+	}
+}
+
+// NewResolvedExternalObjectStore builds a ResolvedObjectStore from an external
+// source URI and parsed spec. Credentials (role_arn/external_id/AK/SK/...)
+// come from the collection spec, NOT from milvus minio configuration.
+func NewResolvedExternalObjectStore(
+	ctx context.Context,
+	source string,
+	spec ExternalSourceSpec,
+	skipBucketCheck bool,
+) (*oss.ResolvedObjectStore, ExternalSourceLocation, error) {
+	location, err := ParseExternalSource(source)
+	if err != nil {
+		return nil, ExternalSourceLocation{}, err
+	}
+
+	provider := spec.CloudProvider
+	if provider == "" {
+		provider = InferCloudProviderFromScheme(location.Scheme)
+	}
+	if provider == "" {
+		return nil, ExternalSourceLocation{}, fmt.Errorf("unsupported external source scheme/provider: %s/%s", location.Scheme, spec.CloudProvider)
+	}
+
+	useSSL := true
+	if spec.UseSSL != nil {
+		useSSL = *spec.UseSSL
+	}
+
+	bucket := location.Bucket
+	if spec.BucketName != "" {
+		bucket = spec.BucketName
+	}
+
+	param := oss.MinioClientParam{
+		Addr:               location.Host,
+		UseSSL:             useSSL,
+		CloudProvider:      provider,
+		Region:             spec.Region,
+		AK:                 spec.AK,
+		SK:                 spec.SK,
+		UseIAM:             spec.UseIAM,
+		IAMEndpoint:        spec.IAMEndpoint,
+		RoleARN:            spec.RoleARN,
+		RoleSessionName:    spec.RoleSessionName,
+		ExternalID:         spec.ExternalID,
+		LoadFrequency:      spec.LoadFrequency,
+		AliyunRoleAuthMode: spec.AliyunRoleAuthMode,
+		BucketName:         bucket,
+		RootPath:           location.RootPath,
+	}
+	if provider == oss.CloudProviderAliyun && param.RoleARN != "" && param.AliyunRoleAuthMode == "" {
+		param.AliyunRoleAuthMode = "oidc"
+	}
+	// Fallback to IAM chain when no explicit role arn / static key is present.
+	if param.RoleARN == "" && param.AK == "" && param.SK == "" && !spec.Anonymous {
+		param.UseIAM = true
+	}
+	oss.WithSkipCheckBucket(skipBucketCheck)(&param)
+
+	client, err := oss.NewMinioClient(ctx, param)
+	if err != nil {
+		return nil, ExternalSourceLocation{}, err
+	}
+	return &oss.ResolvedObjectStore{
+		Store:      oss.NewMinioObjectStore(client),
+		BucketName: client.BucketName,
+		RootPath:   client.RootPath,
+	}, location, nil
+}
+
+// NewResolvedExternalObjectStoreFromSchema builds an external store from a raw
+// external_source URI + external_spec JSON pair.
+func NewResolvedExternalObjectStoreFromSchema(
+	ctx context.Context,
+	externalSource, externalSpec string,
+	skipBucketCheck bool,
+) (*oss.ResolvedObjectStore, ExternalSourceLocation, error) {
+	if externalSource == "" {
+		return nil, ExternalSourceLocation{}, fmt.Errorf("external source is empty")
+	}
+	spec, err := ParseExternalSpec(externalSpec)
+	if err != nil {
+		return nil, ExternalSourceLocation{}, err
+	}
+	return NewResolvedExternalObjectStore(ctx, externalSource, spec, skipBucketCheck)
+}
+
+// NewResolvedExternalObjectStoreFromCollection builds an external store from a
+// collection model. Returns an error if the collection is not external.
+func NewResolvedExternalObjectStoreFromCollection(
+	ctx context.Context,
+	collection *models.Collection,
+	skipBucketCheck bool,
+) (*oss.ResolvedObjectStore, ExternalSourceLocation, error) {
+	proto := collection.GetProto()
+	if proto.GetSchema().GetExternalSource() == "" {
+		return nil, ExternalSourceLocation{}, fmt.Errorf("collection %d does not have external source", proto.GetID())
+	}
+	return NewResolvedExternalObjectStoreFromSchema(
+		ctx,
+		proto.GetSchema().GetExternalSource(),
+		proto.GetSchema().GetExternalSpec(),
+		skipBucketCheck,
+	)
+}
+
+// FileBackend indicates which object store a manifest file belongs to.
+type FileBackend int
+
+const (
+	// FileBackendInternal means the file lives in milvus's own object storage.
+	FileBackendInternal FileBackend = iota
+	// FileBackendExternal means the file lives in the external collection's
+	// source bucket and requires the collection-attached credentials.
+	FileBackendExternal
+)
+
+func (b FileBackend) String() string {
+	switch b {
+	case FileBackendInternal:
+		return "internal"
+	case FileBackendExternal:
+		return "external"
+	default:
+		return "unknown"
+	}
+}
+
+// ManifestPathResolver routes a manifest file path to the correct object store.
+//
+// The discriminator matches milvus-storage's FilesystemCache::resolve_config:
+//   - absolute URI (contains "://")  -> external store
+//   - contains "ROOT_PATH"           -> external store (placeholder replaced)
+//   - relative path (no scheme)      -> internal store, resolved under the
+//     segment base path + dir prefix
+//
+// This is what makes a single manifest mixing external data files and internal
+// function-output files (e.g. sparse vectors generated from varchar) work.
+type ManifestPathResolver struct {
+	internalStore    oss.ObjectStore
+	externalStore    oss.ObjectStore
+	manifestBasePath string
+	location         ExternalSourceLocation
+}
+
+// NewManifestPathResolver builds a resolver. manifestBasePath is the resolved
+// segment base path (e.g. {rootPath}/files/insert_log/{coll}/{part}/{seg}).
+func NewManifestPathResolver(
+	internalStore oss.ObjectStore,
+	manifestBasePath string,
+	externalStore oss.ObjectStore,
+	location ExternalSourceLocation,
+) *ManifestPathResolver {
+	return &ManifestPathResolver{
+		internalStore:    internalStore,
+		externalStore:    externalStore,
+		manifestBasePath: manifestBasePath,
+		location:         location,
+	}
+}
+
+// Resolve returns the store, resolved object key and backend for a manifest
+// file path. dirPrefix is the layout directory of the section the path belongs
+// to (_data, _delta, _stats, _index or ../lobs).
+func (r *ManifestPathResolver) Resolve(filePath, dirPrefix string) (oss.ObjectStore, string, FileBackend, error) {
+	trimmed := strings.TrimSpace(filePath)
+	if trimmed == "" {
+		return nil, "", 0, fmt.Errorf("manifest file path is empty")
+	}
+
+	if strings.Contains(trimmed, "://") {
+		key, err := ResolveExternalObjectKey(r.location, trimmed)
+		if err != nil {
+			return nil, "", 0, err
+		}
+		return r.externalStore, key, FileBackendExternal, nil
+	}
+
+	if strings.Contains(trimmed, "ROOT_PATH") {
+		key := strings.ReplaceAll(trimmed, "ROOT_PATH", r.location.RootPath)
+		return r.externalStore, path.Clean(strings.TrimPrefix(key, "/")), FileBackendExternal, nil
+	}
+
+	rel := strings.TrimPrefix(strings.TrimSpace(trimmed), "/")
+	key := path.Join(r.manifestBasePath, dirPrefix, rel)
+	return r.internalStore, key, FileBackendInternal, nil
+}
+
+// ResolveExternalObjectKey resolves an external file reference (absolute URI,
+// ROOT_PATH placeholder, or path relative to the external source) into an
+// object key used with the external store.
+func ResolveExternalObjectKey(location ExternalSourceLocation, externalFile string) (string, error) {
+	trimmed := strings.TrimSpace(externalFile)
+	if trimmed == "" {
+		return "", fmt.Errorf("external file path is empty")
+	}
+	if strings.Contains(trimmed, "ROOT_PATH") {
+		return strings.ReplaceAll(trimmed, "ROOT_PATH", location.RootPath), nil
+	}
+	if strings.Contains(trimmed, "://") {
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return "", fmt.Errorf("parse external file path: %w", err)
+		}
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) == 0 || parts[0] == "" {
+			return "", fmt.Errorf("external file path %s does not include bucket", trimmed)
+		}
+		if u.Host != "" && u.Host != location.Host {
+			return "", fmt.Errorf("external file host %s does not match external source host %s", u.Host, location.Host)
+		}
+		if parts[0] != location.Bucket {
+			return "", fmt.Errorf("external file bucket %s does not match external source bucket %s", parts[0], location.Bucket)
+		}
+		trimmed = filepath.Join(parts[1:]...)
+	}
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if location.RootPath == "" {
+		return path.Clean(trimmed), nil
+	}
+	if trimmed == location.RootPath || strings.HasPrefix(trimmed, location.RootPath+"/") {
+		return path.Clean(trimmed), nil
+	}
+	return path.Join(location.RootPath, trimmed), nil
+}
+
+func ReadMapString(payload map[string]any, key string) string {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func ReadMapBool(payload map[string]any, key string) (bool, bool) {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return false, false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	default:
+		return false, false
+	}
+}

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -36,16 +36,45 @@ type ExternalSourceSpec struct {
 	LoadFrequency      int
 }
 
+// LocationForm distinguishes the two accepted external_source URI shapes,
+// mirroring milvus pkg/util/externalspec and milvus-storage StorageUri.
+type LocationForm int
+
+const (
+	// LocationFormMilvus is `scheme://endpoint/bucket/key`: the URI host is the
+	// storage endpoint and the first path segment is the bucket.
+	LocationFormMilvus LocationForm = iota
+	// LocationFormAWS is `scheme://bucket/key`: the URI host is the bucket and
+	// the endpoint is derived from extfs.cloud_provider + extfs.region.
+	LocationFormAWS
+)
+
 // ExternalSourceLocation is the parsed external_source URI.
 type ExternalSourceLocation struct {
 	Scheme   string
 	Host     string
 	Bucket   string
 	RootPath string
+	// Address is the storage endpoint used to build the object store client:
+	// the URI host for the Milvus form, or DeriveEndpoint(provider, region)
+	// for the AWS form.
+	Address string
+	Form    LocationForm
 }
 
 // ParseExternalSpec parses the external spec JSON (schema.ExternalSpec).
 func ParseExternalSpec(raw string) (ExternalSourceSpec, error) {
+	return parseExternalSpec(raw, true)
+}
+
+// ParseExternalSpecLoose parses the external spec JSON without rejecting
+// unsupported file formats. It is used by commands that only annotate paths
+// (e.g. show manifest) and must not fail on non-parquet external collections.
+func ParseExternalSpecLoose(raw string) (ExternalSourceSpec, error) {
+	return parseExternalSpec(raw, false)
+}
+
+func parseExternalSpec(raw string, validateFormat bool) (ExternalSourceSpec, error) {
 	if strings.TrimSpace(raw) == "" {
 		return ExternalSourceSpec{}, nil
 	}
@@ -59,7 +88,7 @@ func ParseExternalSpec(raw string) (ExternalSourceSpec, error) {
 		Format:             ReadMapString(payload, "format"),
 		AliyunRoleAuthMode: ReadMapString(payload, "aliyun_role_auth_mode"),
 	}
-	if spec.Format != "" && !strings.EqualFold(spec.Format, "parquet") {
+	if validateFormat && spec.Format != "" && !strings.EqualFold(spec.Format, "parquet") {
 		return ExternalSourceSpec{}, fmt.Errorf("external collection format %s is not supported", spec.Format)
 	}
 
@@ -98,7 +127,10 @@ func ParseExternalSpec(raw string) (ExternalSourceSpec, error) {
 	return spec, nil
 }
 
-// ParseExternalSource parses the external_source URI.
+// ParseExternalSource parses the external_source URI into scheme / host /
+// bucket / root path, assuming the Milvus form (host = endpoint, first path
+// segment = bucket). Use ResolveExternalSource to apply the AWS-form swap
+// based on the spec.
 func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -112,9 +144,12 @@ func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 		return ExternalSourceLocation{}, fmt.Errorf("external source %s does not include bucket", raw)
 	}
 	location := ExternalSourceLocation{
-		Scheme: u.Scheme,
-		Host:   u.Host,
-		Bucket: parts[0],
+		Scheme:   u.Scheme,
+		Host:     u.Host,
+		Bucket:   parts[0],
+		RootPath: "",
+		Address:  u.Host,
+		Form:     LocationFormMilvus,
 	}
 	if len(parts) > 1 {
 		location.RootPath = path.Clean(filepath.Join(parts[1:]...))
@@ -123,6 +158,125 @@ func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 		}
 	}
 	return location, nil
+}
+
+// ResolveExternalSource applies the two-form URI contract on top of
+// ParseExternalSource. It mirrors milvus-storage's Layer-3 swap decision:
+//
+//	derived := DeriveEndpoint(spec.CloudProvider, spec.Region)
+//	if derived != "" && StripURIScheme(derived) != host &&
+//	   !IsCloudEndpointHost(host) {
+//	    // AWS form: host is the bucket, endpoint is derived
+//	}
+//
+// The returned location carries the final bucket/root path and the endpoint
+// address used to build the object store client.
+func ResolveExternalSource(raw string, spec ExternalSourceSpec) (ExternalSourceLocation, error) {
+	location, err := ParseExternalSource(raw)
+	if err != nil {
+		return ExternalSourceLocation{}, err
+	}
+
+	derived := DeriveEndpoint(spec.CloudProvider, spec.Region)
+	if derived != "" && StripURIScheme(derived) != location.Host && !IsCloudEndpointHost(location.Host) {
+		// AWS form: host is the bucket, path is the key (may be empty).
+		location.Form = LocationFormAWS
+		location.Bucket = location.Host
+		trimmed := strings.TrimPrefix(strings.TrimSpace(raw), location.Scheme+"://"+location.Host)
+		trimmed = strings.TrimPrefix(trimmed, "/")
+		if trimmed != "" {
+			location.RootPath = path.Clean(trimmed)
+			if location.RootPath == "." {
+				location.RootPath = ""
+			}
+		} else {
+			location.RootPath = ""
+		}
+		location.Address = derived
+	}
+	return location, nil
+}
+
+// StripURIScheme removes an http(s):// prefix, if present.
+func StripURIScheme(addr string) string {
+	for _, scheme := range []string{"https://", "http://"} {
+		if strings.HasPrefix(addr, scheme) {
+			return strings.TrimPrefix(addr, scheme)
+		}
+	}
+	return addr
+}
+
+// IsCloudEndpointHost reports whether host belongs to a known cloud provider
+// endpoint family (i.e. the URI is Milvus-form regardless of the derived
+// endpoint). Mirrors milvus externalspec.IsCloudEndpointHost.
+func IsCloudEndpointHost(host string) bool {
+	h := strings.ToLower(host)
+	suffixes := []string{
+		".amazonaws.com", ".amazonaws.com.cn",
+		".googleapis.com",
+		".aliyuncs.com",
+		".myqcloud.com",
+		".myhuaweicloud.com",
+		".core.windows.net", ".core.chinacloudapi.cn",
+		".core.usgovcloudapi.net", ".core.cloudapi.de",
+	}
+	for _, s := range suffixes {
+		if strings.HasSuffix(h, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// DeriveEndpoint returns the cloud endpoint for a provider/region pair, or ""
+// when it cannot be derived (empty region, unknown provider). Mirrors milvus
+// externalspec.DeriveEndpoint.
+func DeriveEndpoint(cloudProvider, region string) string {
+	cp := strings.ToLower(cloudProvider)
+	switch cp {
+	case "aws":
+		if region == "" {
+			return ""
+		}
+		if strings.HasPrefix(region, "cn-") {
+			return "https://s3." + region + ".amazonaws.com.cn"
+		}
+		return "https://s3." + region + ".amazonaws.com"
+	case "gcp":
+		return "https://storage.googleapis.com"
+	case "aliyun":
+		if region == "" {
+			return ""
+		}
+		return "https://oss-" + region + ".aliyuncs.com"
+	case "tencent":
+		if region == "" {
+			return ""
+		}
+		return "https://cos." + region + ".myqcloud.com"
+	case "huawei":
+		if region == "" {
+			return ""
+		}
+		return "https://obs." + region + ".myhuaweicloud.com"
+	case "azure":
+		r := strings.ToLower(region)
+		if r == "" {
+			return ""
+		}
+		if strings.HasPrefix(r, "china") {
+			return "core.chinacloudapi.cn"
+		}
+		if strings.HasPrefix(r, "usgov") || strings.HasPrefix(r, "usdod") {
+			return "core.usgovcloudapi.net"
+		}
+		if strings.HasPrefix(r, "germany") {
+			return "core.cloudapi.de"
+		}
+		return "core.windows.net"
+	}
+	return ""
 }
 
 // InferCloudProviderFromScheme infers the cloud provider from the URI scheme.
@@ -152,7 +306,7 @@ func NewResolvedExternalObjectStore(
 	spec ExternalSourceSpec,
 	skipBucketCheck bool,
 ) (*oss.ResolvedObjectStore, ExternalSourceLocation, error) {
-	location, err := ParseExternalSource(source)
+	location, err := ResolveExternalSource(source, spec)
 	if err != nil {
 		return nil, ExternalSourceLocation{}, err
 	}
@@ -175,8 +329,13 @@ func NewResolvedExternalObjectStore(
 		bucket = spec.BucketName
 	}
 
+	addr := location.Address
+	if addr == "" {
+		addr = location.Host
+	}
+
 	param := oss.MinioClientParam{
-		Addr:               location.Host,
+		Addr:               addr,
 		UseSSL:             useSSL,
 		CloudProvider:      provider,
 		Region:             spec.Region,
@@ -246,6 +405,24 @@ func NewResolvedExternalObjectStoreFromCollection(
 		proto.GetSchema().GetExternalSpec(),
 		skipBucketCheck,
 	)
+}
+
+// ResolveExternalLocationFromCollection parses the collection's external source
+// and spec into a location WITHOUT connecting to the external bucket or
+// validating the file format. Commands that only annotate paths (e.g. show
+// manifest) should use this instead of NewResolvedExternalObjectStoreFromCollection
+// so they do not fail when external credentials or connectivity are broken.
+func ResolveExternalLocationFromCollection(collection *models.Collection) (ExternalSourceLocation, error) {
+	proto := collection.GetProto()
+	schema := proto.GetSchema()
+	if schema.GetExternalSource() == "" {
+		return ExternalSourceLocation{}, fmt.Errorf("collection %d does not have external source", proto.GetID())
+	}
+	spec, err := ParseExternalSpecLoose(schema.GetExternalSpec())
+	if err != nil {
+		return ExternalSourceLocation{}, err
+	}
+	return ResolveExternalSource(schema.GetExternalSource(), spec)
 }
 
 // FileBackend indicates which object store a manifest file belongs to.
@@ -332,7 +509,9 @@ func (r *ManifestPathResolver) Resolve(filePath, dirPrefix string) (oss.ObjectSt
 
 // ResolveExternalObjectKey resolves an external file reference (absolute URI,
 // ROOT_PATH placeholder, or path relative to the external source) into an
-// object key used with the external store.
+// object key used with the external store. Absolute URIs are validated against
+// the location according to its form (Milvus-form: host = endpoint, first path
+// segment = bucket; AWS-form: host = bucket, full path = key).
 func ResolveExternalObjectKey(location ExternalSourceLocation, externalFile string) (string, error) {
 	trimmed := strings.TrimSpace(externalFile)
 	if trimmed == "" {
@@ -346,17 +525,26 @@ func ResolveExternalObjectKey(location ExternalSourceLocation, externalFile stri
 		if err != nil {
 			return "", fmt.Errorf("parse external file path: %w", err)
 		}
-		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-		if len(parts) == 0 || parts[0] == "" {
-			return "", fmt.Errorf("external file path %s does not include bucket", trimmed)
+		if location.Form == LocationFormAWS {
+			// scheme://bucket/key — host is the bucket, path is the key.
+			if u.Host != "" && u.Host != location.Bucket {
+				return "", fmt.Errorf("external file host %s does not match external source bucket %s", u.Host, location.Bucket)
+			}
+			trimmed = strings.TrimPrefix(u.Path, "/")
+		} else {
+			// scheme://endpoint/bucket/key — host is the endpoint.
+			if u.Host != "" && u.Host != location.Address && u.Host != location.Host {
+				return "", fmt.Errorf("external file host %s does not match external source endpoint %s", u.Host, location.Address)
+			}
+			parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+			if len(parts) == 0 || parts[0] == "" {
+				return "", fmt.Errorf("external file path %s does not include bucket", trimmed)
+			}
+			if parts[0] != location.Bucket {
+				return "", fmt.Errorf("external file bucket %s does not match external source bucket %s", parts[0], location.Bucket)
+			}
+			trimmed = strings.Join(parts[1:], "/")
 		}
-		if u.Host != "" && u.Host != location.Host {
-			return "", fmt.Errorf("external file host %s does not match external source host %s", u.Host, location.Host)
-		}
-		if parts[0] != location.Bucket {
-			return "", fmt.Errorf("external file bucket %s does not match external source bucket %s", parts[0], location.Bucket)
-		}
-		trimmed = filepath.Join(parts[1:]...)
 	}
 	trimmed = strings.TrimPrefix(trimmed, "/")
 	if location.RootPath == "" {

--- a/states/ossutil/external_test.go
+++ b/states/ossutil/external_test.go
@@ -16,9 +16,11 @@ type resolverTestStore struct{}
 func (s *resolverTestStore) Open(ctx context.Context, key string, opts ...oss.OpenOption) (storagecommon.ReadSeeker, error) {
 	return nil, nil
 }
+
 func (s *resolverTestStore) Stat(ctx context.Context, key string) (*models.FsStat, error) {
 	return nil, nil
 }
+
 func (s *resolverTestStore) List(ctx context.Context, prefix string, recursive bool) (<-chan oss.ObjectInfo, error) {
 	return nil, nil
 }

--- a/states/ossutil/external_test.go
+++ b/states/ossutil/external_test.go
@@ -1,0 +1,268 @@
+package ossutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+)
+
+// resolverTestStore is a minimal oss.ObjectStore stub for path-routing tests.
+// It is never opened, only passed through by ManifestPathResolver.
+type resolverTestStore struct{}
+
+func (s *resolverTestStore) Open(ctx context.Context, key string, opts ...oss.OpenOption) (storagecommon.ReadSeeker, error) {
+	return nil, nil
+}
+func (s *resolverTestStore) Stat(ctx context.Context, key string) (*models.FsStat, error) {
+	return nil, nil
+}
+func (s *resolverTestStore) List(ctx context.Context, prefix string, recursive bool) (<-chan oss.ObjectInfo, error) {
+	return nil, nil
+}
+
+func TestManifestPathResolverMixedManifest(t *testing.T) {
+	location := ExternalSourceLocation{
+		Host:     "oss-cn-hangzhou.aliyuncs.com",
+		Bucket:   "test-oss-0815",
+		RootPath: "testlake/parquet",
+	}
+	internalStore := &resolverTestStore{}
+	externalStore := &resolverTestStore{}
+
+	// manifestBasePath mirrors {rootPath}/files/insert_log/{coll}/{part}/{seg}
+	resolver := NewManifestPathResolver(internalStore, "by-dev/files/insert_log/1/2/3", externalStore, location)
+
+	tests := []struct {
+		name      string
+		file      string
+		dirPrefix string
+		wantStore *resolverTestStore
+		wantKey   string
+		wantBack  FileBackend
+		wantErr   bool
+	}{
+		{
+			name:      "external absolute uri",
+			file:      "oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet/part-0001.parquet",
+			dirPrefix: "_data",
+			wantStore: externalStore,
+			wantKey:   "testlake/parquet/part-0001.parquet",
+			wantBack:  FileBackendExternal,
+		},
+		{
+			name:      "external ROOT_PATH placeholder",
+			file:      "ROOT_PATH/part-0002.parquet",
+			dirPrefix: "_data",
+			wantStore: externalStore,
+			wantKey:   "testlake/parquet/part-0002.parquet",
+			wantBack:  FileBackendExternal,
+		},
+		{
+			name:      "internal function output file",
+			file:      "abc-123.parquet",
+			dirPrefix: "_data",
+			wantStore: internalStore,
+			wantKey:   "by-dev/files/insert_log/1/2/3/_data/abc-123.parquet",
+			wantBack:  FileBackendInternal,
+		},
+		{
+			name:      "internal bm25 stats",
+			file:      "bm25.3/0",
+			dirPrefix: "_stats",
+			wantStore: internalStore,
+			wantKey:   "by-dev/files/insert_log/1/2/3/_stats/bm25.3/0",
+			wantBack:  FileBackendInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, key, backend, err := resolver.Resolve(tt.file, tt.dirPrefix)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if store != tt.wantStore {
+				t.Fatalf("Resolve() store mismatch: got %#v, want %#v", store, tt.wantStore)
+			}
+			if key != tt.wantKey {
+				t.Fatalf("Resolve() key = %q, want %q", key, tt.wantKey)
+			}
+			if backend != tt.wantBack {
+				t.Fatalf("Resolve() backend = %v, want %v", backend, tt.wantBack)
+			}
+		})
+	}
+}
+
+func TestParseExternalSpecFullKeys(t *testing.T) {
+	raw := `{
+		"format": "parquet",
+		"extfs": {
+			"cloud_provider": "aws",
+			"region": "us-east-1",
+			"role_arn": "arn:aws:iam::1:role/r",
+			"session_name": "birdwatcher",
+			"external_id": "ext-123",
+			"access_key_id": "AKIA",
+			"access_key_value": "secret",
+			"use_iam": false,
+			"iam_endpoint": "https://sts.example.com",
+			"bucket_name": "override-bucket",
+			"storage_type": "remote",
+			"use_ssl": true,
+			"load_frequency": "3600"
+		}
+	}`
+
+	spec, err := ParseExternalSpec(raw)
+	if err != nil {
+		t.Fatalf("ParseExternalSpec() error = %v", err)
+	}
+	if spec.Format != "parquet" {
+		t.Fatalf("unexpected format: %s", spec.Format)
+	}
+	if spec.CloudProvider != "aws" {
+		t.Fatalf("unexpected cloud provider: %s", spec.CloudProvider)
+	}
+	if spec.Region != "us-east-1" {
+		t.Fatalf("unexpected region: %s", spec.Region)
+	}
+	if spec.RoleARN != "arn:aws:iam::1:role/r" {
+		t.Fatalf("unexpected role arn: %s", spec.RoleARN)
+	}
+	if spec.RoleSessionName != "birdwatcher" {
+		t.Fatalf("unexpected session name: %s", spec.RoleSessionName)
+	}
+	if spec.ExternalID != "ext-123" {
+		t.Fatalf("unexpected external id: %s", spec.ExternalID)
+	}
+	if spec.AK != "AKIA" || spec.SK != "secret" {
+		t.Fatalf("unexpected access keys: %q/%q", spec.AK, spec.SK)
+	}
+	if spec.UseIAM {
+		t.Fatalf("expected use_iam=false")
+	}
+	if spec.IAMEndpoint != "https://sts.example.com" {
+		t.Fatalf("unexpected iam endpoint: %s", spec.IAMEndpoint)
+	}
+	if spec.BucketName != "override-bucket" {
+		t.Fatalf("unexpected bucket name: %s", spec.BucketName)
+	}
+	if spec.StorageType != "remote" {
+		t.Fatalf("unexpected storage type: %s", spec.StorageType)
+	}
+	if spec.UseSSL == nil || !*spec.UseSSL {
+		t.Fatalf("expected use_ssl=true, got %#v", spec.UseSSL)
+	}
+	if spec.LoadFrequency != 3600 {
+		t.Fatalf("unexpected load frequency: %d", spec.LoadFrequency)
+	}
+}
+
+func TestParseExternalSpecEmpty(t *testing.T) {
+	spec, err := ParseExternalSpec("")
+	if err != nil {
+		t.Fatalf("ParseExternalSpec() error = %v", err)
+	}
+	if spec.Format != "" {
+		t.Fatalf("unexpected format: %s", spec.Format)
+	}
+}
+
+func TestParseExternalSpecRejectsUnsupportedFormat(t *testing.T) {
+	raw := `{"format":"lance-table","extfs":{}}`
+	if _, err := ParseExternalSpec(raw); err == nil {
+		t.Fatalf("expected error for unsupported format")
+	}
+}
+
+func TestParseExternalSource(t *testing.T) {
+	location, err := ParseExternalSource("oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet")
+	if err != nil {
+		t.Fatalf("ParseExternalSource() error = %v", err)
+	}
+	if location.Scheme != "oss" {
+		t.Fatalf("unexpected scheme: %s", location.Scheme)
+	}
+	if location.Host != "oss-cn-hangzhou.aliyuncs.com" {
+		t.Fatalf("unexpected host: %s", location.Host)
+	}
+	if location.Bucket != "test-oss-0815" {
+		t.Fatalf("unexpected bucket: %s", location.Bucket)
+	}
+	if location.RootPath != "testlake/parquet" {
+		t.Fatalf("unexpected root path: %s", location.RootPath)
+	}
+}
+
+func TestResolveExternalObjectKey(t *testing.T) {
+	location := ExternalSourceLocation{
+		Host:     "oss-cn-hangzhou.aliyuncs.com",
+		Bucket:   "test-oss-0815",
+		RootPath: "testlake/parquet",
+	}
+
+	tests := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			name: "relative path",
+			file: "part-0001.parquet",
+			want: "testlake/parquet/part-0001.parquet",
+		},
+		{
+			name: "already rooted",
+			file: "testlake/parquet/part-0002.parquet",
+			want: "testlake/parquet/part-0002.parquet",
+		},
+		{
+			name: "full uri",
+			file: "oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet/part-0003.parquet",
+			want: "testlake/parquet/part-0003.parquet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveExternalObjectKey(location, tt.file)
+			if err != nil {
+				t.Fatalf("ResolveExternalObjectKey() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveExternalObjectKey() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferCloudProviderFromScheme(t *testing.T) {
+	tests := []struct {
+		scheme string
+		want   string
+	}{
+		{scheme: "oss", want: "aliyun"},
+		{scheme: "s3", want: "aws"},
+		{scheme: "aws", want: "aws"},
+		{scheme: "minio", want: "aws"},
+		{scheme: "gs", want: "gcp"},
+		{scheme: "gcs", want: "gcp"},
+		{scheme: "cos", want: "tencent"},
+		{scheme: "obs", want: "huawei"},
+		{scheme: "unknown", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scheme, func(t *testing.T) {
+			if got := InferCloudProviderFromScheme(tt.scheme); got != tt.want {
+				t.Fatalf("InferCloudProviderFromScheme(%q) = %q, want %q", tt.scheme, got, tt.want)
+			}
+		})
+	}
+}

--- a/states/ossutil/external_test.go
+++ b/states/ossutil/external_test.go
@@ -268,3 +268,164 @@ func TestInferCloudProviderFromScheme(t *testing.T) {
 		})
 	}
 }
+
+func TestDeriveEndpoint(t *testing.T) {
+	tests := []struct {
+		provider string
+		region   string
+		want     string
+	}{
+		{provider: "aws", region: "us-east-1", want: "https://s3.us-east-1.amazonaws.com"},
+		{provider: "aws", region: "cn-north-1", want: "https://s3.cn-north-1.amazonaws.com.cn"},
+		{provider: "aws", region: "", want: ""},
+		{provider: "gcp", region: "", want: "https://storage.googleapis.com"},
+		{provider: "aliyun", region: "cn-hangzhou", want: "https://oss-cn-hangzhou.aliyuncs.com"},
+		{provider: "aliyun", region: "", want: ""},
+		{provider: "tencent", region: "ap-guangzhou", want: "https://cos.ap-guangzhou.myqcloud.com"},
+		{provider: "huawei", region: "cn-north-4", want: "https://obs.cn-north-4.myhuaweicloud.com"},
+		{provider: "azure", region: "public", want: "core.windows.net"},
+		{provider: "azure", region: "china", want: "core.chinacloudapi.cn"},
+		{provider: "azure", region: "", want: ""},
+		{provider: "unknown", region: "us-east-1", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.region, func(t *testing.T) {
+			if got := DeriveEndpoint(tt.provider, tt.region); got != tt.want {
+				t.Fatalf("DeriveEndpoint(%q, %q) = %q, want %q", tt.provider, tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCloudEndpointHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{host: "s3.us-east-1.amazonaws.com", want: true},
+		{host: "storage.googleapis.com", want: true},
+		{host: "oss-cn-hangzhou.aliyuncs.com", want: true},
+		{host: "cos.ap-guangzhou.myqcloud.com", want: true},
+		{host: "myacct.core.windows.net", want: true},
+		{host: "my-bucket", want: false},
+		{host: "localhost:9000", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := IsCloudEndpointHost(tt.host); got != tt.want {
+				t.Fatalf("IsCloudEndpointHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveExternalSourceAWSForm(t *testing.T) {
+	// s3://bucket/key with AWS cloud_provider + region: host is the bucket,
+	// endpoint is derived.
+	location, err := ResolveExternalSource("s3://my-bucket/root/file", ExternalSourceSpec{
+		CloudProvider: "aws",
+		Region:        "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveExternalSource() error = %v", err)
+	}
+	if location.Form != LocationFormAWS {
+		t.Fatalf("expected AWS form, got %v", location.Form)
+	}
+	if location.Bucket != "my-bucket" {
+		t.Fatalf("unexpected bucket: %s", location.Bucket)
+	}
+	if location.RootPath != "root/file" {
+		t.Fatalf("unexpected root path: %s", location.RootPath)
+	}
+	if location.Address != "https://s3.us-east-1.amazonaws.com" {
+		t.Fatalf("unexpected address: %s", location.Address)
+	}
+}
+
+func TestResolveExternalSourceMilvusForm(t *testing.T) {
+	// oss://endpoint/bucket/key stays Milvus form regardless of spec.
+	location, err := ResolveExternalSource("oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet",
+		ExternalSourceSpec{CloudProvider: "aliyun", Region: "cn-hangzhou"})
+	if err != nil {
+		t.Fatalf("ResolveExternalSource() error = %v", err)
+	}
+	if location.Form != LocationFormMilvus {
+		t.Fatalf("expected Milvus form, got %v", location.Form)
+	}
+	if location.Bucket != "test-oss-0815" {
+		t.Fatalf("unexpected bucket: %s", location.Bucket)
+	}
+	if location.RootPath != "testlake/parquet" {
+		t.Fatalf("unexpected root path: %s", location.RootPath)
+	}
+	if location.Address != "oss-cn-hangzhou.aliyuncs.com" {
+		t.Fatalf("unexpected address: %s", location.Address)
+	}
+}
+
+func TestResolveExternalSourceCloudEndpointHostStaysMilvus(t *testing.T) {
+	// s3://s3.amazonaws.com/bucket/key: host is a known cloud endpoint, so it
+	// stays Milvus form even with a regional spec.
+	location, err := ResolveExternalSource("s3://s3.amazonaws.com/my-bucket/key",
+		ExternalSourceSpec{CloudProvider: "aws", Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("ResolveExternalSource() error = %v", err)
+	}
+	if location.Form != LocationFormMilvus {
+		t.Fatalf("expected Milvus form, got %v", location.Form)
+	}
+	if location.Bucket != "my-bucket" {
+		t.Fatalf("unexpected bucket: %s", location.Bucket)
+	}
+}
+
+func TestResolveExternalObjectKeyAWSForm(t *testing.T) {
+	location := ExternalSourceLocation{
+		Scheme:   "s3",
+		Host:     "my-bucket",
+		Bucket:   "my-bucket",
+		RootPath: "root",
+		Address:  "https://s3.us-east-1.amazonaws.com",
+		Form:     LocationFormAWS,
+	}
+
+	tests := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			name: "absolute aws uri",
+			file: "s3://my-bucket/root/data/part-0001.parquet",
+			want: "root/data/part-0001.parquet",
+		},
+		{
+			name: "relative path",
+			file: "data/part-0002.parquet",
+			want: "root/data/part-0002.parquet",
+		},
+		{
+			name: "mismatched bucket",
+			file: "s3://other-bucket/root/data.parquet",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveExternalObjectKey(location, tt.file)
+			if tt.want == "" {
+				if err == nil {
+					t.Fatalf("expected error for %q, got key %q", tt.file, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveExternalObjectKey() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveExternalObjectKey() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/birdwatcher/states/ossutil"
 	"github.com/milvus-io/birdwatcher/storage"
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 	"github.com/milvus-io/birdwatcher/storage/tasks"
@@ -97,6 +98,22 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	}
 	rootPath := resolvedStore.RootPath
 
+	// External collections: build the external store with credentials from the
+	// collection (role_arn / external_id / ...) instead of minio configuration.
+	// A single manifest may mix external data files with internal function
+	// output files (e.g. sparse vectors from varchar), so we route per-file.
+	external := isExternalCollection(collection)
+	var externalStore *oss.ResolvedObjectStore
+	var externalLocation ossutil.ExternalSourceLocation
+	if external {
+		externalStore, externalLocation, err = ossutil.NewResolvedExternalObjectStoreFromCollection(ctx, collection, p.SkipBucketCheck)
+		if err != nil {
+			fmt.Println("Failed to create external store,", err.Error())
+			return err
+		}
+		fmt.Printf("External Source: %s\n", collection.GetProto().GetSchema().GetExternalSource())
+	}
+
 	fmt.Printf("=== start to execute \"%s\" task with filter expresion: \"%s\" ===\n", p.Action, p.Expr)
 	fmt.Printf("=== worker num: %d, skip delete: %t ===\n", p.WorkerNum, p.IgnoreDelete)
 
@@ -121,6 +138,15 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	}
 
 	getObject := func(binlogPath string) (storagecommon.ReadSeeker, error) {
+		if external && externalStore != nil {
+			if isExternalPath(binlogPath) {
+				key, err := ossutil.ResolveExternalObjectKey(externalLocation, binlogPath)
+				if err != nil {
+					return nil, err
+				}
+				return externalStore.Store.Open(ctx, key)
+			}
+		}
 		logPath := oss.ResolveObjectKey(rootPath, binlogPath)
 		return resolvedStore.Store.Open(ctx, logPath)
 	}
@@ -173,6 +199,23 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 		filters := []storage.EntryFilter{loEntryFilter, deltalogFilter}
 		if exprFilter != nil {
 			filters = append(filters, exprFilter)
+		}
+
+		// External collections store data in manifest-referenced files that may
+		// mix external source files and internal function-output files. Route
+		// them through the manifest resolver instead of the binlog iterator.
+		if external && externalStore != nil && segment.GetManifestPath() != "" {
+			return scanExternalSegment(ctx,
+				resolvedStore.Store,
+				rootPath,
+				externalStore.Store,
+				externalLocation,
+				segment,
+				collection.GetProto().GetSchema(),
+				fields,
+				filters,
+				scanTask,
+			)
 		}
 
 		iter := storage.NewSegmentIterator(segment,

--- a/states/scan_binlog_external.go
+++ b/states/scan_binlog_external.go
@@ -1,0 +1,290 @@
+package states
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/file"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+	"github.com/milvus-io/birdwatcher/states/ossutil"
+	"github.com/milvus-io/birdwatcher/storage"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+	"github.com/milvus-io/birdwatcher/storage/tasks"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// scanExternalSegment scans an external collection segment by reading its
+// manifest and iterating the column group files. Files are routed to the
+// internal or external object store per-file (a single manifest may mix
+// external data files and internal function-output files such as sparse
+// vectors generated from varchar columns).
+//
+// filters are applied per row, matching the binlog scan path contract
+// (filter.Match(pk, ts, values)).
+func scanExternalSegment(ctx context.Context,
+	internalStore oss.ObjectStore,
+	internalRootPath string,
+	externalStore oss.ObjectStore,
+	externalLocation ossutil.ExternalSourceLocation,
+	segment *models.Segment,
+	schema *schemapb.CollectionSchema,
+	fields map[int64]*schemapb.FieldSchema,
+	filters []storage.EntryFilter,
+	scanTask tasks.ScanTask,
+) error {
+	rawManifest := segment.GetManifestPath()
+	if rawManifest == "" {
+		return errors.Newf("external segment %d has no manifest path", segment.GetID())
+	}
+
+	var manifestRef struct {
+		Ver      int    `json:"ver"`
+		BasePath string `json:"base_path"`
+	}
+	if err := json.Unmarshal([]byte(rawManifest), &manifestRef); err != nil {
+		return errors.Wrap(err, "parse manifest path JSON")
+	}
+
+	manifestBasePath := oss.ResolveObjectKey(internalRootPath, manifestRef.BasePath)
+	manifestPath := path.Join(manifestBasePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
+
+	obj, err := internalStore.Open(ctx, manifestPath)
+	if err != nil {
+		return errors.Wrapf(err, "get manifest object %s", manifestPath)
+	}
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
+
+	m, err := parseManifest(obj)
+	if err != nil {
+		return errors.Wrap(err, "parse manifest")
+	}
+
+	resolver := ossutil.NewManifestPathResolver(internalStore, manifestBasePath, externalStore, externalLocation)
+
+	// fieldID => manifest column name
+	field2Column := buildExternalColumnMap(schema, fields)
+
+	pkSchema, ok := getPKSchema(schema)
+	if !ok {
+		return errors.New("pk field not found in schema")
+	}
+
+	var pk storagecommon.PrimaryKey
+	switch pkSchema.GetDataType() {
+	case schemapb.DataType_Int64:
+		pk = &storagecommon.Int64PrimaryKey{}
+	case schemapb.DataType_VarChar:
+		pk = &storagecommon.VarCharPrimaryKey{}
+	default:
+		return errors.Newf("unsupported primary key type %s", pkSchema.GetDataType().String())
+	}
+
+	batchIdx := 0
+	for _, cg := range m.ColumnGroups {
+		// map manifest column names in this group to output field IDs
+		col2Field := make(map[string]int64)
+		usable := false
+		for _, colName := range cg.Columns {
+			if fid, ok := field2Column[colName]; ok {
+				col2Field[colName] = fid
+				usable = true
+			}
+		}
+		if !usable {
+			continue
+		}
+
+		for _, f := range cg.Files {
+			store, objectKey, _, err := resolver.Resolve(f.Path, "_data")
+			if err != nil {
+				fmt.Printf("failed to resolve manifest file path %s: %s\n", f.Path, err.Error())
+				continue
+			}
+			if err := scanExternalParquetFile(ctx, store, objectKey, col2Field, fields, pk, filters, scanTask, segment.GetID(), batchIdx); err != nil {
+				fmt.Printf("failed to scan %s: %s\n", objectKey, err.Error())
+				continue
+			}
+			batchIdx++
+		}
+	}
+	return nil
+}
+
+// buildExternalColumnMap builds a map from manifest column name to field ID for
+// all output fields. For external data columns the manifest stores the source
+// column name (external_field); for internal function-output fields it stores
+// the numeric field ID string.
+func buildExternalColumnMap(schema *schemapb.CollectionSchema, fields map[int64]*schemapb.FieldSchema) map[string]int64 {
+	result := make(map[string]int64)
+	for fid, field := range fields {
+		if ext := field.GetExternalField(); ext != "" {
+			result[ext] = fid
+			continue
+		}
+		result[strconv.FormatInt(fid, 10)] = fid
+		// fall back to field name as well, in case the manifest uses names
+		result[field.GetName()] = fid
+	}
+	return result
+}
+
+func getPKSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSchema, bool) {
+	for _, field := range schema.GetFields() {
+		if field.GetIsPrimaryKey() {
+			return field, true
+		}
+	}
+	return nil, false
+}
+
+// scanExternalParquetFile reads one parquet object and feeds every row into the
+// scan task. values is keyed by field ID; PK and timestamp are set when present.
+func scanExternalParquetFile(ctx context.Context,
+	store oss.ObjectStore,
+	objectKey string,
+	col2Field map[string]int64,
+	fields map[int64]*schemapb.FieldSchema,
+	pk storagecommon.PrimaryKey,
+	filters []storage.EntryFilter,
+	scanTask tasks.ScanTask,
+	segmentID int64,
+	batchIdx int,
+) error {
+	obj, err := store.Open(ctx, objectKey)
+	if err != nil {
+		return errors.Wrapf(err, "open object %s", objectKey)
+	}
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
+
+	pqReader, err := file.NewParquetReader(obj)
+	if err != nil {
+		return errors.Wrapf(err, "open parquet %s", objectKey)
+	}
+	defer pqReader.Close()
+
+	arrReader, err := pqarrow.NewFileReader(pqReader, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
+	if err != nil {
+		return errors.Wrapf(err, "create arrow reader for %s", objectKey)
+	}
+	rr, err := arrReader.GetRecordReader(ctx, nil, nil)
+	if err != nil {
+		return errors.Wrapf(err, "get record reader for %s", objectKey)
+	}
+	defer rr.Release()
+
+	batchInfo := &storagecommon.BatchInfo{
+		SegmentID: segmentID,
+		BatchIdx:  batchIdx,
+	}
+
+	for rr.Next() {
+		rec := rr.Record()
+		if rec == nil {
+			continue
+		}
+		cols := int(rec.NumCols())
+		colIdxByName := make(map[string]int, cols)
+		for i := 0; i < cols; i++ {
+			colIdxByName[rec.ColumnName(i)] = i
+		}
+
+		rows := int(rec.NumRows())
+		for row := 0; row < rows; row++ {
+			values := make(map[int64]any)
+			valueSet := false
+			for colName, fid := range col2Field {
+				idx, ok := colIdxByName[colName]
+				if !ok {
+					continue
+				}
+				fieldSchema, ok := fields[fid]
+				if !ok {
+					continue
+				}
+				arr := rec.Column(idx)
+				if arr == nil || arr.IsNull(row) {
+					continue
+				}
+				val, ok := deserializeParquetCell(arr, row, fieldSchema.GetDataType())
+				if !ok {
+					continue
+				}
+				values[fid] = val
+				valueSet = true
+				if fieldSchema.GetIsPrimaryKey() {
+					pk.SetValue(val)
+				}
+			}
+			if !valueSet {
+				continue
+			}
+
+			ts := int64(0)
+			if v, ok := values[1]; ok {
+				if tsv, ok := v.(int64); ok {
+					ts = tsv
+				}
+			}
+
+			matched := true
+			for _, filter := range filters {
+				match, err := filter.Match(pk, ts, values)
+				if err != nil {
+					return err
+				}
+				if !match {
+					matched = false
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+
+			if err := scanTask.Scan(pk, batchInfo, row, values); err != nil {
+				return err
+			}
+		}
+	}
+	if err := rr.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+// deserializeParquetCell deserializes a single cell from an arrow array using
+// the common serde map when available; falls back to scalar extraction.
+func deserializeParquetCell(arr arrow.Array, row int, dataType schemapb.DataType) (any, bool) {
+	if entry, ok := storagecommon.SerdeMap[dataType]; ok {
+		return entry.Deserialize(arr, row)
+	}
+	return nil, false
+}
+
+// isExternalCollection returns whether the collection schema is an external
+// collection (has an external source).
+func isExternalCollection(collection *models.Collection) bool {
+	return collection.GetProto().GetSchema().GetExternalSource() != ""
+}
+
+// isExternalPath reports whether a path references the external source bucket
+// (an absolute URI or a ROOT_PATH placeholder that the external store resolves).
+func isExternalPath(filePath string) bool {
+	trimmed := strings.TrimSpace(filePath)
+	return strings.Contains(trimmed, "://") || strings.Contains(trimmed, "ROOT_PATH")
+}

--- a/states/scan_binlog_external.go
+++ b/states/scan_binlog_external.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -22,16 +23,20 @@ import (
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 	"github.com/milvus-io/birdwatcher/storage/tasks"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // scanExternalSegment scans an external collection segment by reading its
-// manifest and iterating the column group files. Files are routed to the
-// internal or external object store per-file (a single manifest may mix
-// external data files and internal function-output files such as sparse
-// vectors generated from varchar columns).
+// manifest and merging the column-group files by global row offset into
+// logical rows. A single manifest may mix external data files and internal
+// function-output files (e.g. sparse vectors generated from varchar columns),
+// each covering overlapping row ranges in separate column groups.
 //
-// filters are applied per row, matching the binlog scan path contract
-// (filter.Match(pk, ts, values)).
+// The virtual PK (segmentID + global row offset) is derived rather than read
+// from any file. Filters are applied per logical row, matching the binlog scan
+// path contract (filter.Match(pk, ts, values)), and Scan is invoked exactly
+// once per logical row.
 func scanExternalSegment(ctx context.Context,
 	internalStore oss.ObjectStore,
 	internalRootPath string,
@@ -74,27 +79,28 @@ func scanExternalSegment(ctx context.Context,
 
 	resolver := ossutil.NewManifestPathResolver(internalStore, manifestBasePath, externalStore, externalLocation)
 
-	// fieldID => manifest column name
+	// fieldID => manifest column name for the output fields
 	field2Column := buildExternalColumnMap(schema, fields)
 
-	pkSchema, ok := getPKSchema(schema)
-	if !ok {
-		return errors.New("pk field not found in schema")
+	// Resolve every manifest column-group file and its store up front. Any
+	// resolution failure (e.g. invalid ARN, missing bucket) aborts the scan
+	// instead of silently producing partial results.
+	//
+	// Each column group's files tile the segment's logical row space: within a
+	// group, file rows are attributed to segment-global offsets by accumulating
+	// the manifest row ranges ([start, end) within the file). Different column
+	// groups (external data vs internal function outputs) independently cover
+	// the same [0, totalRows) and are merged by segment-global offset below.
+	type resolvedFile struct {
+		store        oss.ObjectStore
+		key          string
+		col2Field    map[string]int64
+		startIdx     int64 // file-local start row (manifest range)
+		endIdx       int64 // file-local end row (manifest range)
+		globalOffset int64 // segment-global start offset of this file's rows
 	}
-
-	var pk storagecommon.PrimaryKey
-	switch pkSchema.GetDataType() {
-	case schemapb.DataType_Int64:
-		pk = &storagecommon.Int64PrimaryKey{}
-	case schemapb.DataType_VarChar:
-		pk = &storagecommon.VarCharPrimaryKey{}
-	default:
-		return errors.Newf("unsupported primary key type %s", pkSchema.GetDataType().String())
-	}
-
-	batchIdx := 0
+	var files []resolvedFile
 	for _, cg := range m.ColumnGroups {
-		// map manifest column names in this group to output field IDs
 		col2Field := make(map[string]int64)
 		usable := false
 		for _, colName := range cg.Columns {
@@ -106,18 +112,100 @@ func scanExternalSegment(ctx context.Context,
 		if !usable {
 			continue
 		}
-
+		var groupOffset int64
 		for _, f := range cg.Files {
 			store, objectKey, _, err := resolver.Resolve(f.Path, "_data")
 			if err != nil {
-				fmt.Printf("failed to resolve manifest file path %s: %s\n", f.Path, err.Error())
-				continue
+				return errors.Wrapf(err, "resolve manifest file path %s", f.Path)
 			}
-			if err := scanExternalParquetFile(ctx, store, objectKey, col2Field, fields, pk, filters, scanTask, segment.GetID(), batchIdx); err != nil {
-				fmt.Printf("failed to scan %s: %s\n", objectKey, err.Error())
-				continue
+			files = append(files, resolvedFile{
+				store:        store,
+				key:          objectKey,
+				col2Field:    col2Field,
+				startIdx:     f.StartIndex,
+				endIdx:       f.EndIndex,
+				globalOffset: groupOffset,
+			})
+			if f.EndIndex > f.StartIndex {
+				groupOffset += f.EndIndex - f.StartIndex
 			}
-			batchIdx++
+		}
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	// Scan every file and merge rows by segment-global offset, so overlapping
+	// column groups contribute their columns to the same logical rows.
+	valuesByOffset := make(map[int64]map[int64]any)
+	for _, rf := range files {
+		if err := scanExternalParquetFile(ctx, rf.store, rf.key, rf.col2Field, fields, rf.startIdx, rf.endIdx, rf.globalOffset, valuesByOffset); err != nil {
+			return err
+		}
+	}
+
+	offsets := make([]int64, 0, len(valuesByOffset))
+	for offset := range valuesByOffset {
+		offsets = append(offsets, offset)
+	}
+	sort.Slice(offsets, func(i, j int) bool { return offsets[i] < offsets[j] })
+
+	pkSchema, ok := getPKSchema(schema)
+	if !ok {
+		return errors.New("pk field not found in schema")
+	}
+	virtualPK := pkSchema.GetName() == common.VirtualPKFieldName
+
+	var pk storagecommon.PrimaryKey
+	switch pkSchema.GetDataType() {
+	case schemapb.DataType_Int64:
+		pk = &storagecommon.Int64PrimaryKey{}
+	case schemapb.DataType_VarChar:
+		pk = &storagecommon.VarCharPrimaryKey{}
+	default:
+		return errors.Newf("unsupported primary key type %s", pkSchema.GetDataType().String())
+	}
+
+	batchInfo := &storagecommon.BatchInfo{
+		SegmentID: segment.GetID(),
+	}
+	for _, offset := range offsets {
+		values := valuesByOffset[offset]
+
+		if virtualPK {
+			pk.SetValue(typeutil.GetVirtualPK(segment.GetID(), offset))
+		} else {
+			pkv, ok := values[pkSchema.GetFieldID()]
+			if !ok {
+				return errors.Newf("primary key field %s not found for row %d of segment %d", pkSchema.GetName(), offset, segment.GetID())
+			}
+			pk.SetValue(pkv)
+		}
+
+		ts := int64(0)
+		if v, ok := values[1]; ok {
+			if tsv, ok := v.(int64); ok {
+				ts = tsv
+			}
+		}
+
+		matched := true
+		for _, filter := range filters {
+			match, err := filter.Match(pk, ts, values)
+			if err != nil {
+				return err
+			}
+			if !match {
+				matched = false
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+
+		if err := scanTask.Scan(pk, batchInfo, int(offset), values); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -150,18 +238,23 @@ func getPKSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSchema, bool
 	return nil, false
 }
 
-// scanExternalParquetFile reads one parquet object and feeds every row into the
-// scan task. values is keyed by field ID; PK and timestamp are set when present.
+// scanExternalParquetFile reads one parquet object and accumulates, per
+// segment-global row offset, the requested field values keyed by field ID.
+//
+// The manifest entry carries a file-local row window [startIdx, endIdx): the
+// same physical parquet can be split into multiple fragments, each contributing
+// a disjoint window. Only rows in that window are attributed to the segment,
+// starting at segment-global offset globalOffset (the file's tiled position
+// within its column group). Null cells are represented as `fieldID: nil` (not
+// omitted); a non-null cell that cannot be deserialized to the requested Milvus
+// type returns an explicit error instead of being silently dropped.
 func scanExternalParquetFile(ctx context.Context,
 	store oss.ObjectStore,
 	objectKey string,
 	col2Field map[string]int64,
 	fields map[int64]*schemapb.FieldSchema,
-	pk storagecommon.PrimaryKey,
-	filters []storage.EntryFilter,
-	scanTask tasks.ScanTask,
-	segmentID int64,
-	batchIdx int,
+	startIdx, endIdx, globalOffset int64,
+	valuesByOffset map[int64]map[int64]any,
 ) error {
 	obj, err := store.Open(ctx, objectKey)
 	if err != nil {
@@ -187,11 +280,8 @@ func scanExternalParquetFile(ctx context.Context,
 	}
 	defer rr.Release()
 
-	batchInfo := &storagecommon.BatchInfo{
-		SegmentID: segmentID,
-		BatchIdx:  batchIdx,
-	}
-
+	fileRow := int64(0)
+	globalRow := globalOffset
 	for rr.Next() {
 		rec := rr.Record()
 		if rec == nil {
@@ -205,8 +295,18 @@ func scanExternalParquetFile(ctx context.Context,
 
 		rows := int(rec.NumRows())
 		for row := 0; row < rows; row++ {
-			values := make(map[int64]any)
-			valueSet := false
+			if fileRow < startIdx {
+				fileRow++
+				continue
+			}
+			if fileRow >= endIdx {
+				return nil
+			}
+			values := valuesByOffset[globalRow]
+			if values == nil {
+				values = make(map[int64]any)
+				valuesByOffset[globalRow] = values
+			}
 			for colName, fid := range col2Field {
 				idx, ok := colIdxByName[colName]
 				if !ok {
@@ -217,52 +317,27 @@ func scanExternalParquetFile(ctx context.Context,
 					continue
 				}
 				arr := rec.Column(idx)
-				if arr == nil || arr.IsNull(row) {
+				if arr == nil {
+					continue
+				}
+				if arr.IsNull(row) {
+					values[fid] = nil
 					continue
 				}
 				val, ok := deserializeParquetCell(arr, row, fieldSchema.GetDataType())
 				if !ok {
-					continue
+					return errors.Newf(
+						"cannot deserialize non-null cell for field %s (id %d, type %s) at row %d of %s",
+						fieldSchema.GetName(), fid, fieldSchema.GetDataType().String(), row, objectKey)
 				}
 				values[fid] = val
-				valueSet = true
-				if fieldSchema.GetIsPrimaryKey() {
-					pk.SetValue(val)
-				}
 			}
-			if !valueSet {
-				continue
-			}
-
-			ts := int64(0)
-			if v, ok := values[1]; ok {
-				if tsv, ok := v.(int64); ok {
-					ts = tsv
-				}
-			}
-
-			matched := true
-			for _, filter := range filters {
-				match, err := filter.Match(pk, ts, values)
-				if err != nil {
-					return err
-				}
-				if !match {
-					matched = false
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
-
-			if err := scanTask.Scan(pk, batchInfo, row, values); err != nil {
-				return err
-			}
+			fileRow++
+			globalRow++
 		}
 	}
 	if err := rr.Err(); err != nil && !errors.Is(err, io.EOF) {
-		return err
+		return errors.Wrapf(err, "read parquet %s", objectKey)
 	}
 	return nil
 }

--- a/states/show_manifest.go
+++ b/states/show_manifest.go
@@ -68,27 +68,31 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 	}
 	rootPath := resolvedStore.RootPath
 
-	// External collections: build the external store with credentials from the
-	// collection (role_arn / external_id / ...) instead of minio configuration.
+	// External collections: parse the external source/spec into a location
+	// WITHOUT connecting to the external bucket. show manifest only reads the
+	// manifest from Milvus internal storage and uses the location to annotate
+	// paths, so it must not fail when external credentials or connectivity are
+	// broken. The external client is created lazily only by commands that
+	// actually read external objects (scan-binlog, inspect-parquet).
 	// Resolve the collection by --collection, or fall back to the first manifest
 	// segment when only --segment is given.
-	var externalStore *oss.ResolvedObjectStore
 	var externalLocation ossutil.ExternalSourceLocation
-	var collection *models.Collection
+	var externalResolved bool
 	collectionID := p.CollectionID
 	if collectionID == 0 && len(manifestSegments) > 0 {
 		collectionID = manifestSegments[0].CollectionID
 	}
 	if collectionID != 0 {
-		collection, err = common.GetCollectionByIDVersion(ctx, s.client, s.basePath, collectionID)
+		collection, err := common.GetCollectionByIDVersion(ctx, s.client, s.basePath, collectionID)
 		if err != nil {
 			return err
 		}
 		if collection.GetProto().GetSchema().GetExternalSource() != "" {
-			externalStore, externalLocation, err = ossutil.NewResolvedExternalObjectStoreFromCollection(ctx, collection, p.SkipBucketCheck)
+			externalLocation, err = ossutil.ResolveExternalLocationFromCollection(collection)
 			if err != nil {
-				return fmt.Errorf("failed to create external store: %w", err)
+				return fmt.Errorf("failed to parse external location: %w", err)
 			}
+			externalResolved = true
 		}
 	}
 
@@ -131,108 +135,19 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 			if err := enc.Encode(manifest); err != nil {
 				fmt.Printf("Error encoding JSON: %v\n", err)
 			}
-		case externalStore != nil && seg.CollectionID == collectionID:
-			resolver := ossutil.NewManifestPathResolver(resolvedStore.Store, basePath, externalStore.Store, externalLocation)
-			printManifestWithResolver(manifest, resolver)
+		case externalResolved && seg.CollectionID == collectionID:
+			// Annotate paths with storage backend / object key. The resolver
+			// only annotates; it never opens external objects, so no external
+			// store is built here.
+			resolver := ossutil.NewManifestPathResolver(resolvedStore.Store, basePath, nil, externalLocation)
+			printManifest(manifest, resolver)
 		default:
-			printManifest(manifest)
+			printManifest(manifest, nil)
 		}
 		fmt.Println()
 	}
 
 	return nil
-}
-
-// printManifestWithResolver prints manifest entries annotated with the storage
-// backend and the resolved object key for each file. It supports manifests that
-// mix external data files with internal function-output files.
-func printManifestWithResolver(m *manifest, resolver *ossutil.ManifestPathResolver) {
-	fmt.Printf("Format:  %s\n", m.Format)
-	if m.Format == "legacy_milv" {
-		fmt.Printf("Magic:   0x%08X (%q)\n", m.Magic, m.MagicStr)
-	}
-	fmt.Printf("Version: %d\n", m.Version)
-
-	fmt.Printf("\nColumn Groups (%d):\n", len(m.ColumnGroups))
-	for i, cg := range m.ColumnGroups {
-		fmt.Printf("\n  --- Column Group #%d ---\n", i)
-		fmt.Printf("  Format:  %s\n", cg.Format)
-		fmt.Printf("  Columns: %v\n", cg.Columns)
-		fmt.Printf("  Files (%d):\n", len(cg.Files))
-		for j, f := range cg.Files {
-			_, key, backend, err := resolver.Resolve(f.Path, "_data")
-			fmt.Printf("    [%d] Path: %s\n", j, f.Path)
-			fmt.Printf("        Range: [%d, %d)\n", f.StartIndex, f.EndIndex)
-			if err != nil {
-				fmt.Printf("        Resolve Error: %v\n", err)
-			} else {
-				fmt.Printf("        Backend: %s  Object Key: %s\n", backend, key)
-			}
-			if len(f.Properties) > 0 {
-				fmt.Printf("        Properties:\n")
-				for pk, pv := range f.Properties {
-					fmt.Printf("          %s: %s\n", pk, pv)
-				}
-			}
-		}
-	}
-
-	fmt.Printf("\nDelta Logs (%d):\n", len(m.DeltaLogs))
-	for i, dl := range m.DeltaLogs {
-		_, key, backend, err := resolver.Resolve(dl.Path, "_delta")
-		if err != nil {
-			fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d  (Resolve Error: %v)\n",
-				i, dl.Path, dl.Type, dl.NumEntries, err)
-		} else {
-			fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d  Backend: %s  Object Key: %s\n",
-				i, dl.Path, dl.Type, dl.NumEntries, backend, key)
-		}
-	}
-
-	if len(m.Stats) > 0 {
-		fmt.Printf("\nStats (%d keys):\n", len(m.Stats))
-		for k, stat := range m.Stats {
-			fmt.Printf("  %s:\n", k)
-			fmt.Printf("    Paths:\n")
-			for _, p := range stat.Paths {
-				_, key, backend, err := resolver.Resolve(p, "_stats")
-				if err != nil {
-					fmt.Printf("      - %s (Resolve Error: %v)\n", p, err)
-				} else {
-					fmt.Printf("      - %s  Backend: %s  Object Key: %s\n", p, backend, key)
-				}
-			}
-		}
-	}
-
-	if len(m.Indexes) > 0 {
-		fmt.Printf("\nIndexes (%d):\n", len(m.Indexes))
-		for i, idx := range m.Indexes {
-			fmt.Printf("  [%d] Column: %s  Type: %s\n", i, idx.ColumnName, idx.IndexType)
-			if idx.Path != "" {
-				_, key, backend, err := resolver.Resolve(idx.Path, "_index")
-				if err != nil {
-					fmt.Printf("      Path: %s (Resolve Error: %v)\n", idx.Path, err)
-				} else {
-					fmt.Printf("      Path: %s  Backend: %s  Object Key: %s\n", idx.Path, backend, key)
-				}
-			}
-		}
-	}
-
-	if len(m.LobFiles) > 0 {
-		fmt.Printf("\nLOB Files (%d):\n", len(m.LobFiles))
-		for i, lob := range m.LobFiles {
-			_, key, backend, err := resolver.Resolve(lob.Path, "../lobs")
-			if err != nil {
-				fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d (Resolve Error: %v)\n",
-					i, lob.Path, lob.FieldID, lob.ValidRows, lob.TotalRows, lob.FileSizeBytes, err)
-			} else {
-				fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d  Backend: %s  Object Key: %s\n",
-					i, lob.Path, lob.FieldID, lob.ValidRows, lob.TotalRows, lob.FileSizeBytes, backend, key)
-			}
-		}
-	}
 }
 
 // Manifest parsing types and logic (Avro binary encoding)
@@ -1135,7 +1050,12 @@ func parseManifest(r io.ReadSeeker) (*manifest, error) {
 	return parseLegacyManifest(r)
 }
 
-func printManifest(m *manifest) {
+// printManifest prints manifest entries. When resolver is non-nil, each file
+// path is annotated with the storage backend and resolved object key; otherwise
+// the raw paths are printed as stored. All existing diagnostic output (column
+// group metadata, stats metadata, V6 index details, index file keys, index
+// properties) is preserved in both modes.
+func printManifest(m *manifest, resolver *ossutil.ManifestPathResolver) {
 	fmt.Printf("Format:  %s\n", m.Format)
 	if m.Format == "legacy_milv" {
 		fmt.Printf("Magic:   0x%08X (%q)\n", m.Magic, m.MagicStr)
@@ -1151,6 +1071,14 @@ func printManifest(m *manifest) {
 		for j, f := range cg.Files {
 			fmt.Printf("    [%d] Path: %s\n", j, f.Path)
 			fmt.Printf("        Range: [%d, %d)\n", f.StartIndex, f.EndIndex)
+			if resolver != nil {
+				_, key, backend, err := resolver.Resolve(f.Path, "_data")
+				if err != nil {
+					fmt.Printf("        Resolve Error: %v\n", err)
+				} else {
+					fmt.Printf("        Backend: %s  Object Key: %s\n", backend, key)
+				}
+			}
 			if len(f.Metadata) > 0 {
 				fmt.Printf("        Metadata (%d bytes): %s\n", len(f.Metadata), hex.EncodeToString(f.Metadata))
 			}
@@ -1165,7 +1093,16 @@ func printManifest(m *manifest) {
 
 	fmt.Printf("\nDelta Logs (%d):\n", len(m.DeltaLogs))
 	for i, dl := range m.DeltaLogs {
-		fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d\n", i, dl.Path, dl.Type, dl.NumEntries)
+		fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d", i, dl.Path, dl.Type, dl.NumEntries)
+		if resolver != nil {
+			_, key, backend, err := resolver.Resolve(dl.Path, "_delta")
+			if err != nil {
+				fmt.Printf("  (Resolve Error: %v)", err)
+			} else {
+				fmt.Printf("  Backend: %s  Object Key: %s", backend, key)
+			}
+		}
+		fmt.Println()
 	}
 
 	if len(m.Stats) > 0 {
@@ -1174,7 +1111,16 @@ func printManifest(m *manifest) {
 			fmt.Printf("  %s:\n", k)
 			fmt.Printf("    Paths:\n")
 			for _, p := range stat.Paths {
-				fmt.Printf("      - %s\n", p)
+				if resolver != nil {
+					_, key, backend, err := resolver.Resolve(p, "_stats")
+					if err != nil {
+						fmt.Printf("      - %s (Resolve Error: %v)\n", p, err)
+					} else {
+						fmt.Printf("      - %s  Backend: %s  Object Key: %s\n", p, backend, key)
+					}
+				} else {
+					fmt.Printf("      - %s\n", p)
+				}
 			}
 			if len(stat.Metadata) > 0 {
 				fmt.Printf("    Metadata:\n")
@@ -1189,6 +1135,14 @@ func printManifest(m *manifest) {
 		fmt.Printf("\nIndexes (%d):\n", len(m.Indexes))
 		for i, idx := range m.Indexes {
 			fmt.Printf("  [%d] Column: %s  Type: %s  Path: %s\n", i, idx.ColumnName, idx.IndexType, idx.Path)
+			if resolver != nil && idx.Path != "" {
+				_, key, backend, err := resolver.Resolve(idx.Path, "_index")
+				if err != nil {
+					fmt.Printf("      Path Resolve Error: %v\n", err)
+				} else {
+					fmt.Printf("      Backend: %s  Object Key: %s\n", backend, key)
+				}
+			}
 			if m.Version == manifestVersionV6 {
 				fmt.Printf("      Name: %s  FieldID: %d  IndexID: %d  BuildID: %d\n",
 					idx.IndexName, idx.FieldID, idx.IndexID, idx.BuildID)
@@ -1212,8 +1166,17 @@ func printManifest(m *manifest) {
 	if len(m.LobFiles) > 0 {
 		fmt.Printf("\nLOB Files (%d):\n", len(m.LobFiles))
 		for i, lob := range m.LobFiles {
-			fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d\n",
+			fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d",
 				i, lob.Path, lob.FieldID, lob.ValidRows, lob.TotalRows, lob.FileSizeBytes)
+			if resolver != nil {
+				_, key, backend, err := resolver.Resolve(lob.Path, "../lobs")
+				if err != nil {
+					fmt.Printf("  (Resolve Error: %v)", err)
+				} else {
+					fmt.Printf("  Backend: %s  Object Key: %s", backend, key)
+				}
+			}
+			fmt.Println()
 		}
 	}
 }

--- a/states/show_manifest.go
+++ b/states/show_manifest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
 	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/birdwatcher/states/ossutil"
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
 
@@ -67,6 +68,30 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 	}
 	rootPath := resolvedStore.RootPath
 
+	// External collections: build the external store with credentials from the
+	// collection (role_arn / external_id / ...) instead of minio configuration.
+	// Resolve the collection by --collection, or fall back to the first manifest
+	// segment when only --segment is given.
+	var externalStore *oss.ResolvedObjectStore
+	var externalLocation ossutil.ExternalSourceLocation
+	var collection *models.Collection
+	collectionID := p.CollectionID
+	if collectionID == 0 && len(manifestSegments) > 0 {
+		collectionID = manifestSegments[0].CollectionID
+	}
+	if collectionID != 0 {
+		collection, err = common.GetCollectionByIDVersion(ctx, s.client, s.basePath, collectionID)
+		if err != nil {
+			return err
+		}
+		if collection.GetProto().GetSchema().GetExternalSource() != "" {
+			externalStore, externalLocation, err = ossutil.NewResolvedExternalObjectStoreFromCollection(ctx, collection, p.SkipBucketCheck)
+			if err != nil {
+				return fmt.Errorf("failed to create external store: %w", err)
+			}
+		}
+	}
+
 	for _, seg := range manifestSegments {
 		rawManifest := seg.GetManifestPath()
 		fmt.Printf("=== Segment %d (Collection: %d, Partition: %d) ===\n", seg.ID, seg.CollectionID, seg.PartitionID)
@@ -105,6 +130,9 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 			if err := enc.Encode(manifest); err != nil {
 				fmt.Printf("Error encoding JSON: %v\n", err)
 			}
+		} else if externalStore != nil && seg.CollectionID == collectionID {
+			resolver := ossutil.NewManifestPathResolver(resolvedStore.Store, basePath, externalStore.Store, externalLocation)
+			printManifestWithResolver(manifest, resolver)
 		} else {
 			printManifest(manifest)
 		}
@@ -112,6 +140,98 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 	}
 
 	return nil
+}
+
+// printManifestWithResolver prints manifest entries annotated with the storage
+// backend and the resolved object key for each file. It supports manifests that
+// mix external data files with internal function-output files.
+func printManifestWithResolver(m *manifest, resolver *ossutil.ManifestPathResolver) {
+	fmt.Printf("Format:  %s\n", m.Format)
+	if m.Format == "legacy_milv" {
+		fmt.Printf("Magic:   0x%08X (%q)\n", m.Magic, m.MagicStr)
+	}
+	fmt.Printf("Version: %d\n", m.Version)
+
+	fmt.Printf("\nColumn Groups (%d):\n", len(m.ColumnGroups))
+	for i, cg := range m.ColumnGroups {
+		fmt.Printf("\n  --- Column Group #%d ---\n", i)
+		fmt.Printf("  Format:  %s\n", cg.Format)
+		fmt.Printf("  Columns: %v\n", cg.Columns)
+		fmt.Printf("  Files (%d):\n", len(cg.Files))
+		for j, f := range cg.Files {
+			_, key, backend, err := resolver.Resolve(f.Path, "_data")
+			fmt.Printf("    [%d] Path: %s\n", j, f.Path)
+			fmt.Printf("        Range: [%d, %d)\n", f.StartIndex, f.EndIndex)
+			if err != nil {
+				fmt.Printf("        Resolve Error: %v\n", err)
+			} else {
+				fmt.Printf("        Backend: %s  Object Key: %s\n", backend, key)
+			}
+			if len(f.Properties) > 0 {
+				fmt.Printf("        Properties:\n")
+				for pk, pv := range f.Properties {
+					fmt.Printf("          %s: %s\n", pk, pv)
+				}
+			}
+		}
+	}
+
+	fmt.Printf("\nDelta Logs (%d):\n", len(m.DeltaLogs))
+	for i, dl := range m.DeltaLogs {
+		_, key, backend, err := resolver.Resolve(dl.Path, "_delta")
+		if err != nil {
+			fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d  (Resolve Error: %v)\n",
+				i, dl.Path, dl.Type, dl.NumEntries, err)
+		} else {
+			fmt.Printf("  [%d] Path: %s  Type: %s  NumEntries: %d  Backend: %s  Object Key: %s\n",
+				i, dl.Path, dl.Type, dl.NumEntries, backend, key)
+		}
+	}
+
+	if len(m.Stats) > 0 {
+		fmt.Printf("\nStats (%d keys):\n", len(m.Stats))
+		for k, stat := range m.Stats {
+			fmt.Printf("  %s:\n", k)
+			fmt.Printf("    Paths:\n")
+			for _, p := range stat.Paths {
+				_, key, backend, err := resolver.Resolve(p, "_stats")
+				if err != nil {
+					fmt.Printf("      - %s (Resolve Error: %v)\n", p, err)
+				} else {
+					fmt.Printf("      - %s  Backend: %s  Object Key: %s\n", p, backend, key)
+				}
+			}
+		}
+	}
+
+	if len(m.Indexes) > 0 {
+		fmt.Printf("\nIndexes (%d):\n", len(m.Indexes))
+		for i, idx := range m.Indexes {
+			fmt.Printf("  [%d] Column: %s  Type: %s\n", i, idx.ColumnName, idx.IndexType)
+			if idx.Path != "" {
+				_, key, backend, err := resolver.Resolve(idx.Path, "_index")
+				if err != nil {
+					fmt.Printf("      Path: %s (Resolve Error: %v)\n", idx.Path, err)
+				} else {
+					fmt.Printf("      Path: %s  Backend: %s  Object Key: %s\n", idx.Path, backend, key)
+				}
+			}
+		}
+	}
+
+	if len(m.LobFiles) > 0 {
+		fmt.Printf("\nLOB Files (%d):\n", len(m.LobFiles))
+		for i, lob := range m.LobFiles {
+			_, key, backend, err := resolver.Resolve(lob.Path, "../lobs")
+			if err != nil {
+				fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d (Resolve Error: %v)\n",
+					i, lob.Path, lob.FieldID, lob.ValidRows, lob.TotalRows, lob.FileSizeBytes, err)
+			} else {
+				fmt.Printf("  [%d] Path: %s  FieldID: %d  Rows: %d/%d  Size: %d  Backend: %s  Object Key: %s\n",
+					i, lob.Path, lob.FieldID, lob.ValidRows, lob.TotalRows, lob.FileSizeBytes, backend, key)
+			}
+		}
+	}
 }
 
 // Manifest parsing types and logic (Avro binary encoding)

--- a/states/show_manifest.go
+++ b/states/show_manifest.go
@@ -124,16 +124,17 @@ func (s *InstanceState) ShowManifestCommand(ctx context.Context, p *ShowManifest
 			continue
 		}
 
-		if p.JSONOutput {
+		switch {
+		case p.JSONOutput:
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			if err := enc.Encode(manifest); err != nil {
 				fmt.Printf("Error encoding JSON: %v\n", err)
 			}
-		} else if externalStore != nil && seg.CollectionID == collectionID {
+		case externalStore != nil && seg.CollectionID == collectionID:
 			resolver := ossutil.NewManifestPathResolver(resolvedStore.Store, basePath, externalStore.Store, externalLocation)
 			printManifestWithResolver(manifest, resolver)
-		} else {
+		default:
 			printManifest(manifest)
 		}
 		fmt.Println()


### PR DESCRIPTION
show manifest and scan-binlog build object store clients from Milvus component configuration, so they cannot read external collection data files whose role_arn/external_id credentials are stored on the collection schema (external_source + external_spec.extfs), not in minio config.

Add a shared layer in states/ossutil that parses the external spec, builds an external store from collection credentials, and routes each manifest file to the internal or external store. A single manifest can mix external data files with internal function-output files such as sparse vectors generated from varchar columns.

- show manifest: label files with backend and resolved object key
- scan-binlog: read external segments via manifest-driven scan
- inspect-parquet --external: route per-file through the resolver

Add unit tests for extfs parsing and mixed-manifest path routing.