### PR TITLE
feat: diagnose nullable vectors in external collections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ birdwatcher_wkafka:
 	@mkdir -p bin
 	@CGO_ENABLED=1 go build -o bin/birdwatcher_wkafka -tags WKAFKA cmd/birdwatcher/main.go
 
+birdwatcher_lance:
+	@echo "Compiling birdwatcher with Lance support"
+	@test -n "$(MILVUS_STORAGE_PKG_CONFIG_PATH)" || \
+		(echo "MILVUS_STORAGE_PKG_CONFIG_PATH must point to the directory containing milvus-storage.pc" && exit 1)
+	@mkdir -p bin
+	@PKG_CONFIG_PATH="$(MILVUS_STORAGE_PKG_CONFIG_PATH):$(PKG_CONFIG_PATH)" \
+		CGO_ENABLED=1 go build -o bin/birdwatcher_lance -tags LANCE cmd/birdwatcher/main.go
+
 getdeps:
 	@mkdir -p $(INSTALL_PATH)
 	@if [ -z "$(INSTALL_GOLANGCI_LINT)" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/milvus-io/birdwatcher
 go 1.26.4
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/aliyun/credentials-go v1.3.10
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/apache/pulsar-client-go v0.19.0
@@ -51,10 +54,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/AthenZ/athenz v1.12.13 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.9.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 // indirect
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect

--- a/oss/aliyun.go
+++ b/oss/aliyun.go
@@ -159,7 +159,7 @@ func buildAliyunRoleCredentialConfig(p MinioClientParam) (*credentials.Config, e
 	case "oidc":
 		oidcTokenFile := os.Getenv(aliyunOIDCTokenFileEnv)
 		oidcProviderArn := os.Getenv(aliyunOIDCProviderArnEnv)
-		fmt.Printf("Aliyun OIDC credential params: %s=%q %s=%q role_arn=%q\n", aliyunOIDCTokenFileEnv, oidcTokenFile, aliyunOIDCProviderArnEnv, oidcProviderArn, p.RoleARN)
+		fmt.Fprintf(os.Stderr, "Aliyun OIDC credential params: %s=%q %s=%q role_arn=%q\n", aliyunOIDCTokenFileEnv, oidcTokenFile, aliyunOIDCProviderArnEnv, oidcProviderArn, p.RoleARN)
 		if oidcTokenFile == "" || oidcProviderArn == "" {
 			return nil, errors.New("aliyun oidc role mode requires ALIBABA_CLOUD_OIDC_TOKEN_FILE and ALIBABA_CLOUD_OIDC_PROVIDER_ARN")
 		}

--- a/oss/azure.go
+++ b/oss/azure.go
@@ -1,0 +1,460 @@
+package oss
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/birdwatcher/models"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+)
+
+type azureObjectStore struct {
+	client    *service.Client
+	container string
+}
+
+// NewAzureObjectStore creates an Azure Blob-backed ObjectStore.
+func NewAzureObjectStore(ctx context.Context, p MinioClientParam) (ObjectStore, error) {
+	if strings.TrimSpace(p.BucketName) == "" {
+		return nil, errors.New("azure container name is empty")
+	}
+
+	client, err := newAzureServiceClient(p)
+	if err != nil {
+		return nil, err
+	}
+	if !p.skipCheckBucket {
+		_, err = client.NewContainerClient(p.BucketName).GetProperties(ctx, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "check azure container %s", p.BucketName)
+		}
+	}
+
+	return &azureObjectStore{client: client, container: p.BucketName}, nil
+}
+
+func newAzureServiceClient(p MinioClientParam) (*service.Client, error) {
+	options := &service.ClientOptions{}
+	options.Transport = newAzureRedactingTransport()
+	if hasAzureSASBrokerConfig(p) {
+		brokerPolicy, err := newAzureSASBrokerPolicy(p)
+		if err != nil {
+			return nil, err
+		}
+		serviceURL, err := azureServiceURL(p)
+		if err != nil {
+			return nil, err
+		}
+		options.PerCallPolicies = append(options.PerCallPolicies, brokerPolicy)
+		return service.NewClientWithNoCredential(serviceURL, options)
+	}
+	if !p.Anonymous && !p.UseIAM && !p.DisableAzureConnectionString {
+		if connectionString := os.Getenv("AZURE_STORAGE_CONNECTION_STRING"); connectionString != "" {
+			return service.NewClientFromConnectionString(connectionString, options)
+		}
+	}
+	serviceURL, err := azureServiceURL(p)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.Anonymous {
+		return service.NewClientWithNoCredential(serviceURL, options)
+	}
+	if p.UseIAM {
+		if tokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); tokenFile != "" {
+			credential, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+				ClientID:      os.Getenv("AZURE_CLIENT_ID"),
+				TenantID:      os.Getenv("AZURE_TENANT_ID"),
+				TokenFilePath: tokenFile,
+			})
+			if err != nil {
+				return nil, errors.Wrap(err, "create azure workload identity credential")
+			}
+			return service.NewClient(serviceURL, credential, options)
+		}
+
+		identityID := azidentity.ClientID("")
+		if clientID := os.Getenv("AZURE_CLIENT_ID"); clientID != "" {
+			identityID = azidentity.ClientID(clientID)
+		}
+		credential, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{ID: identityID})
+		if err != nil {
+			return nil, errors.Wrap(err, "create azure managed identity credential")
+		}
+		return service.NewClient(serviceURL, credential, options)
+	}
+
+	if p.AK == "" || p.SK == "" {
+		return nil, errors.New("azure storage account name and key are required")
+	}
+	credential, err := azblob.NewSharedKeyCredential(p.AK, p.SK)
+	if err != nil {
+		return nil, errors.Wrap(err, "create azure shared key credential")
+	}
+	return service.NewClientWithSharedKeyCredential(serviceURL, credential, options)
+}
+
+func azureServiceURL(p MinioClientParam) (string, error) {
+	address := strings.Trim(strings.TrimSpace(p.Addr), "/")
+	if address == "" {
+		return "", errors.New("azure storage endpoint is empty")
+	}
+	if err := validateAzureServiceHost(address); err != nil {
+		return "", err
+	}
+
+	accountFromHost, accountQualified := azureAccountFromServiceHost(address)
+	scheme := "http"
+	if p.UseSSL {
+		scheme = "https"
+	}
+	if accountQualified {
+		if p.AK != "" && !strings.EqualFold(strings.TrimSpace(p.AK), accountFromHost) {
+			return "", errors.New("azure storage account name does not match the service endpoint")
+		}
+		return scheme + "://" + address + "/", nil
+	}
+
+	accountName := strings.TrimSpace(p.AK)
+	if accountName == "" {
+		return "", errors.New(
+			"azure storage account name is required when address is an endpoint suffix",
+		)
+	}
+	serviceHost := fmt.Sprintf("%s.blob.%s", accountName, address)
+	if err := validateAzureServiceHost(serviceHost); err != nil {
+		return "", err
+	}
+	return scheme + "://" + serviceHost + "/", nil
+}
+
+func validateAzureServiceHost(host string) error {
+	u, err := url.Parse("https://" + host + "/")
+	if err != nil || u.User != nil || u.Host != host || u.Path != "/" ||
+		u.RawQuery != "" || u.Fragment != "" {
+		return errors.New("azure storage endpoint must be a bare host")
+	}
+	return nil
+}
+
+func azureAccountFromServiceHost(host string) (string, bool) {
+	hostname := strings.ToLower(host)
+	if u, err := url.Parse("https://" + host); err == nil {
+		hostname = strings.ToLower(u.Hostname())
+	}
+	markerIndex := strings.Index(hostname, ".blob.")
+	if markerIndex <= 0 {
+		return "", false
+	}
+	accountName := strings.SplitN(hostname[:markerIndex], ".", 2)[0]
+	return accountName, accountName != ""
+}
+
+func (s *azureObjectStore) Open(ctx context.Context, key string, opts ...OpenOption) (storagecommon.ReadSeeker, error) {
+	settings := &openSettings{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(settings)
+		}
+	}
+
+	start := int64(0)
+	length := int64(-1)
+	if settings.rangeSet {
+		if settings.start < 0 || settings.end < settings.start {
+			return nil, errors.New("invalid open range")
+		}
+		if settings.end-settings.start == math.MaxInt64 {
+			return nil, errors.New("open range is too large")
+		}
+		start = settings.start
+		length = settings.end - settings.start + 1
+	}
+
+	client := s.client.NewContainerClient(s.container).NewBlobClient(key)
+	return &azureBlobReader{
+		ctx:    ctx,
+		client: client,
+		start:  start,
+		length: length,
+	}, nil
+}
+
+func (s *azureObjectStore) Stat(ctx context.Context, key string) (*models.FsStat, error) {
+	response, err := s.client.NewContainerClient(s.container).NewBlobClient(key).GetProperties(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	if response.ContentLength == nil {
+		return nil, errors.New("azure blob response is missing content length")
+	}
+
+	result := &models.FsStat{Size: *response.ContentLength}
+	if response.ETag != nil {
+		result.ETag = string(*response.ETag)
+	}
+	if response.LastModified != nil {
+		result.LastModified = *response.LastModified
+	}
+	if response.VersionID != nil {
+		result.VersionID = *response.VersionID
+	}
+	return result, nil
+}
+
+func (s *azureObjectStore) List(ctx context.Context, prefix string, recursive bool) (<-chan ObjectInfo, error) {
+	result := make(chan ObjectInfo)
+	containerClient := s.client.NewContainerClient(s.container)
+	go func() {
+		defer close(result)
+		if recursive {
+			pager := containerClient.NewListBlobsFlatPager(&azblob.ListBlobsFlatOptions{Prefix: &prefix})
+			for pager.More() {
+				response, err := pager.NextPage(ctx)
+				if err != nil {
+					sendAzureObjectInfo(ctx, result, ObjectInfo{Err: err})
+					return
+				}
+				if response.Segment == nil {
+					sendAzureObjectInfo(ctx, result, ObjectInfo{Err: errors.New("azure list response is missing segment")})
+					return
+				}
+				for _, item := range response.Segment.BlobItems {
+					if item == nil || item.Name == nil {
+						continue
+					}
+					if item.Properties == nil {
+						continue
+					}
+					if !sendAzureObjectInfo(ctx, result, azureBlobItemInfo(
+						item.Name,
+						item.Properties.ContentLength,
+						item.Properties.ETag,
+						item.Properties.LastModified,
+						item.VersionID,
+					)) {
+						return
+					}
+				}
+			}
+			return
+		}
+
+		pager := containerClient.NewListBlobsHierarchyPager("/", &container.ListBlobsHierarchyOptions{Prefix: &prefix})
+		for pager.More() {
+			response, err := pager.NextPage(ctx)
+			if err != nil {
+				sendAzureObjectInfo(ctx, result, ObjectInfo{Err: err})
+				return
+			}
+			if response.Segment == nil {
+				sendAzureObjectInfo(ctx, result, ObjectInfo{Err: errors.New("azure list response is missing segment")})
+				return
+			}
+			for _, item := range response.Segment.BlobItems {
+				if item == nil || item.Name == nil {
+					continue
+				}
+				if item.Properties == nil {
+					continue
+				}
+				if !sendAzureObjectInfo(ctx, result, azureBlobItemInfo(
+					item.Name,
+					item.Properties.ContentLength,
+					item.Properties.ETag,
+					item.Properties.LastModified,
+					item.VersionID,
+				)) {
+					return
+				}
+			}
+			for _, item := range response.Segment.BlobPrefixes {
+				if item == nil || item.Name == nil {
+					continue
+				}
+				if !sendAzureObjectInfo(ctx, result, ObjectInfo{Key: *item.Name, IsDir: true}) {
+					return
+				}
+			}
+		}
+	}()
+	return result, nil
+}
+
+func azureBlobItemInfo(
+	name *string,
+	contentLength *int64,
+	etag *azcore.ETag,
+	lastModified *time.Time,
+	versionID *string,
+) ObjectInfo {
+	result := ObjectInfo{Key: *name}
+	if contentLength != nil {
+		result.Size = *contentLength
+	}
+	if etag != nil {
+		result.ETag = string(*etag)
+	}
+	if lastModified != nil {
+		result.LastModified = *lastModified
+	}
+	if versionID != nil {
+		result.VersionID = *versionID
+	}
+	return result
+}
+
+func sendAzureObjectInfo(ctx context.Context, ch chan<- ObjectInfo, info ObjectInfo) bool {
+	select {
+	case ch <- info:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+type azureBlobReader struct {
+	ctx    context.Context
+	client *blob.Client
+	start  int64
+	length int64
+	pos    int64
+	body   io.ReadCloser
+}
+
+func (r *azureBlobReader) Read(buffer []byte) (int, error) {
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	if r.length >= 0 && r.pos >= r.length {
+		return 0, io.EOF
+	}
+	if r.body == nil {
+		if err := r.openBody(); err != nil {
+			return 0, err
+		}
+	}
+
+	if r.length >= 0 {
+		remaining := r.length - r.pos
+		if int64(len(buffer)) > remaining {
+			buffer = buffer[:remaining]
+		}
+	}
+	n, err := r.body.Read(buffer)
+	r.pos += int64(n)
+	if err == io.EOF {
+		_ = r.closeBody()
+	}
+	return n, err
+}
+
+func (r *azureBlobReader) ReadAt(buffer []byte, offset int64) (int, error) {
+	if offset < 0 {
+		return 0, errors.New("negative azure blob read offset")
+	}
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	if r.length >= 0 && offset >= r.length {
+		return 0, io.EOF
+	}
+
+	readLength := int64(len(buffer))
+	if offset > math.MaxInt64-readLength {
+		return 0, errors.New("azure blob read range overflows int64")
+	}
+	if r.length >= 0 && offset+readLength > r.length {
+		readLength = r.length - offset
+	}
+	response, err := r.client.DownloadStream(r.ctx, &blob.DownloadStreamOptions{
+		Range: blob.HTTPRange{Offset: r.start + offset, Count: readLength},
+	})
+	if err != nil {
+		return 0, err
+	}
+	body := response.NewRetryReader(r.ctx, nil)
+	defer body.Close()
+
+	n, err := io.ReadFull(body, buffer[:readLength])
+	if err != nil {
+		return n, err
+	}
+	if readLength < int64(len(buffer)) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *azureBlobReader) Seek(offset int64, whence int) (int64, error) {
+	var next int64
+	switch whence {
+	case io.SeekStart:
+		next = offset
+	case io.SeekCurrent:
+		next = r.pos + offset
+	case io.SeekEnd:
+		if r.length < 0 {
+			response, err := r.client.GetProperties(r.ctx, nil)
+			if err != nil {
+				return 0, err
+			}
+			if response.ContentLength == nil || *response.ContentLength < r.start {
+				return 0, errors.New("invalid azure blob content length")
+			}
+			r.length = *response.ContentLength - r.start
+		}
+		next = r.length + offset
+	default:
+		return 0, errors.New("invalid seek whence")
+	}
+	if next < 0 {
+		return 0, errors.New("negative azure blob seek position")
+	}
+	if err := r.closeBody(); err != nil {
+		return 0, err
+	}
+	r.pos = next
+	return next, nil
+}
+
+func (r *azureBlobReader) Close() error {
+	return r.closeBody()
+}
+
+func (r *azureBlobReader) openBody() error {
+	httpRange := blob.HTTPRange{Offset: r.start + r.pos}
+	if r.length >= 0 {
+		httpRange.Count = r.length - r.pos
+	}
+	response, err := r.client.DownloadStream(r.ctx, &blob.DownloadStreamOptions{Range: httpRange})
+	if err != nil {
+		return err
+	}
+	r.body = response.NewRetryReader(r.ctx, nil)
+	return nil
+}
+
+func (r *azureBlobReader) closeBody() error {
+	if r.body == nil {
+		return nil
+	}
+	err := r.body.Close()
+	r.body = nil
+	return err
+}

--- a/oss/azure_sas.go
+++ b/oss/azure_sas.go
@@ -1,0 +1,252 @@
+package oss
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+const (
+	defaultAzureSASDuration       = 900
+	defaultAzureSASRequestTimeout = 3 * time.Second
+	azureSASRefreshOffset         = time.Minute
+	maxAzureSASBrokerResponseSize = 1 << 20
+)
+
+type azureSASBrokerConfig struct {
+	endpoint        string
+	region          string
+	bucket          string
+	clientID        string
+	tenantID        string
+	accountName     string
+	durationSeconds int
+}
+
+type azureSASBrokerPolicy struct {
+	broker *azureSASBroker
+}
+
+type azureRedactingTransport struct {
+	client *http.Client
+}
+
+type azureSASBroker struct {
+	config     azureSASBrokerConfig
+	httpClient *http.Client
+	now        func() time.Time
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+type azureSASBrokerRequest struct {
+	CSP              string `json:"csp"`
+	Region           string `json:"region"`
+	Bucket           string `json:"bucket"`
+	DurationSeconds  int    `json:"durationSeconds"`
+	AzureClientID    string `json:"azureClientId"`
+	AzureTenantID    string `json:"azureTenantId"`
+	AzureAccountName string `json:"azureAccountName"`
+}
+
+type azureSASBrokerResponse struct {
+	Success     bool                      `json:"success"`
+	Credentials azureSASBrokerCredentials `json:"credentials"`
+}
+
+type azureSASBrokerCredentials struct {
+	AccountName  string `json:"tempAk"`
+	SessionToken string `json:"sessionToken"`
+	ExpiredAt    string `json:"expiredAt"`
+}
+
+func hasAzureSASBrokerConfig(p MinioClientParam) bool {
+	return p.AzureClientID != "" || p.AzureTenantID != "" || p.AzureCredentialEndpoint != ""
+}
+
+func newAzureSASBrokerPolicy(p MinioClientParam) (policy.Policy, error) {
+	if p.AzureClientID == "" || p.AzureTenantID == "" || p.AzureCredentialEndpoint == "" ||
+		p.AK == "" || p.Region == "" || p.BucketName == "" {
+		return nil, errors.New(
+			"azure credential broker requires client ID, tenant ID, credential endpoint, " +
+				"account name, region, and container",
+		)
+	}
+	if p.SK != "" || p.UseIAM || p.Anonymous || p.RoleARN != "" {
+		return nil, errors.New("azure credential broker cannot be combined with another credential mode")
+	}
+	endpoint, err := url.Parse(p.AzureCredentialEndpoint)
+	if err != nil || endpoint.Host == "" || (endpoint.Scheme != "http" && endpoint.Scheme != "https") {
+		return nil, errors.New("azure credential endpoint must be a valid HTTP(S) URL")
+	}
+
+	durationSeconds := p.LoadFrequency
+	if durationSeconds <= 0 {
+		durationSeconds = defaultAzureSASDuration
+	}
+	requestTimeout := time.Duration(p.AzureRequestTimeoutMs) * time.Millisecond
+	if requestTimeout <= 0 {
+		requestTimeout = defaultAzureSASRequestTimeout
+	}
+	broker := &azureSASBroker{
+		config: azureSASBrokerConfig{
+			endpoint:        p.AzureCredentialEndpoint,
+			region:          p.Region,
+			bucket:          p.BucketName,
+			clientID:        p.AzureClientID,
+			tenantID:        p.AzureTenantID,
+			accountName:     p.AK,
+			durationSeconds: durationSeconds,
+		},
+		httpClient: &http.Client{Timeout: requestTimeout},
+		now:        time.Now,
+	}
+	return &azureSASBrokerPolicy{broker: broker}, nil
+}
+
+func (p *azureSASBrokerPolicy) Do(request *policy.Request) (*http.Response, error) {
+	token, err := p.broker.getToken(request.Raw().Context())
+	if err != nil {
+		return nil, err
+	}
+	requestURL := request.Raw().URL
+	if requestURL.RawQuery == "" {
+		requestURL.RawQuery = token
+	} else {
+		requestURL.RawQuery += "&" + token
+	}
+	return request.Next()
+}
+
+func newAzureRedactingTransport() policy.Transporter {
+	return &azureRedactingTransport{client: &http.Client{}}
+}
+
+func (t *azureRedactingTransport) Do(request *http.Request) (*http.Response, error) {
+	response, err := t.client.Do(request)
+	if err == nil {
+		return response, nil
+	}
+
+	var urlError *url.Error
+	if !errors.As(err, &urlError) {
+		return response, err
+	}
+	sanitized := *urlError
+	requestURL, parseErr := url.Parse(sanitized.URL)
+	if parseErr != nil {
+		sanitized.URL = "<redacted>"
+	} else {
+		requestURL.RawQuery = ""
+		requestURL.ForceQuery = false
+		sanitized.URL = requestURL.String()
+	}
+	return response, &sanitized
+}
+
+func (b *azureSASBroker) getToken(ctx context.Context) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.now()
+	if b.token != "" && b.expiresAt.Sub(now) > azureSASRefreshOffset {
+		return b.token, nil
+	}
+	token, expiresAt, err := b.fetchToken(ctx, now)
+	if err == nil {
+		b.token = token
+		b.expiresAt = expiresAt
+		return token, nil
+	}
+	if b.token != "" {
+		expired := !b.expiresAt.After(now)
+		mlog.Warn(ctx, "Azure credential broker refresh failed",
+			zap.Bool("cached_token_expired", expired),
+			zap.Error(err),
+		)
+		if expired {
+			return "", errors.Wrap(err, "refresh azure credential after cached token expired")
+		}
+		return b.token, nil
+	}
+	return "", err
+}
+
+func (b *azureSASBroker) fetchToken(ctx context.Context, now time.Time) (string, time.Time, error) {
+	payload, err := json.Marshal(azureSASBrokerRequest{
+		CSP:              "azure",
+		Region:           b.config.region,
+		Bucket:           b.config.bucket,
+		DurationSeconds:  b.config.durationSeconds,
+		AzureClientID:    b.config.clientID,
+		AzureTenantID:    b.config.tenantID,
+		AzureAccountName: b.config.accountName,
+	})
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "marshal azure credential broker request")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, b.config.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "create azure credential broker request")
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := b.httpClient.Do(request)
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "request azure credential broker")
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", time.Time{}, errors.Newf(
+			"azure credential broker returned HTTP status %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxAzureSASBrokerResponseSize+1))
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "read azure credential broker response")
+	}
+	if len(body) > maxAzureSASBrokerResponseSize {
+		return "", time.Time{}, errors.New("azure credential broker response exceeds 1 MiB")
+	}
+
+	var result azureSASBrokerResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", time.Time{}, errors.Wrap(err, "parse azure credential broker response")
+	}
+	if !result.Success {
+		return "", time.Time{}, errors.New("azure credential broker returned success=false")
+	}
+	if result.Credentials.AccountName != b.config.accountName {
+		return "", time.Time{}, errors.Newf(
+			"azure credential broker returned token for account %q, expected %q",
+			result.Credentials.AccountName,
+			b.config.accountName,
+		)
+	}
+	token := strings.TrimPrefix(strings.TrimSpace(result.Credentials.SessionToken), "?")
+	query, err := url.ParseQuery(token)
+	if err != nil || query.Get("sig") == "" {
+		return "", time.Time{}, errors.New("azure credential broker returned an invalid SAS token")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, result.Credentials.ExpiredAt)
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "parse azure credential broker token expiration")
+	}
+	if !expiresAt.After(now) {
+		return "", time.Time{}, errors.New("azure credential broker returned an expired SAS token")
+	}
+	return token, expiresAt, nil
+}

--- a/oss/azure_sas.go
+++ b/oss/azure_sas.go
@@ -137,6 +137,7 @@ func newAzureRedactingTransport() policy.Transporter {
 }
 
 func (t *azureRedactingTransport) Do(request *http.Request) (*http.Response, error) {
+	// #nosec G704 -- Azure SDK requests target the operator-configured storage endpoint.
 	response, err := t.client.Do(request)
 	if err == nil {
 		return response, nil

--- a/oss/azure_test.go
+++ b/oss/azure_test.go
@@ -1,0 +1,525 @@
+package oss
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+)
+
+func TestAzureObjectStore(t *testing.T) {
+	content := []byte("0123456789abcdef")
+	lastModified := time.Date(2026, time.September, 2, 8, 0, 0, 0, time.UTC)
+	server := newAzureObjectStoreTestServer(t, content, lastModified)
+	defer server.Close()
+
+	client, err := service.NewClientWithNoCredential(server.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("create azure test client: %v", err)
+	}
+	store := &azureObjectStore{client: client, container: "container"}
+
+	t.Run("open full object", func(t *testing.T) {
+		reader, err := store.Open(t.Context(), "prefix/blob.bin")
+		if err != nil {
+			t.Fatalf("Open() error = %v", err)
+		}
+		closer := reader.(io.Closer)
+		defer closer.Close()
+
+		actual, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		if !bytes.Equal(actual, content) {
+			t.Fatalf("ReadAll() = %q, want %q", actual, content)
+		}
+
+		position, err := reader.Seek(-4, io.SeekEnd)
+		if err != nil {
+			t.Fatalf("Seek() error = %v", err)
+		}
+		if position != int64(len(content)-4) {
+			t.Fatalf("Seek() = %d, want %d", position, len(content)-4)
+		}
+		actual = make([]byte, 4)
+		if _, err := io.ReadFull(reader, actual); err != nil {
+			t.Fatalf("read suffix: %v", err)
+		}
+		if !bytes.Equal(actual, content[len(content)-4:]) {
+			t.Fatalf("suffix = %q, want %q", actual, content[len(content)-4:])
+		}
+	})
+
+	t.Run("open range", func(t *testing.T) {
+		reader, err := store.Open(t.Context(), "prefix/blob.bin", WithOpenRange(3, 7))
+		if err != nil {
+			t.Fatalf("Open() error = %v", err)
+		}
+		defer reader.(io.Closer).Close()
+
+		actual, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		if !bytes.Equal(actual, content[3:8]) {
+			t.Fatalf("range = %q, want %q", actual, content[3:8])
+		}
+
+		actual = make([]byte, 3)
+		if _, err := reader.ReadAt(actual, 1); err != nil {
+			t.Fatalf("ReadAt() error = %v", err)
+		}
+		if !bytes.Equal(actual, content[4:7]) {
+			t.Fatalf("ReadAt() = %q, want %q", actual, content[4:7])
+		}
+	})
+
+	t.Run("invalid range", func(t *testing.T) {
+		if _, err := store.Open(t.Context(), "prefix/blob.bin", WithOpenRange(4, 3)); err == nil {
+			t.Fatal("Open() expected invalid range error")
+		}
+	})
+
+	t.Run("stat", func(t *testing.T) {
+		stat, err := store.Stat(t.Context(), "prefix/blob.bin")
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if stat.Size != int64(len(content)) || stat.ETag != `"etag"` || !stat.LastModified.Equal(lastModified) || stat.VersionID != "version-1" {
+			t.Fatalf("Stat() = %#v", stat)
+		}
+	})
+
+	t.Run("list recursive", func(t *testing.T) {
+		objects, err := store.List(t.Context(), "prefix/", true)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		items := collectAzureObjectInfos(objects)
+		if len(items) != 1 || items[0].Key != "prefix/blob.bin" || items[0].Size != int64(len(content)) || items[0].IsDir {
+			t.Fatalf("List() = %#v", items)
+		}
+	})
+
+	t.Run("list hierarchy", func(t *testing.T) {
+		objects, err := store.List(t.Context(), "prefix/", false)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		items := collectAzureObjectInfos(objects)
+		if len(items) != 2 || items[0].Key != "prefix/blob.bin" || items[1].Key != "prefix/dir/" || !items[1].IsDir {
+			t.Fatalf("List() = %#v", items)
+		}
+	})
+}
+
+func TestNewAzureObjectStore(t *testing.T) {
+	t.Run("empty container", func(t *testing.T) {
+		_, err := NewAzureObjectStore(t.Context(), MinioClientParam{})
+		if err == nil || !strings.Contains(err.Error(), "container name is empty") {
+			t.Fatalf("NewAzureObjectStore() error = %v", err)
+		}
+	})
+
+	t.Run("container check", func(t *testing.T) {
+		checked := make(chan struct{}, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			if request.URL.Query().Get("restype") != "container" {
+				t.Errorf("unexpected azure request: %s", request.URL.String())
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			select {
+			case checked <- struct{}{}:
+			default:
+			}
+			response.Header().Set("x-ms-request-id", "request-id")
+			response.Header().Set("x-ms-version", "2021-12-02")
+			response.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		accountKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+		t.Setenv("AZURE_STORAGE_CONNECTION_STRING", fmt.Sprintf(
+			"DefaultEndpointsProtocol=http;AccountName=test;AccountKey=%s;BlobEndpoint=%s/test;",
+			accountKey,
+			server.URL,
+		))
+		store, err := NewAzureObjectStore(t.Context(), MinioClientParam{BucketName: "container"})
+		if err != nil {
+			t.Fatalf("NewAzureObjectStore() error = %v", err)
+		}
+		if store == nil {
+			t.Fatal("NewAzureObjectStore() returned nil store")
+		}
+		select {
+		case <-checked:
+		default:
+			t.Fatal("NewAzureObjectStore() did not check the container")
+		}
+	})
+
+	t.Run("skip container check", func(t *testing.T) {
+		requested := make(chan struct{}, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			select {
+			case requested <- struct{}{}:
+			default:
+			}
+			response.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		accountKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+		t.Setenv("AZURE_STORAGE_CONNECTION_STRING", fmt.Sprintf(
+			"DefaultEndpointsProtocol=http;AccountName=test;AccountKey=%s;BlobEndpoint=%s/test;",
+			accountKey,
+			server.URL,
+		))
+		param := MinioClientParam{BucketName: "container"}
+		WithSkipCheckBucket(true)(&param)
+		store, err := NewAzureObjectStore(t.Context(), param)
+		if err != nil {
+			t.Fatalf("NewAzureObjectStore() error = %v", err)
+		}
+		if store == nil {
+			t.Fatal("NewAzureObjectStore() returned nil store")
+		}
+		select {
+		case <-requested:
+			t.Fatal("skip bucket check issued an HTTP request")
+		default:
+		}
+	})
+}
+
+func TestAzureServiceURL(t *testing.T) {
+	url, err := azureServiceURL(MinioClientParam{
+		AK:     "account",
+		Addr:   "core.windows.net/",
+		UseSSL: true,
+	})
+	if err != nil {
+		t.Fatalf("azureServiceURL() error = %v", err)
+	}
+	if url != "https://account.blob.core.windows.net/" {
+		t.Fatalf("azureServiceURL() = %q", url)
+	}
+	url, err = azureServiceURL(MinioClientParam{
+		AK:     "account",
+		Addr:   "account.blob.core.windows.net",
+		UseSSL: true,
+	})
+	if err != nil {
+		t.Fatalf("azureServiceURL() with account-qualified host error = %v", err)
+	}
+	if url != "https://account.blob.core.windows.net/" {
+		t.Fatalf("azureServiceURL() with account-qualified host = %q", url)
+	}
+	url, err = azureServiceURL(MinioClientParam{
+		Addr:   "account.blob.core.windows.net",
+		UseSSL: true,
+	})
+	if err != nil {
+		t.Fatalf("azureServiceURL() without explicit account error = %v", err)
+	}
+	if url != "https://account.blob.core.windows.net/" {
+		t.Fatalf("azureServiceURL() without explicit account = %q", url)
+	}
+	url, err = azureServiceURL(MinioClientParam{
+		AK:   "account",
+		Addr: "core.windows.net",
+	})
+	if err != nil {
+		t.Fatalf("azureServiceURL() with HTTP error = %v", err)
+	}
+	if url != "http://account.blob.core.windows.net/" {
+		t.Fatalf("azureServiceURL() with HTTP = %q", url)
+	}
+	url, err = azureServiceURL(MinioClientParam{Addr: "account.blob.core.windows.net"})
+	if err != nil {
+		t.Fatalf("azureServiceURL() with account-qualified HTTP error = %v", err)
+	}
+	if url != "http://account.blob.core.windows.net/" {
+		t.Fatalf("azureServiceURL() with account-qualified HTTP = %q", url)
+	}
+	if _, err := azureServiceURL(MinioClientParam{Addr: "core.windows.net"}); err == nil {
+		t.Fatal("azureServiceURL() expected account error")
+	}
+	if _, err := azureServiceURL(MinioClientParam{
+		AK:   "other-account",
+		Addr: "account.blob.core.windows.net",
+	}); err == nil {
+		t.Fatal("azureServiceURL() expected account mismatch error")
+	}
+	if _, err := azureServiceURL(MinioClientParam{AK: "account"}); err == nil {
+		t.Fatal("azureServiceURL() expected endpoint error")
+	}
+
+	accountKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING",
+		"DefaultEndpointsProtocol=https;AccountName=ambientaccount;AccountKey="+
+			accountKey+";EndpointSuffix=core.windows.net")
+	client, err := newAzureServiceClient(MinioClientParam{
+		AK:                           "requestaccount",
+		SK:                           accountKey,
+		Addr:                         "core.windows.net",
+		UseSSL:                       true,
+		DisableAzureConnectionString: true,
+	})
+	if err != nil {
+		t.Fatalf("newAzureServiceClient() error = %v", err)
+	}
+	if client.URL() != "https://requestaccount.blob.core.windows.net/" {
+		t.Fatalf("newAzureServiceClient() URL = %q", client.URL())
+	}
+}
+
+func TestAzureRedactingTransportRedactsQueryFromErrors(t *testing.T) {
+	transport := &azureRedactingTransport{client: &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial failed")
+		}),
+	}}
+	request, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"https://account.blob.core.windows.net/container/blob?sv=1&sig=secret-signature",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	_, err = transport.Do(request)
+	if err == nil {
+		t.Fatal("azureRedactingTransport.Do() expected an error")
+	}
+	if strings.Contains(err.Error(), "secret-signature") || strings.Contains(err.Error(), "sig=") {
+		t.Fatalf("azureRedactingTransport.Do() leaked SAS query: %v", err)
+	}
+	if !strings.Contains(err.Error(), "account.blob.core.windows.net/container/blob") {
+		t.Fatalf("azureRedactingTransport.Do() removed the useful object path: %v", err)
+	}
+}
+
+func TestAzureSASBrokerRefreshFallback(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	newBroker := func(expiresAt time.Time) *azureSASBroker {
+		return &azureSASBroker{
+			config:     azureSASBrokerConfig{endpoint: server.URL},
+			httpClient: server.Client(),
+			now: func() time.Time {
+				return now
+			},
+			token:     "sv=1&sig=cached",
+			expiresAt: expiresAt,
+		}
+	}
+
+	t.Run("still valid", func(t *testing.T) {
+		broker := newBroker(now.Add(30 * time.Second))
+		token, err := broker.getToken(t.Context())
+		if err != nil {
+			t.Fatalf("getToken() error = %v", err)
+		}
+		if token != "sv=1&sig=cached" {
+			t.Fatalf("getToken() = %q", token)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		broker := newBroker(now.Add(-time.Second))
+		token, err := broker.getToken(t.Context())
+		if err == nil || !strings.Contains(err.Error(), "cached token expired") {
+			t.Fatalf("getToken() token = %q, error = %v", token, err)
+		}
+		if token != "" {
+			t.Fatalf("getToken() returned expired token %q", token)
+		}
+	})
+}
+
+func TestAzureSASBrokerPolicy(t *testing.T) {
+	var brokerRequests int
+	var brokerRequest azureSASBrokerRequest
+	broker := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		brokerRequests++
+		if request.Method != http.MethodPost || request.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected broker request: method=%s content-type=%s", request.Method, request.Header.Get("Content-Type"))
+		}
+		if err := json.NewDecoder(request.Body).Decode(&brokerRequest); err != nil {
+			t.Errorf("decode broker request: %v", err)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"success": true,
+			"credentials": map[string]string{
+				"tempAk":       "account",
+				"sessionToken": "?sv=1&sig=encoded%2Bsignature%3D",
+				"expiredAt":    time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+		})
+	}))
+	defer broker.Close()
+
+	brokerPolicy, err := newAzureSASBrokerPolicy(MinioClientParam{
+		AK:                      "account",
+		Region:                  "westus3",
+		BucketName:              "container",
+		AzureClientID:           "client-id",
+		AzureTenantID:           "tenant-id",
+		AzureCredentialEndpoint: broker.URL,
+		LoadFrequency:           3600,
+	})
+	if err != nil {
+		t.Fatalf("newAzureSASBrokerPolicy() error = %v", err)
+	}
+
+	var storageRequests int
+	storage := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		storageRequests++
+		query := request.URL.Query()
+		if query.Get("restype") != "container" || query.Get("sig") != "encoded+signature=" {
+			t.Errorf("storage query = %q", request.URL.RawQuery)
+		}
+		response.Header().Set("x-ms-request-id", "request-id")
+		response.Header().Set("x-ms-version", "2021-12-02")
+		response.WriteHeader(http.StatusOK)
+	}))
+	defer storage.Close()
+
+	options := &service.ClientOptions{}
+	options.PerCallPolicies = append(options.PerCallPolicies, brokerPolicy)
+	client, err := service.NewClientWithNoCredential(storage.URL+"/", options)
+	if err != nil {
+		t.Fatalf("create azure test client: %v", err)
+	}
+	for range 2 {
+		if _, err := client.NewContainerClient("container").GetProperties(t.Context(), nil); err != nil {
+			t.Fatalf("GetProperties() error = %v", err)
+		}
+	}
+	if brokerRequests != 1 || storageRequests != 2 {
+		t.Fatalf("request counts: broker=%d storage=%d", brokerRequests, storageRequests)
+	}
+	if brokerRequest.CSP != "azure" || brokerRequest.Region != "westus3" ||
+		brokerRequest.Bucket != "container" || brokerRequest.DurationSeconds != 3600 ||
+		brokerRequest.AzureClientID != "client-id" || brokerRequest.AzureTenantID != "tenant-id" ||
+		brokerRequest.AzureAccountName != "account" {
+		t.Fatalf("broker request = %#v", brokerRequest)
+	}
+}
+
+func TestAzureSASBrokerPolicyRejectsIncompleteConfig(t *testing.T) {
+	_, err := newAzureSASBrokerPolicy(MinioClientParam{
+		AK:                      "account",
+		Region:                  "westus3",
+		BucketName:              "container",
+		AzureClientID:           "client-id",
+		AzureCredentialEndpoint: "https://broker.example.com",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires client ID") {
+		t.Fatalf("newAzureSASBrokerPolicy() error = %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func newAzureObjectStoreTestServer(t *testing.T, content []byte, lastModified time.Time) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("x-ms-request-id", "request-id")
+		response.Header().Set("x-ms-version", "2021-12-02")
+
+		if request.URL.Query().Get("comp") == "list" {
+			response.Header().Set("Content-Type", "application/xml")
+			hierarchy := request.URL.Query().Get("delimiter") == "/"
+			prefix := ""
+			if hierarchy {
+				prefix = "<BlobPrefix><Name>prefix/dir/</Name></BlobPrefix>"
+			}
+			_, _ = fmt.Fprintf(response, `<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="%s" ContainerName="container">
+  <Prefix>prefix/</Prefix><Marker></Marker><MaxResults>5000</MaxResults>
+  <Blobs>
+    <Blob>
+      <Name>prefix/blob.bin</Name><Deleted>false</Deleted><Snapshot></Snapshot><VersionId>version-1</VersionId>
+      <Properties><Last-Modified>%s</Last-Modified><Etag>"etag"</Etag><Content-Length>%d</Content-Length><BlobType>BlockBlob</BlobType></Properties>
+    </Blob>
+    %s
+  </Blobs>
+  <NextMarker></NextMarker>
+</EnumerationResults>`, request.URL.Scheme+request.URL.Host, lastModified.Format(http.TimeFormat), len(content), prefix)
+			return
+		}
+
+		if request.Method == http.MethodHead {
+			response.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			response.Header().Set("ETag", `"etag"`)
+			response.Header().Set("Last-Modified", lastModified.Format(http.TimeFormat))
+			response.Header().Set("x-ms-version-id", "version-1")
+			response.WriteHeader(http.StatusOK)
+			return
+		}
+
+		rangeHeader := request.Header.Get("x-ms-range")
+		if rangeHeader == "" {
+			rangeHeader = request.Header.Get("Range")
+		}
+		start, end := parseAzureTestRange(t, rangeHeader, int64(len(content)))
+		response.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
+		response.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(content)))
+		response.Header().Set("ETag", `"etag"`)
+		response.Header().Set("Last-Modified", lastModified.Format(http.TimeFormat))
+		response.WriteHeader(http.StatusPartialContent)
+		_, _ = response.Write(content[start : end+1])
+	}))
+}
+
+func parseAzureTestRange(t *testing.T, value string, size int64) (int64, int64) {
+	t.Helper()
+	if value == "" {
+		return 0, size - 1
+	}
+	value = strings.TrimPrefix(value, "bytes=")
+	parts := strings.SplitN(value, "-", 2)
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		t.Fatalf("invalid range start %q: %v", value, err)
+	}
+	end := size - 1
+	if len(parts) == 2 && parts[1] != "" {
+		end, err = strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			t.Fatalf("invalid range end %q: %v", value, err)
+		}
+	}
+	return start, end
+}
+
+func collectAzureObjectInfos(source <-chan ObjectInfo) []ObjectInfo {
+	var result []ObjectInfo
+	for item := range source {
+		result = append(result, item)
+	}
+	return result
+}

--- a/oss/azure_test.go
+++ b/oss/azure_test.go
@@ -320,6 +320,7 @@ func TestAzureSASBrokerRefreshFallback(t *testing.T) {
 	defer server.Close()
 
 	newBroker := func(expiresAt time.Time) *azureSASBroker {
+		// #nosec G101 -- This broker uses a synthetic SAS token for cache tests.
 		return &azureSASBroker{
 			config:     azureSASBrokerConfig{endpoint: server.URL},
 			httpClient: server.Client(),
@@ -337,6 +338,7 @@ func TestAzureSASBrokerRefreshFallback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("getToken() error = %v", err)
 		}
+		// #nosec G101 -- Expected synthetic SAS token, not a credential.
 		if token != "sv=1&sig=cached" {
 			t.Fatalf("getToken() = %q", token)
 		}
@@ -368,6 +370,7 @@ func TestAzureSASBrokerPolicy(t *testing.T) {
 		response.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(response).Encode(map[string]any{
 			"success": true,
+			// #nosec G101 -- Synthetic broker response used only by the test server.
 			"credentials": map[string]string{
 				"tempAk":       "account",
 				"sessionToken": "?sv=1&sig=encoded%2Bsignature%3D",
@@ -426,6 +429,7 @@ func TestAzureSASBrokerPolicy(t *testing.T) {
 }
 
 func TestAzureSASBrokerPolicyRejectsIncompleteConfig(t *testing.T) {
+	// #nosec G101 -- Placeholder account and client identifiers for validation tests.
 	_, err := newAzureSASBrokerPolicy(MinioClientParam{
 		AK:                      "account",
 		Region:                  "westus3",
@@ -468,7 +472,7 @@ func newAzureObjectStoreTestServer(t *testing.T, content []byte, lastModified ti
     %s
   </Blobs>
   <NextMarker></NextMarker>
-</EnumerationResults>`, request.URL.Scheme+request.URL.Host, lastModified.Format(http.TimeFormat), len(content), prefix)
+</EnumerationResults>`, "https://account.blob.core.windows.net", lastModified.Format(http.TimeFormat), len(content), prefix)
 			return
 		}
 

--- a/oss/minio.go
+++ b/oss/minio.go
@@ -3,6 +3,7 @@ package oss
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -17,24 +18,33 @@ const (
 	CloudProviderAzure   = "azure"
 	CloudProviderTencent = "tencent"
 	CloudProviderHuawei  = "huawei"
+	CloudProviderMinio   = "minio"
 )
 
 type MinioClientParam struct {
-	Addr          string
-	Port          string
-	AK            string
-	SK            string
-	UseIAM        bool
-	IAMEndpoint   string
-	UseSSL        bool
-	CloudProvider string
-	Region        string
+	Addr           string
+	Port           string
+	AK             string
+	SK             string
+	UseIAM         bool
+	Anonymous      bool
+	IAMEndpoint    string
+	UseSSL         bool
+	UseVirtualHost *bool
+	CloudProvider  string
+	Region         string
 
 	RoleARN            string
 	RoleSessionName    string
 	ExternalID         string
 	LoadFrequency      int
 	AliyunRoleAuthMode string
+
+	AzureClientID                string
+	AzureTenantID                string
+	AzureCredentialEndpoint      string
+	AzureRequestTimeoutMs        int64
+	DisableAzureConnectionString bool
 
 	BucketName string
 	RootPath   string
@@ -200,7 +210,7 @@ func NewMinioClient(ctx context.Context, p MinioClientParam) (*MinioClient, erro
 
 	var err error
 	switch p.CloudProvider {
-	case CloudProviderAWS:
+	case CloudProviderAWS, CloudProviderMinio:
 		err = processMinioAwsOptions(p, opts)
 	case CloudProviderGCP:
 		// adhoc to remove port of gcs address to let minio-go know it's gcs
@@ -215,30 +225,39 @@ func NewMinioClient(ctx context.Context, p MinioClientParam) (*MinioClient, erro
 	case CloudProviderHuawei:
 		err = processMinioHuaweiOptions(p, opts)
 	case CloudProviderAzure:
-		// TODO support azure
-		fallthrough
+		return nil, errors.New("azure storage requires the ObjectStore API")
 	default:
 		return nil, errors.Newf("Cloud provider %s not supported yet", p.CloudProvider)
 	}
 	if err != nil {
 		return nil, err
 	}
+	if p.Anonymous {
+		opts.Creds = credentials.NewStaticV4("", "", "")
+	}
+	if p.UseVirtualHost != nil {
+		if *p.UseVirtualHost {
+			opts.BucketLookup = minio.BucketLookupDNS
+		} else {
+			opts.BucketLookup = minio.BucketLookupPath
+		}
+	}
 
-	fmt.Printf("Start to connect to oss endpoint: %s\n", endpoint)
+	fmt.Fprintf(os.Stderr, "Start to connect to oss endpoint: %s\n", endpoint)
 	client, err := minio.New(endpoint, opts)
 	if err != nil {
-		fmt.Println("new client failed: ", err.Error())
+		fmt.Fprintln(os.Stderr, "new client failed: ", err.Error())
 		return nil, err
 	}
 
-	fmt.Println("Connection successful!")
+	fmt.Fprintln(os.Stderr, "Connection successful!")
 
 	if p.skipCheckBucket {
-		fmt.Println("Skip bucket existence check...")
+		fmt.Fprintln(os.Stderr, "Skip bucket existence check...")
 	} else {
 		ok, err := client.BucketExists(ctx, p.BucketName)
 		if err != nil {
-			fmt.Printf("check bucket %s exists failed: %s\n", p.BucketName, err.Error())
+			fmt.Fprintf(os.Stderr, "check bucket %s exists failed: %s\n", p.BucketName, err.Error())
 			return nil, err
 		}
 		if !ok {

--- a/oss/minio_test.go
+++ b/oss/minio_test.go
@@ -1,0 +1,43 @@
+package oss
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestNewMinioClientKeepsStdoutClean(t *testing.T) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = writePipe
+	defer func() {
+		os.Stdout = oldStdout
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	}()
+
+	param := MinioClientParam{
+		Addr:          "localhost:9000",
+		CloudProvider: CloudProviderAWS,
+		BucketName:    "test-bucket",
+	}
+	WithSkipCheckBucket(true)(&param)
+	if _, err := NewMinioClient(t.Context(), param); err != nil {
+		t.Fatalf("NewMinioClient() error = %v", err)
+	}
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("close stdout capture: %v", err)
+	}
+	os.Stdout = oldStdout
+
+	output, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("read stdout capture: %v", err)
+	}
+	if len(output) != 0 {
+		t.Fatalf("NewMinioClient() stdout = %q, want empty", output)
+	}
+}

--- a/states/inspect_external_vector_nulls.go
+++ b/states/inspect_external_vector_nulls.go
@@ -1,0 +1,1176 @@
+package states
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/bitutil"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/file"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	"github.com/cockroachdb/errors"
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+type ExternalVectorNullRange struct {
+	SegmentID          int64  `json:"segment_id"`
+	ObjectKey          string `json:"object_key"`
+	StartIndex         int64  `json:"start_index"`
+	EndIndex           int64  `json:"end_index"`
+	ArrowType          string `json:"arrow_type,omitempty"`
+	Rows               int64  `json:"rows"`
+	ValidRows          int64  `json:"valid_rows"`
+	MetadataNoNullRows int64  `json:"metadata_no_null_rows"`
+	RowNullRows        int64  `json:"row_null_rows"`
+	FullNullRows       int64  `json:"full_null_rows"`
+	PartialNullRows    int64  `json:"partial_null_rows"`
+	InvalidLengthRows  int64  `json:"invalid_length_rows"`
+	InspectionError    string `json:"inspection_error,omitempty"`
+}
+
+func (f *ExternalVectorNullRange) hasIssue() bool {
+	return f.RowNullRows > 0 || f.FullNullRows > 0 || f.PartialNullRows > 0 ||
+		f.InvalidLengthRows > 0 || f.InspectionError != ""
+}
+
+type ExternalVectorNullReport struct {
+	CollectionID       int64                      `json:"collection_id"`
+	CollectionName     string                     `json:"collection_name"`
+	FieldID            int64                      `json:"field_id"`
+	FieldName          string                     `json:"field_name"`
+	ExternalField      string                     `json:"external_field"`
+	FieldType          string                     `json:"field_type"`
+	Nullable           bool                       `json:"nullable"`
+	Dimension          int64                      `json:"dimension"`
+	ExternalSource     string                     `json:"external_source"`
+	Format             string                     `json:"format"`
+	SourcePrefix       string                     `json:"source_prefix"`
+	Exact              bool                       `json:"exact"`
+	SegmentsMatched    int64                      `json:"segments_matched"`
+	FilesFound         int64                      `json:"files_found"`
+	FilesScanned       int64                      `json:"files_scanned"`
+	RowGroupsScanned   int64                      `json:"row_groups_scanned"`
+	RowGroupsSkipped   int64                      `json:"row_groups_skipped"`
+	RangesFound        int64                      `json:"ranges_found"`
+	RangesScanned      int64                      `json:"ranges_scanned"`
+	RangesWithIssues   int64                      `json:"ranges_with_issues"`
+	RangesFailed       int64                      `json:"ranges_failed"`
+	Rows               int64                      `json:"rows"`
+	ValidRows          int64                      `json:"valid_rows"`
+	MetadataNoNullRows int64                      `json:"metadata_no_null_rows"`
+	RowNullRows        int64                      `json:"row_null_rows"`
+	FullNullRows       int64                      `json:"full_null_rows"`
+	PartialNullRows    int64                      `json:"partial_null_rows"`
+	InvalidLengthRows  int64                      `json:"invalid_length_rows"`
+	Ranges             []*ExternalVectorNullRange `json:"ranges,omitempty"`
+}
+
+func (r *ExternalVectorNullReport) Entities() any {
+	return r
+}
+
+func (r *ExternalVectorNullReport) PrintAs(format framework.Format) string {
+	switch format {
+	case framework.FormatJSON:
+		return framework.MarshalJSON(r)
+	case framework.FormatLine:
+		var sb strings.Builder
+		summary := *r
+		summary.Ranges = nil
+		payload, err := json.Marshal(&summary)
+		if err == nil {
+			sb.Write(payload)
+		}
+		for _, result := range r.Ranges {
+			payload, err := json.Marshal(result)
+			if err != nil {
+				continue
+			}
+			if sb.Len() > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.Write(payload)
+		}
+		return sb.String()
+	default:
+		return r.printPlain()
+	}
+}
+
+func (r *ExternalVectorNullReport) TableHeaders() table.Row {
+	return table.Row{"Segment", "Object range", "Rows", "Valid", "Metadata no-null", "Row null", "Full null", "Partial null", "Invalid length", "Error"}
+}
+
+func (r *ExternalVectorNullReport) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(r.Ranges))
+	for _, result := range r.Ranges {
+		rows = append(rows, table.Row{
+			result.SegmentID,
+			fmt.Sprintf("%s[%d,%d)", result.ObjectKey, result.StartIndex, result.EndIndex),
+			result.Rows,
+			result.ValidRows,
+			result.MetadataNoNullRows,
+			result.RowNullRows,
+			result.FullNullRows,
+			result.PartialNullRows,
+			result.InvalidLengthRows,
+			result.InspectionError,
+		})
+	}
+	return rows
+}
+
+func (r *ExternalVectorNullReport) TableTitle() string {
+	return fmt.Sprintf(
+		"External vector nulls: collection=%d field=%s format=%s segments=%d files=%d/%d ranges=%d/%d rows=%d metadata_no_null=%d row_null=%d full_null=%d partial_null=%d invalid_length=%d failed=%d",
+		r.CollectionID,
+		r.FieldName,
+		r.Format,
+		r.SegmentsMatched,
+		r.FilesScanned,
+		r.FilesFound,
+		r.RangesScanned,
+		r.RangesFound,
+		r.Rows,
+		r.MetadataNoNullRows,
+		r.RowNullRows,
+		r.FullNullRows,
+		r.PartialNullRows,
+		r.InvalidLengthRows,
+		r.RangesFailed,
+	)
+}
+
+func (r *ExternalVectorNullReport) printPlain() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "External vector null scan\n")
+	fmt.Fprintf(&sb, "Collection: %s(%d)\n", r.CollectionName, r.CollectionID)
+	fmt.Fprintf(&sb, "Field: %s(%d) -> %s | type=%s nullable=%t dim=%d\n",
+		r.FieldName, r.FieldID, r.ExternalField, r.FieldType, r.Nullable, r.Dimension)
+	fmt.Fprintf(&sb, "Source: %s\n", r.ExternalSource)
+	fmt.Fprintf(&sb, "Scope: format=%s prefix=%s segments=%d files=%d/%d ranges=%d/%d failed=%d with_issues=%d\n",
+		r.Format, r.SourcePrefix, r.SegmentsMatched, r.FilesScanned, r.FilesFound,
+		r.RangesScanned, r.RangesFound, r.RangesFailed, r.RangesWithIssues)
+	fmt.Fprintf(&sb, "I/O: exact=%t row_groups_scanned=%d row_groups_skipped=%d\n",
+		r.Exact, r.RowGroupsScanned, r.RowGroupsSkipped)
+	fmt.Fprintf(&sb, "Definitions: row_null=parent list is null; full_null=expected-length parent-valid list with all child elements null; partial_null=expected-length parent-valid list with mixed valid/null child elements\n")
+	fmt.Fprintf(&sb, "Rows: total=%d valid=%d metadata_no_null=%d row_null=%d full_null=%d partial_null=%d invalid_length=%d",
+		r.Rows, r.ValidRows, r.MetadataNoNullRows, r.RowNullRows, r.FullNullRows, r.PartialNullRows, r.InvalidLengthRows)
+	if r.MetadataNoNullRows > 0 {
+		fmt.Fprintf(&sb, "\nNote: metadata_no_null rows are proven null-free by Parquet statistics; vector lengths were not read or validated")
+	}
+	if r.RangesFailed > 0 {
+		fmt.Fprintf(&sb, "\nWarning: %d range(s) failed inspection; aggregate row counts are incomplete", r.RangesFailed)
+	}
+	for _, result := range r.Ranges {
+		fmt.Fprintf(&sb,
+			"\n  segment=%d object=%s range=[%d,%d) type=%s rows=%d valid=%d metadata_no_null=%d row_null=%d full_null=%d partial_null=%d invalid_length=%d",
+			result.SegmentID,
+			result.ObjectKey,
+			result.StartIndex,
+			result.EndIndex,
+			result.ArrowType,
+			result.Rows,
+			result.ValidRows,
+			result.MetadataNoNullRows,
+			result.RowNullRows,
+			result.FullNullRows,
+			result.PartialNullRows,
+			result.InvalidLengthRows,
+		)
+		if result.InspectionError != "" {
+			fmt.Fprintf(&sb, " error=%q", result.InspectionError)
+		}
+	}
+	return sb.String()
+}
+
+func (s *InstanceState) scanExternalVectorNullSegments(ctx context.Context, collection *models.Collection, p *ScanBinlogParams) (*ExternalVectorNullReport, error) {
+	if collection == nil || collection.GetProto() == nil || collection.GetProto().GetSchema() == nil {
+		return nil, errors.New("collection metadata does not contain a schema")
+	}
+	collectionInfo := collection.GetProto()
+	schema := collectionInfo.GetSchema()
+	if strings.TrimSpace(schema.GetExternalSource()) == "" {
+		return nil, errors.Newf(
+			"collection %d is not an external collection: external_source is empty", collectionInfo.GetID())
+	}
+
+	if len(p.Fields) != 1 || strings.TrimSpace(p.Fields[0]) == "" {
+		return nil, errors.New("detect-vector-nulls action requires exactly one field name in --fields")
+	}
+	if p.WorkerNum <= 0 || p.WorkerNum > 64 {
+		return nil, errors.New("--workerNum must be between 1 and 64")
+	}
+	if p.BatchSize <= 0 {
+		return nil, errors.New("--batchSize must be positive")
+	}
+
+	field, externalField, dim, err := resolveExternalVectorField(schema, strings.TrimSpace(p.Fields[0]))
+	if err != nil {
+		return nil, err
+	}
+	spec, err := parseExternalSpec(schema.GetExternalSpec())
+	if err != nil {
+		return nil, err
+	}
+	format := strings.ToLower(strings.TrimSpace(spec.Format))
+	if format == "" {
+		format = "parquet"
+	}
+	if format != "parquet" && format != "lance-table" {
+		return nil, errors.Newf("external collection format %s is not supported", format)
+	}
+	if format == "lance-table" {
+		if err := ensureLanceVectorScannerAvailable(); err != nil {
+			return nil, err
+		}
+	}
+
+	segments, err := common.ListSegments(ctx, s.client, s.basePath, func(segment *models.Segment) bool {
+		return (p.SegmentID == 0 || p.SegmentID == segment.ID) &&
+			p.CollectionID == segment.CollectionID &&
+			(p.PartitionID == 0 || p.PartitionID == segment.PartitionID) &&
+			(p.IncludeUnhealthy || segment.State != commonpb.SegmentState_Dropped)
+	})
+	if err != nil {
+		return nil, err
+	}
+	segments, err = selectExternalCollectionSegments(segments, p.SegmentID)
+	if err != nil {
+		return nil, err
+	}
+	if len(segments) == 0 {
+		return nil, errors.New("no external collection segments matched the supplied filters")
+	}
+
+	manifestParams := []oss.MinioConnectParam{oss.WithSkipCheckBucket(p.SkipBucketCheck)}
+	if p.MinioAddress != "" {
+		manifestParams = append(manifestParams, oss.WithMinioAddr(p.MinioAddress))
+	}
+	manifestStore, err := s.GetObjectStore(ctx, manifestParams...)
+	if err != nil {
+		return nil, err
+	}
+
+	var externalStore oss.ObjectStore
+	var externalRootPath string
+	var location externalSourceLocation
+	if format == "parquet" {
+		store, _, rootPath, resolvedLocation, err := newExternalObjectStore(
+			ctx, schema.GetExternalSource(), spec, p.SkipBucketCheck)
+		if err != nil {
+			return nil, err
+		}
+		externalStore = store
+		externalRootPath = rootPath
+		location = resolvedLocation
+	} else {
+		location, err = externalSourceLocationForSpec(schema.GetExternalSource(), spec)
+		if err != nil {
+			return nil, err
+		}
+		externalRootPath = location.RootPath
+	}
+
+	ranges := make([]externalVectorSegmentRange, 0)
+	for _, segment := range segments {
+		segmentRanges, err := externalVectorRangesForSegment(
+			ctx,
+			manifestStore.Store,
+			manifestStore.RootPath,
+			location,
+			segment,
+			field.GetFieldID(),
+			externalField,
+			format,
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolve vector source ranges for segment %d", segment.GetID())
+		}
+		ranges = append(ranges, segmentRanges...)
+	}
+	if len(ranges) == 0 {
+		return nil, errors.Newf("no source ranges found for field %s in matched segment manifests", field.GetName())
+	}
+	filesFound := make(map[string]struct{})
+	for _, sourceRange := range ranges {
+		filesFound[sourceRange.ObjectKey] = struct{}{}
+	}
+
+	report := &ExternalVectorNullReport{
+		CollectionID:    collectionInfo.GetID(),
+		CollectionName:  schema.GetName(),
+		FieldID:         field.GetFieldID(),
+		FieldName:       field.GetName(),
+		ExternalField:   externalField,
+		FieldType:       field.GetDataType().String(),
+		Nullable:        field.GetNullable(),
+		Dimension:       dim,
+		ExternalSource:  redactExternalVectorSource(schema.GetExternalSource()),
+		Format:          format,
+		SourcePrefix:    externalRootPath,
+		Exact:           p.Exact || format == "lance-table",
+		SegmentsMatched: int64(len(segments)),
+		FilesFound:      int64(len(filesFound)),
+		RangesFound:     int64(len(ranges)),
+		Ranges:          make([]*ExternalVectorNullRange, 0),
+	}
+
+	var results <-chan externalVectorObjectResult
+	if format == "lance-table" {
+		results = scanLanceVectorNullRanges(
+			ctx, ranges, externalField, field.GetDataType(), dim,
+			int(p.WorkerNum), p.BatchSize, location, spec,
+		)
+	} else {
+		results = scanExternalVectorNullRanges(
+			ctx, externalStore, ranges, externalField, field.GetDataType(), dim,
+			int(p.WorkerNum), p.BatchSize, p.Exact,
+		)
+	}
+	for objectResult := range results {
+		report.FilesScanned++
+		report.RowGroupsScanned += objectResult.RowGroupsScanned
+		report.RowGroupsSkipped += objectResult.RowGroupsSkipped
+		for _, result := range objectResult.Ranges {
+			report.RangesScanned++
+			report.Rows += result.Rows
+			report.ValidRows += result.ValidRows
+			report.MetadataNoNullRows += result.MetadataNoNullRows
+			report.RowNullRows += result.RowNullRows
+			report.FullNullRows += result.FullNullRows
+			report.PartialNullRows += result.PartialNullRows
+			report.InvalidLengthRows += result.InvalidLengthRows
+			if result.InspectionError != "" {
+				report.RangesFailed++
+			}
+			if result.hasIssue() {
+				report.RangesWithIssues++
+				report.Ranges = append(report.Ranges, result)
+			}
+		}
+	}
+	sort.Slice(report.Ranges, func(i, j int) bool {
+		if report.Ranges[i].SegmentID != report.Ranges[j].SegmentID {
+			return report.Ranges[i].SegmentID < report.Ranges[j].SegmentID
+		}
+		if report.Ranges[i].ObjectKey != report.Ranges[j].ObjectKey {
+			return report.Ranges[i].ObjectKey < report.Ranges[j].ObjectKey
+		}
+		return report.Ranges[i].StartIndex < report.Ranges[j].StartIndex
+	})
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+func selectExternalCollectionSegments(segments []*models.Segment, requestedSegmentID int64) ([]*models.Segment, error) {
+	externalSegments := make([]*models.Segment, 0, len(segments))
+	requestedSegmentWithoutManifest := false
+	for _, segment := range segments {
+		if strings.TrimSpace(segment.GetManifestPath()) == "" {
+			if requestedSegmentID != 0 {
+				requestedSegmentWithoutManifest = true
+			}
+			continue
+		}
+		externalSegments = append(externalSegments, segment)
+	}
+	if requestedSegmentWithoutManifest && len(externalSegments) == 0 {
+		return nil, errors.Newf(
+			"segment %d is not an external collection segment: manifest_path is empty",
+			requestedSegmentID,
+		)
+	}
+	return externalSegments, nil
+}
+
+func resolveExternalVectorField(schema *schemapb.CollectionSchema, fieldName string) (*schemapb.FieldSchema, string, int64, error) {
+	for _, field := range schema.GetFields() {
+		if field.GetName() != fieldName {
+			continue
+		}
+		if !typeutil.IsFixDimVectorType(field.GetDataType()) {
+			return nil, "", 0, errors.Newf(
+				"field %s has unsupported type %s; only fixed-dimension vector fields are supported",
+				fieldName, field.GetDataType())
+		}
+		externalField := strings.TrimSpace(field.GetExternalField())
+		if externalField == "" {
+			return nil, "", 0, errors.Newf("field %s is not mapped to an external source column", fieldName)
+		}
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, "", 0, errors.Wrapf(err, "get dimension for field %s", fieldName)
+		}
+		if dim <= 0 {
+			return nil, "", 0, errors.Newf("field %s has invalid dimension %d", fieldName, dim)
+		}
+		return field, externalField, dim, nil
+	}
+	return nil, "", 0, errors.Newf("field %s not found in collection schema", fieldName)
+}
+
+type externalVectorSegmentRange struct {
+	SegmentID  int64
+	ObjectKey  string
+	Format     string
+	StartIndex int64
+	EndIndex   int64
+}
+
+func externalVectorRangesForSegment(ctx context.Context, manifestStore oss.ObjectStore, manifestRootPath string, location externalSourceLocation, segment *models.Segment, fieldID int64, externalField, sourceFormat string) ([]externalVectorSegmentRange, error) {
+	if segment.GetManifestPath() == "" {
+		return nil, errors.New("segment does not have a refresh manifest")
+	}
+	var manifestRef struct {
+		Ver      int    `json:"ver"`
+		BasePath string `json:"base_path"`
+	}
+	if err := json.Unmarshal([]byte(segment.GetManifestPath()), &manifestRef); err != nil {
+		return nil, errors.Wrap(err, "parse segment manifest reference")
+	}
+	manifestBasePath := oss.ResolveObjectKey(manifestRootPath, manifestRef.BasePath)
+	manifestPath := path.Join(manifestBasePath, "_metadata", fmt.Sprintf("manifest-%d.avro", manifestRef.Ver))
+	obj, err := manifestStore.Open(ctx, manifestPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "open manifest %s", manifestPath)
+	}
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
+	m, err := parseManifest(obj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse manifest %s", manifestPath)
+	}
+
+	fieldIDString := strconv.FormatInt(fieldID, 10)
+	ranges := make([]externalVectorSegmentRange, 0)
+	for _, columnGroup := range m.ColumnGroups {
+		if !containsManifestColumn(columnGroup.Columns, fieldIDString, externalField) {
+			continue
+		}
+		columnGroupFormat := strings.ToLower(strings.TrimSpace(columnGroup.Format))
+		if columnGroupFormat == "" {
+			columnGroupFormat = sourceFormat
+		}
+		if columnGroupFormat != sourceFormat {
+			return nil, errors.Newf(
+				"manifest column group format %s does not match external source format %s",
+				columnGroupFormat,
+				sourceFormat,
+			)
+		}
+		for _, sourceFile := range columnGroup.Files {
+			if sourceFile.StartIndex < 0 || sourceFile.EndIndex <= sourceFile.StartIndex {
+				return nil, errors.Newf(
+					"invalid source range [%d, %d) for %s",
+					sourceFile.StartIndex,
+					sourceFile.EndIndex,
+					redactExternalVectorObjectKey(sourceFile.Path),
+				)
+			}
+			var objectKey string
+			if sourceFormat == "lance-table" {
+				objectKey, err = resolveExternalManifestLancePath(location, sourceFile.Path)
+			} else {
+				objectKey, err = resolveExternalManifestObjectKey(location, manifestRef.BasePath, sourceFile.Path)
+			}
+			if err != nil {
+				return nil, errors.New(sanitizeExternalVectorInspectionError(err, sourceFile.Path))
+			}
+			ranges = append(ranges, externalVectorSegmentRange{
+				SegmentID:  segment.GetID(),
+				ObjectKey:  objectKey,
+				Format:     sourceFormat,
+				StartIndex: sourceFile.StartIndex,
+				EndIndex:   sourceFile.EndIndex,
+			})
+		}
+	}
+	if len(ranges) == 0 {
+		return nil, errors.Newf("field %s(%d) is not present in the segment manifest", externalField, fieldID)
+	}
+	return ranges, nil
+}
+
+func containsManifestColumn(columns []string, candidates ...string) bool {
+	for _, column := range columns {
+		for _, candidate := range candidates {
+			if column == candidate {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func resolveExternalManifestLancePath(location externalSourceLocation, rawPath string) (string, error) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" {
+		return "", errors.New("manifest Lance path is empty")
+	}
+	if strings.Contains(trimmed, "://") {
+		return trimmed, nil
+	}
+	parts := strings.SplitN(trimmed, "?", 2)
+	objectPath := strings.ReplaceAll(parts[0], "ROOT_PATH", location.RootPath)
+	objectPath = strings.TrimPrefix(path.Clean("/"+objectPath), "/")
+	if location.RootPath != "" && objectPath != location.RootPath &&
+		!strings.HasPrefix(objectPath, location.RootPath+"/") {
+		objectPath = path.Join(location.RootPath, objectPath)
+	}
+	if location.Scheme == "" || location.Host == "" || location.Bucket == "" {
+		return "", errors.New("cannot resolve relative Lance path without source scheme, endpoint, and bucket")
+	}
+	resolved := fmt.Sprintf("%s://%s/%s/%s", location.Scheme, location.Host, location.Bucket, objectPath)
+	if len(parts) == 2 {
+		resolved += "?" + parts[1]
+	}
+	return resolved, nil
+}
+
+func buildLancePropertyValues(location externalSourceLocation, spec externalSourceSpec, batchSize int64) (map[string]string, error) {
+	provider := spec.CloudProvider
+	if provider == "" {
+		provider = inferLegacyCloudProviderFromScheme(location.Scheme)
+	}
+	if provider == "" {
+		return nil, errors.Newf("cannot determine Lance cloud provider for scheme %s", location.Scheme)
+	}
+	if spec.Anonymous && provider != externalspec.CloudProviderGCP {
+		return nil, errors.Newf("anonymous Lance access is not supported for cloud provider %s", provider)
+	}
+
+	useSSL := location.Scheme != externalspec.SchemeMinIO
+	if spec.UseSSL != nil {
+		useSSL = *spec.UseSSL
+	}
+	useVirtualHost := false
+	if spec.UseVirtualHost != nil {
+		useVirtualHost = *spec.UseVirtualHost
+	}
+	useIAM := spec.UseIAM
+	if spec.RoleARN == "" && spec.AccessKeyID == "" && spec.AccessKeyValue == "" &&
+		spec.GCPTargetServiceAccount == "" && spec.AzureCredentialEndpoint == "" && !spec.Anonymous {
+		useIAM = true
+	}
+
+	externalPrefix := "extfs.birdwatcher."
+	values := map[string]string{
+		externalPrefix + "address":                    location.Host,
+		externalPrefix + "bucket_name":                location.Bucket,
+		externalPrefix + "root_path":                  location.RootPath,
+		externalPrefix + "storage_type":               "remote",
+		externalPrefix + "access_key_id":              spec.AccessKeyID,
+		externalPrefix + "access_key_value":           spec.AccessKeyValue,
+		externalPrefix + "iam_endpoint":               spec.IAMEndpoint,
+		externalPrefix + "region":                     spec.Region,
+		externalPrefix + "ssl_ca_cert":                spec.SSLCACert,
+		externalPrefix + "role_arn":                   spec.RoleARN,
+		externalPrefix + "session_name":               spec.RoleSessionName,
+		externalPrefix + "external_id":                spec.ExternalID,
+		externalPrefix + "gcp_target_service_account": spec.GCPTargetServiceAccount,
+		externalPrefix + "azure_client_id":            spec.AzureClientID,
+		externalPrefix + "azure_tenant_id":            spec.AzureTenantID,
+		externalPrefix + "azure_credential_endpoint":  spec.AzureCredentialEndpoint,
+		externalPrefix + "use_ssl":                    strconv.FormatBool(useSSL),
+		externalPrefix + "use_iam":                    strconv.FormatBool(useIAM),
+		externalPrefix + "use_virtual_host":           strconv.FormatBool(useVirtualHost),
+		externalPrefix + "request_timeout_ms":         "10000",
+		externalPrefix + "max_connections":            "100",
+		"reader.logical_chunk_rows":                   strconv.FormatInt(batchSize, 10),
+		"reader.record_batch_max_rows":                strconv.FormatInt(batchSize, 10),
+		"reader.metadata_cache.enable":                "true",
+	}
+	// minio is a Milvus-only sentinel used to select Milvus-form URI parsing.
+	// milvus-storage uses the AWS backend for S3-compatible stores and rejects
+	// minio as a cloud_provider value.
+	if provider != externalspec.CloudProviderMinIO {
+		values[externalPrefix+"cloud_provider"] = provider
+	}
+	if spec.LoadFrequency > 0 {
+		values[externalPrefix+"load_frequency"] = strconv.Itoa(spec.LoadFrequency)
+	}
+	if spec.Anonymous && provider == externalspec.CloudProviderGCP {
+		values[externalPrefix+"gcp_native_without_auth"] = "true"
+	}
+	return values, nil
+}
+
+type externalVectorObjectResult struct {
+	Ranges           []*ExternalVectorNullRange
+	RowGroupsScanned int64
+	RowGroupsSkipped int64
+}
+
+type externalVectorObjectJob struct {
+	ObjectKey string
+	Ranges    []externalVectorSegmentRange
+}
+
+type externalVectorScanInterval struct {
+	StartIndex   int64
+	EndIndex     int64
+	RangeIndexes []int
+}
+
+func buildExternalVectorScanIntervals(ranges []externalVectorSegmentRange) ([]externalVectorScanInterval, error) {
+	type indexedRange struct {
+		index      int
+		rangeValue externalVectorSegmentRange
+	}
+	indexed := make([]indexedRange, len(ranges))
+	for i, sourceRange := range ranges {
+		if sourceRange.StartIndex < 0 || sourceRange.EndIndex <= sourceRange.StartIndex {
+			return nil, errors.Newf(
+				"invalid external vector row range [%d, %d)", sourceRange.StartIndex, sourceRange.EndIndex)
+		}
+		indexed[i] = indexedRange{index: i, rangeValue: sourceRange}
+	}
+	sort.Slice(indexed, func(i, j int) bool {
+		if indexed[i].rangeValue.StartIndex != indexed[j].rangeValue.StartIndex {
+			return indexed[i].rangeValue.StartIndex < indexed[j].rangeValue.StartIndex
+		}
+		if indexed[i].rangeValue.EndIndex != indexed[j].rangeValue.EndIndex {
+			return indexed[i].rangeValue.EndIndex < indexed[j].rangeValue.EndIndex
+		}
+		return indexed[i].index < indexed[j].index
+	})
+
+	intervals := make([]externalVectorScanInterval, 0, len(indexed))
+	for _, item := range indexed {
+		if len(intervals) == 0 || item.rangeValue.StartIndex > intervals[len(intervals)-1].EndIndex {
+			intervals = append(intervals, externalVectorScanInterval{
+				StartIndex:   item.rangeValue.StartIndex,
+				EndIndex:     item.rangeValue.EndIndex,
+				RangeIndexes: []int{item.index},
+			})
+			continue
+		}
+
+		current := &intervals[len(intervals)-1]
+		current.EndIndex = max(current.EndIndex, item.rangeValue.EndIndex)
+		current.RangeIndexes = append(current.RangeIndexes, item.index)
+	}
+	return intervals, nil
+}
+
+func scanExternalVectorNullRanges(ctx context.Context, store oss.ObjectStore, ranges []externalVectorSegmentRange, externalField string, fieldType schemapb.DataType, dim int64, workers int, batchSize int64, exact bool) <-chan externalVectorObjectResult {
+	results := make(chan externalVectorObjectResult)
+	objectRanges := make(map[string][]externalVectorSegmentRange)
+	for _, sourceRange := range ranges {
+		objectRanges[sourceRange.ObjectKey] = append(objectRanges[sourceRange.ObjectKey], sourceRange)
+	}
+	keys := make([]string, 0, len(objectRanges))
+	for objectKey := range objectRanges {
+		keys = append(keys, objectKey)
+	}
+	sort.Strings(keys)
+	jobs := make(chan externalVectorObjectJob)
+	workers = min(workers, len(keys))
+	if workers == 0 {
+		close(results)
+		return results
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				result := inspectExternalVectorNullObject(
+					ctx, store, job, externalField, fieldType, dim, batchSize, exact)
+				select {
+				case results <- result:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, objectKey := range keys {
+			job := externalVectorObjectJob{ObjectKey: objectKey, Ranges: objectRanges[objectKey]}
+			select {
+			case jobs <- job:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	return results
+}
+
+func inspectExternalVectorNullObject(ctx context.Context, store oss.ObjectStore, job externalVectorObjectJob, externalField string, fieldType schemapb.DataType, dim, batchSize int64, exact bool) externalVectorObjectResult {
+	objectResult := externalVectorObjectResult{Ranges: make([]*ExternalVectorNullRange, len(job.Ranges))}
+	for i, sourceRange := range job.Ranges {
+		objectResult.Ranges[i] = &ExternalVectorNullRange{
+			SegmentID:  sourceRange.SegmentID,
+			ObjectKey:  redactExternalVectorObjectKey(sourceRange.ObjectKey),
+			StartIndex: sourceRange.StartIndex,
+			EndIndex:   sourceRange.EndIndex,
+		}
+	}
+	failAll := func(err error) externalVectorObjectResult {
+		message := sanitizeExternalVectorInspectionError(err, job.ObjectKey)
+		for _, result := range objectResult.Ranges {
+			if result.InspectionError == "" {
+				result.InspectionError = message
+			}
+		}
+		return objectResult
+	}
+
+	obj, err := store.Open(ctx, job.ObjectKey)
+	if err != nil {
+		return failAll(err)
+	}
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
+	pqReader, err := file.NewParquetReader(obj)
+	if err != nil {
+		return failAll(err)
+	}
+	defer pqReader.Close()
+	arrowReader, err := pqarrow.NewFileReader(
+		pqReader,
+		pqarrow.ArrowReadProperties{BatchSize: batchSize},
+		memory.DefaultAllocator,
+	)
+	if err != nil {
+		return failAll(err)
+	}
+	leafIndices, arrowType, err := projectedExternalFieldLeaves(pqReader, arrowReader, externalField)
+	if err != nil {
+		return failAll(err)
+	}
+	for _, result := range objectResult.Ranges {
+		result.ArrowType = arrowType
+	}
+
+	rowGroupStarts := make([]int64, pqReader.NumRowGroups())
+	rowGroupEnds := make([]int64, pqReader.NumRowGroups())
+	var rowOffset int64
+	for rowGroup := range pqReader.NumRowGroups() {
+		rowGroupStarts[rowGroup] = rowOffset
+		rowOffset += pqReader.MetaData().RowGroup(rowGroup).NumRows()
+		rowGroupEnds[rowGroup] = rowOffset
+	}
+	if rowOffset != pqReader.NumRows() {
+		return failAll(errors.Newf(
+			"parquet row group total %d does not match file row count %d", rowOffset, pqReader.NumRows()))
+	}
+	type indexedRange struct {
+		index int
+		start int64
+		end   int64
+	}
+	validRanges := make([]indexedRange, 0, len(job.Ranges))
+	for i, sourceRange := range job.Ranges {
+		if sourceRange.StartIndex < 0 || sourceRange.EndIndex <= sourceRange.StartIndex ||
+			sourceRange.EndIndex > pqReader.NumRows() {
+			objectResult.Ranges[i].InspectionError = fmt.Sprintf(
+				"invalid parquet row range [%d, %d) for file with %d rows",
+				sourceRange.StartIndex, sourceRange.EndIndex, pqReader.NumRows())
+			continue
+		}
+		validRanges = append(validRanges, indexedRange{
+			index: i,
+			start: sourceRange.StartIndex,
+			end:   sourceRange.EndIndex,
+		})
+	}
+	sort.Slice(validRanges, func(i, j int) bool {
+		if validRanges[i].start != validRanges[j].start {
+			return validRanges[i].start < validRanges[j].start
+		}
+		if validRanges[i].end != validRanges[j].end {
+			return validRanges[i].end < validRanges[j].end
+		}
+		return validRanges[i].index < validRanges[j].index
+	})
+
+	var activeRanges []indexedRange
+	nextRange := 0
+	for rowGroup := range pqReader.NumRowGroups() {
+		rowGroupStart := rowGroupStarts[rowGroup]
+		rowGroupEnd := rowGroupEnds[rowGroup]
+		stillActive := activeRanges[:0]
+		for _, sourceRange := range activeRanges {
+			if sourceRange.end > rowGroupStart {
+				stillActive = append(stillActive, sourceRange)
+			}
+		}
+		activeRanges = stillActive
+		for nextRange < len(validRanges) && validRanges[nextRange].start < rowGroupEnd {
+			if validRanges[nextRange].end > rowGroupStart {
+				activeRanges = append(activeRanges, validRanges[nextRange])
+			}
+			nextRange++
+		}
+
+		overlapping := make([]int, 0, len(activeRanges))
+		for _, sourceRange := range activeRanges {
+			overlapping = append(overlapping, sourceRange.index)
+		}
+		if len(overlapping) == 0 {
+			continue
+		}
+		if !exact && parquetRowGroupHasNoNulls(pqReader, rowGroup, leafIndices) {
+			objectResult.RowGroupsSkipped++
+			for _, rangeIndex := range overlapping {
+				sourceRange := job.Ranges[rangeIndex]
+				rows := min(sourceRange.EndIndex, rowGroupEnds[rowGroup]) -
+					max(sourceRange.StartIndex, rowGroupStarts[rowGroup])
+				objectResult.Ranges[rangeIndex].Rows += rows
+				objectResult.Ranges[rangeIndex].MetadataNoNullRows += rows
+			}
+			continue
+		}
+
+		objectResult.RowGroupsScanned++
+		rr, err := arrowReader.GetRecordReader(ctx, leafIndices, []int{rowGroup})
+		if err != nil {
+			return failAll(err)
+		}
+		streamOffset := rowGroupStarts[rowGroup]
+		for rr.Next() {
+			record := rr.Record()
+			if record.NumCols() != 1 {
+				rr.Release()
+				return failAll(errors.Newf(
+					"projected field %s returned %d Arrow columns", externalField, record.NumCols()))
+			}
+			batchEnd := streamOffset + record.NumRows()
+			for _, rangeIndex := range overlapping {
+				sourceRange := job.Ranges[rangeIndex]
+				overlapStart := max(sourceRange.StartIndex, streamOffset)
+				overlapEnd := min(sourceRange.EndIndex, batchEnd)
+				if overlapStart >= overlapEnd {
+					continue
+				}
+				projected := array.NewSlice(
+					record.Column(0), overlapStart-streamOffset, overlapEnd-streamOffset)
+				counts, classifyErr := classifyExternalVectorArray(projected, fieldType, dim)
+				projected.Release()
+				if classifyErr != nil {
+					rr.Release()
+					return failAll(classifyErr)
+				}
+				addExternalVectorNullCounts(objectResult.Ranges[rangeIndex], counts)
+			}
+			streamOffset = batchEnd
+		}
+		readerErr := rr.Err()
+		rr.Release()
+		if readerErr != nil && !errors.Is(readerErr, io.EOF) {
+			return failAll(readerErr)
+		}
+	}
+
+	for i, sourceRange := range job.Ranges {
+		result := objectResult.Ranges[i]
+		if result.InspectionError == "" && result.Rows != sourceRange.EndIndex-sourceRange.StartIndex {
+			result.InspectionError = fmt.Sprintf(
+				"range row count mismatch: expected %d, scanned %d",
+				sourceRange.EndIndex-sourceRange.StartIndex,
+				result.Rows,
+			)
+		}
+	}
+	return objectResult
+}
+
+func redactExternalVectorObjectKey(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<redacted>"
+	}
+	u.User = nil
+	query := make(url.Values)
+	for _, rawID := range u.Query()["fragment_id"] {
+		if _, err := strconv.ParseUint(rawID, 10, 64); err == nil {
+			query.Add("fragment_id", rawID)
+		}
+	}
+	u.RawQuery = query.Encode()
+	u.ForceQuery = false
+	u.Fragment = ""
+	return u.String()
+}
+
+func sanitizeExternalVectorInspectionError(err error, objectPaths ...string) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	for _, objectPath := range objectPaths {
+		trimmed := strings.TrimSpace(objectPath)
+		if trimmed == "" {
+			continue
+		}
+		message = strings.ReplaceAll(message, trimmed, redactExternalVectorObjectKey(trimmed))
+	}
+	return message
+}
+
+func redactExternalVectorSource(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Opaque != "" || u.RawQuery != "" || u.Fragment != "" ||
+		externalspec.ValidateExternalSource(raw) != nil {
+		return "<redacted>"
+	}
+	return raw
+}
+
+// parquetRowGroupHasNoNulls is deliberately conservative: missing or invalid
+// statistics force a data read. A zero null count proves that neither parent
+// nor child values are null, but it does not prove that vector lengths match.
+func parquetRowGroupHasNoNulls(reader *file.Reader, rowGroup int, leafIndices []int) bool {
+	metadata := reader.MetaData().RowGroup(rowGroup)
+	for _, leafIndex := range leafIndices {
+		columnChunk, err := metadata.ColumnChunk(leafIndex)
+		if err != nil {
+			return false
+		}
+		statistics, err := columnChunk.Statistics()
+		if err != nil || statistics == nil || !statistics.HasNullCount() || statistics.NullCount() != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func addExternalVectorNullCounts(result *ExternalVectorNullRange, counts externalVectorNullCounts) {
+	result.Rows += counts.Rows
+	result.ValidRows += counts.ValidRows
+	result.RowNullRows += counts.RowNullRows
+	result.FullNullRows += counts.FullNullRows
+	result.PartialNullRows += counts.PartialNullRows
+	result.InvalidLengthRows += counts.InvalidLengthRows
+}
+
+func projectedExternalFieldLeaves(pqReader *file.Reader, reader *pqarrow.FileReader, externalField string) ([]int, string, error) {
+	for i := range reader.Manifest.Fields {
+		field := &reader.Manifest.Fields[i]
+		if field.Field == nil || field.Field.Name != externalField {
+			continue
+		}
+		leaves := make([]int, 0, 1)
+		parquetSchema := pqReader.MetaData().Schema
+		for columnIndex := 0; columnIndex < parquetSchema.NumColumns(); columnIndex++ {
+			columnPath := parquetSchema.Column(columnIndex).ColumnPath()
+			if len(columnPath) > 0 && columnPath[0] == externalField {
+				leaves = append(leaves, columnIndex)
+			}
+		}
+		if len(leaves) == 0 {
+			return nil, "", errors.Newf("external field %s has no parquet leaf columns", externalField)
+		}
+		return leaves, field.Field.Type.String(), nil
+	}
+	return nil, "", errors.Newf("external field %s not found in parquet schema", externalField)
+}
+
+type externalVectorNullCounts struct {
+	Rows              int64
+	ValidRows         int64
+	RowNullRows       int64
+	FullNullRows      int64
+	PartialNullRows   int64
+	InvalidLengthRows int64
+}
+
+func classifyExternalVectorArray(values arrow.Array, fieldType schemapb.DataType, dim int64) (externalVectorNullCounts, error) {
+	var counts externalVectorNullCounts
+	counts.Rows = int64(values.Len())
+
+	if list, ok := values.(array.ListLike); ok {
+		return classifyExternalVectorList(list, fieldType, dim)
+	}
+
+	switch typed := values.(type) {
+	case *array.FixedSizeBinary:
+		expectedWidth, err := externalVectorByteWidth(fieldType, dim)
+		if err != nil {
+			return counts, err
+		}
+		actualWidth := int64(typed.DataType().(*arrow.FixedSizeBinaryType).ByteWidth)
+		for i := 0; i < typed.Len(); i++ {
+			if typed.IsNull(i) {
+				counts.RowNullRows++
+			} else if actualWidth != expectedWidth {
+				counts.InvalidLengthRows++
+			} else {
+				counts.ValidRows++
+			}
+		}
+		return counts, nil
+	case *array.Binary:
+		return classifyVariableBinaryVector(typed.Len(), typed.IsNull, func(i int) int64 {
+			return int64(typed.ValueLen(i))
+		}, fieldType, dim)
+	case *array.LargeBinary:
+		return classifyVariableBinaryVector(typed.Len(), typed.IsNull, func(i int) int64 {
+			return int64(typed.ValueLen(i))
+		}, fieldType, dim)
+	case *array.BinaryView:
+		return classifyVariableBinaryVector(typed.Len(), typed.IsNull, func(i int) int64 {
+			return int64(typed.ValueLen(i))
+		}, fieldType, dim)
+	default:
+		return counts, errors.Newf(
+			"unsupported Arrow type %s for external vector null inspection", values.DataType())
+	}
+}
+
+func classifyExternalVectorList(values array.ListLike, fieldType schemapb.DataType, dim int64) (externalVectorNullCounts, error) {
+	counts := externalVectorNullCounts{Rows: int64(values.Len())}
+	child := values.ListValues()
+	expectedLength, err := expectedExternalVectorListLength(fieldType, dim, child.DataType())
+	if err != nil {
+		return counts, err
+	}
+	for i := 0; i < values.Len(); i++ {
+		if values.IsNull(i) {
+			counts.RowNullRows++
+			continue
+		}
+		start, end := values.ValueOffsets(i)
+		length := end - start
+		if length != expectedLength {
+			counts.InvalidLengthRows++
+			continue
+		}
+		valid := countValidChildValues(child, start, end)
+		switch {
+		case valid == length:
+			counts.ValidRows++
+		case valid == 0:
+			counts.FullNullRows++
+		default:
+			counts.PartialNullRows++
+		}
+	}
+	return counts, nil
+}
+
+func classifyVariableBinaryVector(length int, isNull func(int) bool, valueLength func(int) int64, fieldType schemapb.DataType, dim int64) (externalVectorNullCounts, error) {
+	counts := externalVectorNullCounts{Rows: int64(length)}
+	expectedWidth, err := externalVectorByteWidth(fieldType, dim)
+	if err != nil {
+		return counts, err
+	}
+	for i := 0; i < length; i++ {
+		if isNull(i) {
+			counts.RowNullRows++
+		} else if valueLength(i) != expectedWidth {
+			counts.InvalidLengthRows++
+		} else {
+			counts.ValidRows++
+		}
+	}
+	return counts, nil
+}
+
+func countValidChildValues(values arrow.Array, start, end int64) int64 {
+	length := end - start
+	if length == 0 || values.NullN() == 0 {
+		return length
+	}
+	return int64(bitutil.CountSetBits(
+		values.NullBitmapBytes(),
+		values.Data().Offset()+int(start),
+		int(length),
+	))
+}
+
+func expectedExternalVectorListLength(fieldType schemapb.DataType, dim int64, childType arrow.DataType) (int64, error) {
+	if err := validateExternalVectorElementType(fieldType, childType); err != nil {
+		return 0, err
+	}
+	if fieldType == schemapb.DataType_BinaryVector ||
+		fieldType == schemapb.DataType_BFloat16Vector ||
+		childType.ID() == arrow.UINT8 {
+		return externalVectorByteWidth(fieldType, dim)
+	}
+	return dim, nil
+}
+
+func validateExternalVectorElementType(fieldType schemapb.DataType, childType arrow.DataType) error {
+	actual := childType.ID()
+	var expected arrow.Type
+	switch fieldType {
+	case schemapb.DataType_FloatVector:
+		expected = arrow.FLOAT32
+	case schemapb.DataType_Int8Vector:
+		expected = arrow.INT8
+	case schemapb.DataType_Float16Vector:
+		expected = arrow.FLOAT16
+	case schemapb.DataType_BinaryVector, schemapb.DataType_BFloat16Vector:
+		expected = arrow.UINT8
+	default:
+		return errors.Newf("unsupported external vector type %s", fieldType)
+	}
+	if actual != expected && actual != arrow.UINT8 {
+		return errors.Newf(
+			"vector list element type mismatch: expected %s or raw uint8, actual %s",
+			expected, childType)
+	}
+	return nil
+}
+
+func externalVectorByteWidth(fieldType schemapb.DataType, dim int64) (int64, error) {
+	switch fieldType {
+	case schemapb.DataType_FloatVector:
+		return dim * 4, nil
+	case schemapb.DataType_BinaryVector:
+		if dim%8 != 0 {
+			return 0, errors.Newf("binary vector dimension %d is not divisible by 8", dim)
+		}
+		return dim / 8, nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return dim * 2, nil
+	case schemapb.DataType_Int8Vector:
+		return dim, nil
+	default:
+		return 0, errors.Newf("unsupported external vector type %s", fieldType)
+	}
+}

--- a/states/inspect_external_vector_nulls.go
+++ b/states/inspect_external_vector_nulls.go
@@ -1034,11 +1034,12 @@ func classifyExternalVectorArray(values arrow.Array, fieldType schemapb.DataType
 		}
 		actualWidth := int64(typed.DataType().(*arrow.FixedSizeBinaryType).ByteWidth)
 		for i := 0; i < typed.Len(); i++ {
-			if typed.IsNull(i) {
+			switch {
+			case typed.IsNull(i):
 				counts.RowNullRows++
-			} else if actualWidth != expectedWidth {
+			case actualWidth != expectedWidth:
 				counts.InvalidLengthRows++
-			} else {
+			default:
 				counts.ValidRows++
 			}
 		}
@@ -1080,10 +1081,10 @@ func classifyExternalVectorList(values array.ListLike, fieldType schemapb.DataTy
 			continue
 		}
 		valid := countValidChildValues(child, start, end)
-		switch {
-		case valid == length:
+		switch valid {
+		case length:
 			counts.ValidRows++
-		case valid == 0:
+		case 0:
 			counts.FullNullRows++
 		default:
 			counts.PartialNullRows++
@@ -1099,11 +1100,12 @@ func classifyVariableBinaryVector(length int, isNull func(int) bool, valueLength
 		return counts, err
 	}
 	for i := 0; i < length; i++ {
-		if isNull(i) {
+		switch {
+		case isNull(i):
 			counts.RowNullRows++
-		} else if valueLength(i) != expectedWidth {
+		case valueLength(i) != expectedWidth:
 			counts.InvalidLengthRows++
-		} else {
+		default:
 			counts.ValidRows++
 		}
 	}

--- a/states/inspect_external_vector_nulls_lance.go
+++ b/states/inspect_external_vector_nulls_lance.go
@@ -1,0 +1,604 @@
+//go:build LANCE && cgo
+
+package states
+
+/*
+#cgo pkg-config: milvus-storage
+
+#include <stdlib.h>
+#include "milvus-storage/ffi_c.h"
+
+static int bw_lance_stream_next(struct ArrowArrayStream* stream, struct ArrowArray* out) {
+    return stream->get_next(stream, out);
+}
+
+static const char* bw_lance_stream_error(struct ArrowArrayStream* stream) {
+    return stream->get_last_error == NULL ? NULL : stream->get_last_error(stream);
+}
+
+static int bw_lance_array_released(struct ArrowArray* array) {
+    return array->release == NULL;
+}
+
+static void bw_lance_stream_release(struct ArrowArrayStream* stream) {
+    if (stream->release != NULL) {
+        stream->release(stream);
+    }
+}
+*/
+import "C"
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/cdata"
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func ensureLanceVectorScannerAvailable() error {
+	return nil
+}
+
+type lanceSchemaCandidateError struct {
+	err error
+}
+
+func (e *lanceSchemaCandidateError) Error() string {
+	return e.err.Error()
+}
+
+func (e *lanceSchemaCandidateError) Unwrap() error {
+	return e.err
+}
+
+func scanLanceVectorNullRanges(
+	ctx context.Context,
+	ranges []externalVectorSegmentRange,
+	externalField string,
+	fieldType schemapb.DataType,
+	dim int64,
+	workers int,
+	batchSize int64,
+	location externalSourceLocation,
+	spec externalSourceSpec,
+) <-chan externalVectorObjectResult {
+	results := make(chan externalVectorObjectResult)
+	datasetRanges := make(map[string][]externalVectorSegmentRange)
+	for _, sourceRange := range ranges {
+		datasetKey := lanceDatasetKey(sourceRange.ObjectKey)
+		datasetRanges[datasetKey] = append(datasetRanges[datasetKey], sourceRange)
+	}
+	keys := make([]string, 0, len(datasetRanges))
+	for datasetKey := range datasetRanges {
+		keys = append(keys, datasetKey)
+	}
+	sort.Strings(keys)
+	jobs := make(chan lanceVectorDatasetJob)
+	workers = min(workers, len(keys))
+	if workers == 0 {
+		close(results)
+		return results
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				result := inspectLanceVectorNullDataset(
+					ctx, job, externalField, fieldType, dim, batchSize, location, spec)
+				for _, objectResult := range splitLanceVectorNullResult(job, result) {
+					select {
+					case results <- objectResult:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, datasetKey := range keys {
+			select {
+			case jobs <- lanceVectorDatasetJob{DatasetKey: datasetKey, Ranges: datasetRanges[datasetKey]}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	return results
+}
+
+type lanceVectorDatasetJob struct {
+	DatasetKey string
+	Ranges     []externalVectorSegmentRange
+}
+
+type lanceVectorScanInterval struct {
+	ObjectKey    string
+	StartIndex   int64
+	EndIndex     int64
+	RangeIndexes []int
+}
+
+func lanceDatasetKey(objectKey string) string {
+	const fragmentDelimiter = "?fragment_id="
+	if index := strings.Index(objectKey, fragmentDelimiter); index >= 0 {
+		return objectKey[:index]
+	}
+	return objectKey
+}
+
+func inspectLanceVectorNullDataset(
+	ctx context.Context,
+	job lanceVectorDatasetJob,
+	externalField string,
+	fieldType schemapb.DataType,
+	dim int64,
+	batchSize int64,
+	location externalSourceLocation,
+	spec externalSourceSpec,
+) externalVectorObjectResult {
+	var lastErr error
+	for _, dataType := range lanceVectorCandidateTypes(fieldType, dim) {
+		result, err := inspectLanceVectorNullDatasetWithType(
+			ctx, job, externalField, fieldType, dim, batchSize, location, spec, dataType)
+		if err == nil {
+			return result
+		}
+		lastErr = err
+		if !shouldTryNextLanceVectorType(err) {
+			break
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.Newf("no Arrow schema candidate for vector type %s", fieldType)
+	}
+	result := externalVectorObjectResult{Ranges: newExternalVectorNullResults(job.Ranges)}
+	message := sanitizeExternalVectorInspectionError(lastErr, job.DatasetKey)
+	for _, item := range result.Ranges {
+		item.InspectionError = message
+	}
+	return result
+}
+
+func inspectLanceVectorNullDatasetWithType(
+	ctx context.Context,
+	job lanceVectorDatasetJob,
+	externalField string,
+	fieldType schemapb.DataType,
+	dim int64,
+	batchSize int64,
+	location externalSourceLocation,
+	spec externalSourceSpec,
+	dataType arrow.DataType,
+) (externalVectorObjectResult, error) {
+	result := externalVectorObjectResult{Ranges: newExternalVectorNullResults(job.Ranges)}
+	if len(job.Ranges) == 0 {
+		return result, errors.New("Lance dataset scan job does not contain ranges")
+	}
+	intervals, err := buildLanceVectorScanIntervals(job.Ranges)
+	if err != nil {
+		return result, err
+	}
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: externalField, Type: dataType, Nullable: true}}, nil)
+	for _, item := range result.Ranges {
+		item.ArrowType = dataType.String()
+	}
+
+	stream, closeStream, err := openLanceVectorStream(
+		intervals, externalField, schema, batchSize, location, spec)
+	if err != nil {
+		return result, err
+	}
+	defer closeStream()
+
+	candidateValidated := false
+	intervalIndex := 0
+	var intervalRowsRead int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		var cArray cdata.CArrowArray
+		if errno := C.bw_lance_stream_next(
+			(*C.struct_ArrowArrayStream)(unsafe.Pointer(stream)),
+			(*C.struct_ArrowArray)(unsafe.Pointer(&cArray)),
+		); errno != 0 {
+			return result, errors.Newf(
+				"read Lance record batch: errno=%d message=%s",
+				int(errno),
+				C.GoString(C.bw_lance_stream_error((*C.struct_ArrowArrayStream)(unsafe.Pointer(stream)))),
+			)
+		}
+		if C.bw_lance_array_released((*C.struct_ArrowArray)(unsafe.Pointer(&cArray))) != 0 {
+			break
+		}
+		record, err := cdata.ImportCRecordBatchWithSchema(&cArray, schema)
+		if err != nil {
+			cdata.ReleaseCArrowArray(&cArray)
+			importErr := errors.Wrap(err, "import Lance record batch")
+			if !candidateValidated {
+				return result, markLanceSchemaCandidateError(importErr)
+			}
+			return result, importErr
+		}
+		candidateValidated = true
+		if record.NumCols() != 1 {
+			record.Release()
+			return result, errors.Newf(
+				"projected Lance field %s returned %d Arrow columns", externalField, record.NumCols())
+		}
+		if err := classifyLanceRecordBatch(
+			record, intervals, &intervalIndex, &intervalRowsRead,
+			job.Ranges, result.Ranges, fieldType, dim,
+		); err != nil {
+			record.Release()
+			return result, err
+		}
+		record.Release()
+	}
+	if intervalIndex != len(intervals) || intervalRowsRead != 0 {
+		return result, errors.Newf(
+			"Lance row count mismatch: completed %d of %d scan intervals",
+			intervalIndex, len(intervals))
+	}
+	for i, sourceRange := range job.Ranges {
+		if result.Ranges[i].Rows != sourceRange.EndIndex-sourceRange.StartIndex {
+			return result, errors.Newf(
+				"Lance range row count mismatch: expected %d, scanned %d",
+				sourceRange.EndIndex-sourceRange.StartIndex,
+				result.Ranges[i].Rows,
+			)
+		}
+	}
+	return result, nil
+}
+
+func buildLanceVectorScanIntervals(ranges []externalVectorSegmentRange) ([]lanceVectorScanInterval, error) {
+	objectRangeIndexes := make(map[string][]int)
+	for index, sourceRange := range ranges {
+		objectRangeIndexes[sourceRange.ObjectKey] = append(objectRangeIndexes[sourceRange.ObjectKey], index)
+	}
+	objectKeys := make([]string, 0, len(objectRangeIndexes))
+	for objectKey := range objectRangeIndexes {
+		objectKeys = append(objectKeys, objectKey)
+	}
+	sort.Strings(objectKeys)
+
+	var scans []lanceVectorScanInterval
+	for _, objectKey := range objectKeys {
+		globalIndexes := objectRangeIndexes[objectKey]
+		objectRanges := make([]externalVectorSegmentRange, len(globalIndexes))
+		for index, globalIndex := range globalIndexes {
+			objectRanges[index] = ranges[globalIndex]
+		}
+		intervals, err := buildExternalVectorScanIntervals(objectRanges)
+		if err != nil {
+			return nil, err
+		}
+		for _, interval := range intervals {
+			rangeIndexes := make([]int, len(interval.RangeIndexes))
+			for index, localIndex := range interval.RangeIndexes {
+				rangeIndexes[index] = globalIndexes[localIndex]
+			}
+			scans = append(scans, lanceVectorScanInterval{
+				ObjectKey:    objectKey,
+				StartIndex:   interval.StartIndex,
+				EndIndex:     interval.EndIndex,
+				RangeIndexes: rangeIndexes,
+			})
+		}
+	}
+	return scans, nil
+}
+
+func classifyLanceRecordBatch(
+	record arrow.Record,
+	intervals []lanceVectorScanInterval,
+	intervalIndex *int,
+	intervalRowsRead *int64,
+	sourceRanges []externalVectorSegmentRange,
+	results []*ExternalVectorNullRange,
+	fieldType schemapb.DataType,
+	dim int64,
+) error {
+	var recordOffset int64
+	for recordOffset < record.NumRows() {
+		if *intervalIndex >= len(intervals) {
+			return errors.Newf("Lance stream returned %d unexpected trailing rows", record.NumRows()-recordOffset)
+		}
+		interval := intervals[*intervalIndex]
+		intervalRows := interval.EndIndex - interval.StartIndex
+		remainingRows := intervalRows - *intervalRowsRead
+		batchRows := min(record.NumRows()-recordOffset, remainingRows)
+		sourceStart := interval.StartIndex + *intervalRowsRead
+		sourceEnd := sourceStart + batchRows
+		for _, rangeIndex := range interval.RangeIndexes {
+			sourceRange := sourceRanges[rangeIndex]
+			overlapStart := max(sourceRange.StartIndex, sourceStart)
+			overlapEnd := min(sourceRange.EndIndex, sourceEnd)
+			if overlapStart >= overlapEnd {
+				continue
+			}
+			projectedStart := recordOffset + overlapStart - sourceStart
+			projectedEnd := recordOffset + overlapEnd - sourceStart
+			projected := array.NewSlice(record.Column(0), projectedStart, projectedEnd)
+			counts, err := classifyExternalVectorArray(projected, fieldType, dim)
+			projected.Release()
+			if err != nil {
+				return err
+			}
+			addExternalVectorNullCounts(results[rangeIndex], counts)
+		}
+		recordOffset += batchRows
+		*intervalRowsRead += batchRows
+		if *intervalRowsRead == intervalRows {
+			(*intervalIndex)++
+			*intervalRowsRead = 0
+		}
+	}
+	return nil
+}
+
+func splitLanceVectorNullResult(job lanceVectorDatasetJob, result externalVectorObjectResult) []externalVectorObjectResult {
+	objectRangeIndexes := make(map[string][]int)
+	for index, sourceRange := range job.Ranges {
+		objectRangeIndexes[sourceRange.ObjectKey] = append(objectRangeIndexes[sourceRange.ObjectKey], index)
+	}
+	objectKeys := make([]string, 0, len(objectRangeIndexes))
+	for objectKey := range objectRangeIndexes {
+		objectKeys = append(objectKeys, objectKey)
+	}
+	sort.Strings(objectKeys)
+
+	objectResults := make([]externalVectorObjectResult, 0, len(objectKeys))
+	for _, objectKey := range objectKeys {
+		ranges := make([]*ExternalVectorNullRange, 0, len(objectRangeIndexes[objectKey]))
+		for _, index := range objectRangeIndexes[objectKey] {
+			ranges = append(ranges, result.Ranges[index])
+		}
+		objectResults = append(objectResults, externalVectorObjectResult{Ranges: ranges})
+	}
+	return objectResults
+}
+
+func openLanceVectorStream(
+	intervals []lanceVectorScanInterval,
+	externalField string,
+	schema *arrow.Schema,
+	batchSize int64,
+	location externalSourceLocation,
+	spec externalSourceSpec,
+) (*cdata.CArrowArrayStream, func(), error) {
+	if len(intervals) == 0 {
+		return nil, nil, errors.New("Lance reader requires at least one scan interval")
+	}
+	properties, err := newLanceProperties(location, spec, batchSize)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer C.loon_properties_free(properties)
+
+	columns, freeColumns := newCStringArray([]string{externalField})
+	defer freeColumns()
+	pathsToRead := make([]string, len(intervals))
+	starts := make([]C.int64_t, len(intervals))
+	ends := make([]C.int64_t, len(intervals))
+	for index, interval := range intervals {
+		pathsToRead[index] = interval.ObjectKey
+		starts[index] = C.int64_t(interval.StartIndex)
+		ends[index] = C.int64_t(interval.EndIndex)
+	}
+	paths, freePaths := newCStringArray(pathsToRead)
+	defer freePaths()
+	format := C.CString("lance-table")
+	defer C.free(unsafe.Pointer(format))
+	var columnGroups *C.LoonColumnGroups
+	ffiResult := C.loon_column_groups_create(
+		(**C.char)(unsafe.Pointer(columns)),
+		1,
+		format,
+		(**C.char)(unsafe.Pointer(paths)),
+		(*C.int64_t)(unsafe.Pointer(&starts[0])),
+		(*C.int64_t)(unsafe.Pointer(&ends[0])),
+		C.size_t(len(intervals)),
+		&columnGroups,
+	)
+	if err := consumeLanceFFIResult(&ffiResult); err != nil {
+		return nil, nil, errors.Wrap(err, "create Lance column groups")
+	}
+	defer C.loon_column_groups_destroy(columnGroups)
+
+	var cSchema cdata.CArrowSchema
+	cdata.ExportArrowSchema(schema, &cSchema)
+	defer cdata.ReleaseCArrowSchema(&cSchema)
+	neededColumns, freeNeededColumns := newCStringArray([]string{externalField})
+	defer freeNeededColumns()
+	var reader C.LoonReaderHandle
+	ffiResult = C.loon_reader_new(
+		columnGroups,
+		(*C.struct_ArrowSchema)(unsafe.Pointer(&cSchema)),
+		(**C.char)(unsafe.Pointer(neededColumns)),
+		1,
+		properties,
+		&reader,
+	)
+	if err := consumeLanceFFIResult(&ffiResult); err != nil {
+		return nil, nil, markLanceSchemaCandidateError(errors.Wrap(err, "open Lance reader"))
+	}
+	closeReader := true
+	defer func() {
+		if closeReader {
+			C.loon_reader_destroy(reader)
+		}
+	}()
+
+	var stream cdata.CArrowArrayStream
+	ffiResult = C.loon_get_record_batch_reader(
+		reader,
+		nil,
+		(*C.struct_ArrowArrayStream)(unsafe.Pointer(&stream)),
+	)
+	if err := consumeLanceFFIResult(&ffiResult); err != nil {
+		return nil, nil, errors.Wrap(err, "open Lance record stream")
+	}
+	closeReader = false
+	cleanup := func() {
+		C.bw_lance_stream_release((*C.struct_ArrowArrayStream)(unsafe.Pointer(&stream)))
+		C.loon_reader_destroy(reader)
+	}
+	return &stream, cleanup, nil
+}
+
+func newLanceProperties(location externalSourceLocation, spec externalSourceSpec, batchSize int64) (*C.LoonProperties, error) {
+	values, err := buildLancePropertyValues(location, spec, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(values))
+	for key, value := range values {
+		if value != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	propertyValues := make([]string, len(keys))
+	for i, key := range keys {
+		propertyValues[i] = values[key]
+	}
+	cKeys, freeKeys := newCStringArray(keys)
+	defer freeKeys()
+	cValues, freeValues := newCStringArray(propertyValues)
+	defer freeValues()
+	properties := &C.LoonProperties{}
+	ffiResult := C.loon_properties_create(
+		(**C.char)(unsafe.Pointer(cKeys)),
+		(**C.char)(unsafe.Pointer(cValues)),
+		C.size_t(len(keys)),
+		properties,
+	)
+	if err := consumeLanceFFIResult(&ffiResult); err != nil {
+		return nil, errors.Wrap(err, "create Lance storage properties")
+	}
+	return properties, nil
+}
+
+func newCStringArray(values []string) (**C.char, func()) {
+	if len(values) == 0 {
+		return nil, func() {}
+	}
+	memory := C.malloc(C.size_t(len(values)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	items := unsafe.Slice((**C.char)(memory), len(values))
+	for i, value := range values {
+		items[i] = C.CString(value)
+	}
+	return (**C.char)(memory), func() {
+		for _, item := range items {
+			C.free(unsafe.Pointer(item))
+		}
+		C.free(memory)
+	}
+}
+
+func consumeLanceFFIResult(result *C.LoonFFIResult) error {
+	if result == nil {
+		return errors.New("milvus-storage returned a nil result")
+	}
+	defer C.loon_ffi_free_result(result)
+	if C.loon_ffi_is_success(result) != 0 {
+		return nil
+	}
+	return errors.Newf(
+		"milvus-storage error %d: %s",
+		int(result.err_code),
+		C.GoString(C.loon_ffi_get_errmsg(result)),
+	)
+}
+
+func lanceVectorCandidateTypes(fieldType schemapb.DataType, dim int64) []arrow.DataType {
+	var semantic arrow.DataType
+	switch fieldType {
+	case schemapb.DataType_FloatVector:
+		semantic = arrow.PrimitiveTypes.Float32
+	case schemapb.DataType_Int8Vector:
+		semantic = arrow.PrimitiveTypes.Int8
+	case schemapb.DataType_Float16Vector:
+		semantic = arrow.FixedWidthTypes.Float16
+	case schemapb.DataType_BFloat16Vector, schemapb.DataType_BinaryVector:
+		semantic = arrow.PrimitiveTypes.Uint8
+	default:
+		return nil
+	}
+	expectedLength, err := expectedExternalVectorListLength(fieldType, dim, semantic)
+	if err != nil || expectedLength > int64(^uint32(0)>>1) {
+		return nil
+	}
+	candidates := []arrow.DataType{
+		arrow.FixedSizeListOf(int32(expectedLength), semantic),
+		arrow.ListOf(semantic),
+		arrow.LargeListOf(semantic),
+	}
+	byteWidth, widthErr := externalVectorByteWidth(fieldType, dim)
+	if semantic.ID() != arrow.UINT8 {
+		if widthErr == nil && byteWidth <= int64(^uint32(0)>>1) {
+			candidates = append(candidates,
+				arrow.FixedSizeListOf(int32(byteWidth), arrow.PrimitiveTypes.Uint8),
+				arrow.ListOf(arrow.PrimitiveTypes.Uint8),
+				arrow.LargeListOf(arrow.PrimitiveTypes.Uint8),
+			)
+		}
+	}
+	if widthErr == nil && byteWidth <= int64(^uint32(0)>>1) {
+		candidates = append(candidates, &arrow.FixedSizeBinaryType{ByteWidth: int(byteWidth)})
+	}
+	candidates = append(candidates,
+		arrow.BinaryTypes.Binary,
+		arrow.BinaryTypes.LargeBinary,
+		arrow.BinaryTypes.BinaryView,
+	)
+	return candidates
+}
+
+func markLanceSchemaCandidateError(err error) error {
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{"schema", "type", "field", "cast", "column"} {
+		if strings.Contains(message, marker) {
+			return &lanceSchemaCandidateError{err: err}
+		}
+	}
+	return err
+}
+
+func shouldTryNextLanceVectorType(err error) bool {
+	var candidateError *lanceSchemaCandidateError
+	return errors.As(err, &candidateError)
+}
+
+func newExternalVectorNullResults(ranges []externalVectorSegmentRange) []*ExternalVectorNullRange {
+	results := make([]*ExternalVectorNullRange, len(ranges))
+	for i, sourceRange := range ranges {
+		results[i] = &ExternalVectorNullRange{
+			SegmentID:  sourceRange.SegmentID,
+			ObjectKey:  redactExternalVectorObjectKey(sourceRange.ObjectKey),
+			StartIndex: sourceRange.StartIndex,
+			EndIndex:   sourceRange.EndIndex,
+		}
+	}
+	return results
+}

--- a/states/inspect_external_vector_nulls_lance_stub.go
+++ b/states/inspect_external_vector_nulls_lance_stub.go
@@ -1,0 +1,33 @@
+//go:build !LANCE || !cgo
+
+package states
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func ensureLanceVectorScannerAvailable() error {
+	return errors.New(
+		"Lance vector scanning is not available in this binary; build Birdwatcher with CGO_ENABLED=1 and -tags LANCE against milvus-storage",
+	)
+}
+
+func scanLanceVectorNullRanges(
+	context.Context,
+	[]externalVectorSegmentRange,
+	string,
+	schemapb.DataType,
+	int64,
+	int,
+	int64,
+	externalSourceLocation,
+	externalSourceSpec,
+) <-chan externalVectorObjectResult {
+	results := make(chan externalVectorObjectResult)
+	close(results)
+	return results
+}

--- a/states/inspect_external_vector_nulls_lance_test.go
+++ b/states/inspect_external_vector_nulls_lance_test.go
@@ -1,0 +1,125 @@
+//go:build LANCE && cgo
+
+package states
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func TestShouldTryNextLanceVectorType(t *testing.T) {
+	runtimeError := errors.New("read field column failed")
+	require.False(t, shouldTryNextLanceVectorType(runtimeError))
+
+	schemaError := markLanceSchemaCandidateError(errors.New("field type mismatch"))
+	require.True(t, shouldTryNextLanceVectorType(schemaError))
+}
+
+func TestLanceDatasetKey(t *testing.T) {
+	require.Equal(t,
+		"s3://endpoint/bucket/table.lance",
+		lanceDatasetKey("s3://endpoint/bucket/table.lance?fragment_id=42"),
+	)
+	require.Equal(t,
+		"invalid-lance-path",
+		lanceDatasetKey("invalid-lance-path"),
+	)
+}
+
+func TestBuildLanceVectorScanIntervals(t *testing.T) {
+	ranges := []externalVectorSegmentRange{
+		{ObjectKey: "s3://table?fragment_id=2", StartIndex: 20, EndIndex: 25},
+		{ObjectKey: "s3://table?fragment_id=1", StartIndex: 0, EndIndex: 5},
+		{ObjectKey: "s3://table?fragment_id=1", StartIndex: 5, EndIndex: 10},
+		{ObjectKey: "s3://table?fragment_id=2", StartIndex: 22, EndIndex: 30},
+	}
+
+	got, err := buildLanceVectorScanIntervals(ranges)
+	require.NoError(t, err)
+	require.Equal(t, []lanceVectorScanInterval{
+		{
+			ObjectKey:    "s3://table?fragment_id=1",
+			StartIndex:   0,
+			EndIndex:     10,
+			RangeIndexes: []int{1, 2},
+		},
+		{
+			ObjectKey:    "s3://table?fragment_id=2",
+			StartIndex:   20,
+			EndIndex:     30,
+			RangeIndexes: []int{0, 3},
+		},
+	}, got)
+}
+
+func TestClassifyLanceRecordBatchAcrossIntervals(t *testing.T) {
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Float32)
+	defer builder.Release()
+	values := builder.ValueBuilder().(*array.Float32Builder)
+
+	builder.Append(true)
+	values.AppendValues([]float32{1, 2}, nil)
+	builder.Append(true)
+	values.AppendNulls(2)
+	builder.Append(true)
+	values.Append(3)
+	values.AppendNull()
+	builder.Append(false)
+	builder.Append(true)
+	values.AppendValues([]float32{4, 5}, nil)
+
+	input := builder.NewArray()
+	defer input.Release()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "vector", Type: input.DataType(), Nullable: true}}, nil)
+	record := array.NewRecord(schema, []arrow.Array{input}, int64(input.Len()))
+	defer record.Release()
+
+	sourceRanges := []externalVectorSegmentRange{
+		{ObjectKey: "s3://table?fragment_id=1", StartIndex: 10, EndIndex: 12},
+		{ObjectKey: "s3://table?fragment_id=2", StartIndex: 20, EndIndex: 23},
+	}
+	intervals := []lanceVectorScanInterval{
+		{ObjectKey: sourceRanges[0].ObjectKey, StartIndex: 10, EndIndex: 12, RangeIndexes: []int{0}},
+		{ObjectKey: sourceRanges[1].ObjectKey, StartIndex: 20, EndIndex: 23, RangeIndexes: []int{1}},
+	}
+	results := newExternalVectorNullResults(sourceRanges)
+	intervalIndex := 0
+	var intervalRowsRead int64
+
+	err := classifyLanceRecordBatch(
+		record, intervals, &intervalIndex, &intervalRowsRead,
+		sourceRanges, results, schemapb.DataType_FloatVector, 2,
+	)
+	require.NoError(t, err)
+	require.Equal(t, len(intervals), intervalIndex)
+	require.Zero(t, intervalRowsRead)
+	require.Equal(t, int64(1), results[0].ValidRows)
+	require.Equal(t, int64(1), results[0].FullNullRows)
+	require.Equal(t, int64(1), results[1].ValidRows)
+	require.Equal(t, int64(1), results[1].RowNullRows)
+	require.Equal(t, int64(1), results[1].PartialNullRows)
+}
+
+func TestLanceVectorCandidateTypesIncludesBinaryLayouts(t *testing.T) {
+	candidates := lanceVectorCandidateTypes(schemapb.DataType_FloatVector, 8)
+	var fixedSizeBinaryWidth int
+	typeIDs := make(map[arrow.Type]bool)
+	for _, candidate := range candidates {
+		typeIDs[candidate.ID()] = true
+		if fixedSizeBinary, ok := candidate.(*arrow.FixedSizeBinaryType); ok {
+			fixedSizeBinaryWidth = fixedSizeBinary.ByteWidth
+		}
+	}
+
+	require.Equal(t, 32, fixedSizeBinaryWidth)
+	require.True(t, typeIDs[arrow.BINARY])
+	require.True(t, typeIDs[arrow.LARGE_BINARY])
+	require.True(t, typeIDs[arrow.BINARY_VIEW])
+}

--- a/states/inspect_external_vector_nulls_test.go
+++ b/states/inspect_external_vector_nulls_test.go
@@ -1,0 +1,671 @@
+package states
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+)
+
+type reopeningObjectStore struct {
+	data  []byte
+	opens atomic.Int64
+}
+
+func (s *reopeningObjectStore) Open(context.Context, string, ...oss.OpenOption) (storagecommon.ReadSeeker, error) {
+	s.opens.Add(1)
+	return bytes.NewReader(s.data), nil
+}
+
+func (*reopeningObjectStore) Stat(context.Context, string) (*models.FsStat, error) {
+	return nil, nil
+}
+
+func (*reopeningObjectStore) List(context.Context, string, bool) (<-chan oss.ObjectInfo, error) {
+	return nil, nil
+}
+
+func TestClassifyExternalVectorArray_ListNullKinds(t *testing.T) {
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Float32)
+	defer builder.Release()
+	values := builder.ValueBuilder().(*array.Float32Builder)
+
+	builder.Append(true)
+	values.AppendValues([]float32{1, 2}, nil)
+	builder.Append(true)
+	values.AppendNulls(2)
+	builder.Append(true)
+	values.Append(3)
+	values.AppendNull()
+	builder.Append(false)
+	builder.Append(true)
+	values.Append(4)
+
+	input := builder.NewArray()
+	defer input.Release()
+
+	got, err := classifyExternalVectorArray(input, schemapb.DataType_FloatVector, 2)
+	if err != nil {
+		t.Fatalf("classifyExternalVectorArray() error = %v", err)
+	}
+	want := externalVectorNullCounts{
+		Rows:              5,
+		ValidRows:         1,
+		RowNullRows:       1,
+		FullNullRows:      1,
+		PartialNullRows:   1,
+		InvalidLengthRows: 1,
+	}
+	if got != want {
+		t.Fatalf("classifyExternalVectorArray() = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyExternalVectorArray_FixedSizeListNullKinds(t *testing.T) {
+	builder := array.NewFixedSizeListBuilder(memory.DefaultAllocator, 2, arrow.PrimitiveTypes.Float32)
+	defer builder.Release()
+	values := builder.ValueBuilder().(*array.Float32Builder)
+
+	builder.Append(true)
+	values.AppendNulls(2)
+	builder.Append(true)
+	values.Append(1)
+	values.AppendNull()
+	builder.Append(false)
+	values.AppendNulls(2)
+	builder.Append(true)
+	values.AppendValues([]float32{2, 3}, nil)
+
+	input := builder.NewArray()
+	defer input.Release()
+
+	got, err := classifyExternalVectorArray(input, schemapb.DataType_FloatVector, 2)
+	if err != nil {
+		t.Fatalf("classifyExternalVectorArray() error = %v", err)
+	}
+	want := externalVectorNullCounts{
+		Rows:            4,
+		ValidRows:       1,
+		RowNullRows:     1,
+		FullNullRows:    1,
+		PartialNullRows: 1,
+	}
+	if got != want {
+		t.Fatalf("classifyExternalVectorArray() = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyExternalVectorArray_AdditionalArrowTypes(t *testing.T) {
+	t.Run("large list", func(t *testing.T) {
+		builder := array.NewLargeListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Float32)
+		defer builder.Release()
+		values := builder.ValueBuilder().(*array.Float32Builder)
+
+		builder.Append(true)
+		values.AppendValues([]float32{1, 2}, nil)
+		builder.Append(true)
+		values.AppendNulls(2)
+
+		input := builder.NewArray()
+		defer input.Release()
+
+		got, err := classifyExternalVectorArray(input, schemapb.DataType_FloatVector, 2)
+		if err != nil {
+			t.Fatalf("classifyExternalVectorArray() error = %v", err)
+		}
+		want := externalVectorNullCounts{Rows: 2, ValidRows: 1, FullNullRows: 1}
+		if got != want {
+			t.Fatalf("classifyExternalVectorArray() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("list view", func(t *testing.T) {
+		builder := array.NewListViewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Float32)
+		defer builder.Release()
+		values := builder.ValueBuilder().(*array.Float32Builder)
+
+		builder.AppendWithSize(true, 2)
+		values.AppendValues([]float32{1, 2}, nil)
+		builder.AppendWithSize(true, 2)
+		values.Append(3)
+		values.AppendNull()
+
+		input := builder.NewArray()
+		defer input.Release()
+
+		got, err := classifyExternalVectorArray(input, schemapb.DataType_FloatVector, 2)
+		if err != nil {
+			t.Fatalf("classifyExternalVectorArray() error = %v", err)
+		}
+		want := externalVectorNullCounts{Rows: 2, ValidRows: 1, PartialNullRows: 1}
+		if got != want {
+			t.Fatalf("classifyExternalVectorArray() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("binary view", func(t *testing.T) {
+		builder := array.NewBinaryViewBuilder(memory.DefaultAllocator)
+		defer builder.Release()
+		builder.Append([]byte{1, 2})
+		builder.AppendNull()
+		builder.Append([]byte{1})
+
+		input := builder.NewArray()
+		defer input.Release()
+
+		got, err := classifyExternalVectorArray(input, schemapb.DataType_BinaryVector, 16)
+		if err != nil {
+			t.Fatalf("classifyExternalVectorArray() error = %v", err)
+		}
+		want := externalVectorNullCounts{
+			Rows:              3,
+			ValidRows:         1,
+			RowNullRows:       1,
+			InvalidLengthRows: 1,
+		}
+		if got != want {
+			t.Fatalf("classifyExternalVectorArray() = %+v, want %+v", got, want)
+		}
+	})
+}
+
+func TestExpectedExternalVectorListLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType schemapb.DataType
+		dim       int64
+		childType arrow.DataType
+		want      int64
+	}{
+		{name: "float semantic", fieldType: schemapb.DataType_FloatVector, dim: 8, childType: arrow.PrimitiveTypes.Float32, want: 8},
+		{name: "float raw bytes", fieldType: schemapb.DataType_FloatVector, dim: 8, childType: arrow.PrimitiveTypes.Uint8, want: 32},
+		{name: "float16 semantic", fieldType: schemapb.DataType_Float16Vector, dim: 8, childType: arrow.FixedWidthTypes.Float16, want: 8},
+		{name: "float16 raw bytes", fieldType: schemapb.DataType_Float16Vector, dim: 8, childType: arrow.PrimitiveTypes.Uint8, want: 16},
+		{name: "bfloat16 bytes", fieldType: schemapb.DataType_BFloat16Vector, dim: 8, childType: arrow.PrimitiveTypes.Uint8, want: 16},
+		{name: "binary bytes", fieldType: schemapb.DataType_BinaryVector, dim: 16, childType: arrow.PrimitiveTypes.Uint8, want: 2},
+		{name: "int8 semantic", fieldType: schemapb.DataType_Int8Vector, dim: 8, childType: arrow.PrimitiveTypes.Int8, want: 8},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := expectedExternalVectorListLength(test.fieldType, test.dim, test.childType)
+			if err != nil {
+				t.Fatalf("expectedExternalVectorListLength() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("expectedExternalVectorListLength() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveExternalVectorField(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:       101,
+				Name:          "embedding",
+				DataType:      schemapb.DataType_FloatVector,
+				ExternalField: "source_vector",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "128"},
+				},
+			},
+		},
+	}
+	field, externalField, dim, err := resolveExternalVectorField(schema, "embedding")
+	if err != nil {
+		t.Fatalf("resolveExternalVectorField() error = %v", err)
+	}
+	if field.GetFieldID() != 101 || externalField != "source_vector" || dim != 128 {
+		t.Fatalf("resolveExternalVectorField() = field=%d external=%s dim=%d", field.GetFieldID(), externalField, dim)
+	}
+}
+
+func TestContainsManifestColumn(t *testing.T) {
+	columns := []string{"100", "101"}
+	if !containsManifestColumn(columns, "vector", "101") {
+		t.Fatal("containsManifestColumn() expected field ID match")
+	}
+	if containsManifestColumn(columns, "vector", "102") {
+		t.Fatal("containsManifestColumn() unexpected match")
+	}
+}
+
+func TestBuildExternalVectorScanIntervals(t *testing.T) {
+	tests := []struct {
+		name   string
+		ranges []externalVectorSegmentRange
+		want   []externalVectorScanInterval
+	}{
+		{
+			name: "keeps disjoint ranges separate",
+			ranges: []externalVectorSegmentRange{
+				{StartIndex: 100, EndIndex: 200},
+				{StartIndex: 1_000_000, EndIndex: 1_000_100},
+			},
+			want: []externalVectorScanInterval{
+				{StartIndex: 100, EndIndex: 200, RangeIndexes: []int{0}},
+				{StartIndex: 1_000_000, EndIndex: 1_000_100, RangeIndexes: []int{1}},
+			},
+		},
+		{
+			name: "merges overlapping and adjacent ranges",
+			ranges: []externalVectorSegmentRange{
+				{StartIndex: 20, EndIndex: 30},
+				{StartIndex: 0, EndIndex: 10},
+				{StartIndex: 8, EndIndex: 20},
+				{StartIndex: 100, EndIndex: 110},
+			},
+			want: []externalVectorScanInterval{
+				{StartIndex: 0, EndIndex: 30, RangeIndexes: []int{1, 2, 0}},
+				{StartIndex: 100, EndIndex: 110, RangeIndexes: []int{3}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := buildExternalVectorScanIntervals(test.ranges)
+			if err != nil {
+				t.Fatalf("buildExternalVectorScanIntervals() error = %v", err)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("buildExternalVectorScanIntervals() = %+v, want %+v", got, test.want)
+			}
+			for i := range got {
+				if got[i].StartIndex != test.want[i].StartIndex ||
+					got[i].EndIndex != test.want[i].EndIndex ||
+					!slices.Equal(got[i].RangeIndexes, test.want[i].RangeIndexes) {
+					t.Fatalf("interval[%d] = %+v, want %+v", i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildExternalVectorScanIntervalsRejectsInvalidRange(t *testing.T) {
+	_, err := buildExternalVectorScanIntervals([]externalVectorSegmentRange{{StartIndex: 10, EndIndex: 10}})
+	if err == nil || !strings.Contains(err.Error(), "invalid external vector row range") {
+		t.Fatalf("buildExternalVectorScanIntervals() error = %v", err)
+	}
+}
+
+func TestInspectExternalVectorNullRangeProjectsVectorAcrossRowGroups(t *testing.T) {
+	allocator := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "vector", Type: arrow.ListOf(arrow.PrimitiveTypes.Float32), Nullable: true},
+	}, nil)
+	builder := array.NewRecordBuilder(allocator, schema)
+	defer builder.Release()
+
+	ids := builder.Field(0).(*array.Int64Builder)
+	ids.AppendValues([]int64{10, 11, 12, 13, 14}, nil)
+	vectors := builder.Field(1).(*array.ListBuilder)
+	values := vectors.ValueBuilder().(*array.Float32Builder)
+
+	vectors.Append(true)
+	values.AppendValues([]float32{1, 2}, nil)
+	vectors.Append(true)
+	values.AppendNulls(2)
+	vectors.Append(true)
+	values.Append(3)
+	values.AppendNull()
+	vectors.Append(false)
+	vectors.Append(true)
+	values.AppendValues([]float32{4, 5}, nil)
+
+	record := builder.NewRecord()
+	defer record.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer table.Release()
+
+	var parquetData bytes.Buffer
+	if err := pqarrow.WriteTable(
+		table,
+		&parquetData,
+		2,
+		parquet.NewWriterProperties(),
+		pqarrow.DefaultWriterProps(),
+	); err != nil {
+		t.Fatalf("WriteTable() error = %v", err)
+	}
+
+	objectResult := inspectExternalVectorNullObject(
+		context.Background(),
+		&singleObjectStore{object: bytes.NewReader(parquetData.Bytes())},
+		externalVectorObjectJob{
+			ObjectKey: "vectors.parquet",
+			Ranges: []externalVectorSegmentRange{{
+				SegmentID:  100,
+				ObjectKey:  "vectors.parquet",
+				StartIndex: 1,
+				EndIndex:   4,
+			}},
+		},
+		"vector",
+		schemapb.DataType_FloatVector,
+		2,
+		2,
+		true,
+	)
+	result := objectResult.Ranges[0]
+	if result.InspectionError != "" {
+		t.Fatalf("inspectExternalVectorNullObject() error = %s", result.InspectionError)
+	}
+	if result.Rows != 3 || result.ValidRows != 0 || result.RowNullRows != 1 ||
+		result.FullNullRows != 1 || result.PartialNullRows != 1 || result.InvalidLengthRows != 0 {
+		t.Fatalf("inspectExternalVectorNullObject() = %+v", result)
+	}
+}
+
+func TestScanExternalVectorNullRangesGroupsObjectsAndSkipsCleanRowGroups(t *testing.T) {
+	allocator := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "vector", Type: arrow.ListOf(arrow.PrimitiveTypes.Float32), Nullable: true},
+	}, nil)
+	builder := array.NewRecordBuilder(allocator, schema)
+	defer builder.Release()
+	vectors := builder.Field(0).(*array.ListBuilder)
+	values := vectors.ValueBuilder().(*array.Float32Builder)
+
+	vectors.Append(true)
+	values.AppendValues([]float32{1, 2}, nil)
+	vectors.Append(true)
+	values.AppendValues([]float32{3, 4}, nil)
+	vectors.Append(true)
+	values.AppendNulls(2)
+	vectors.Append(true)
+	values.Append(5)
+	values.AppendNull()
+	vectors.Append(false)
+	vectors.Append(true)
+	values.AppendValues([]float32{6, 7}, nil)
+
+	record := builder.NewRecord()
+	defer record.Release()
+	tbl := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer tbl.Release()
+	var parquetData bytes.Buffer
+	if err := pqarrow.WriteTable(
+		tbl,
+		&parquetData,
+		2,
+		parquet.NewWriterProperties(),
+		pqarrow.DefaultWriterProps(),
+	); err != nil {
+		t.Fatalf("WriteTable() error = %v", err)
+	}
+
+	ranges := []externalVectorSegmentRange{
+		{SegmentID: 1, ObjectKey: "vectors.parquet", StartIndex: 0, EndIndex: 4},
+		{SegmentID: 2, ObjectKey: "vectors.parquet", StartIndex: 1, EndIndex: 6},
+	}
+	t.Run("metadata fast path", func(t *testing.T) {
+		store := &reopeningObjectStore{data: parquetData.Bytes()}
+		var got []externalVectorObjectResult
+		for result := range scanExternalVectorNullRanges(
+			context.Background(), store, ranges, "vector",
+			schemapb.DataType_FloatVector, 2, 4, 2, false,
+		) {
+			got = append(got, result)
+		}
+		if store.opens.Load() != 1 {
+			t.Fatalf("object opens = %d, want 1", store.opens.Load())
+		}
+		if len(got) != 1 || got[0].RowGroupsSkipped != 1 || got[0].RowGroupsScanned != 2 {
+			t.Fatalf("object result = %+v", got)
+		}
+		first, second := got[0].Ranges[0], got[0].Ranges[1]
+		if first.Rows != 4 || first.MetadataNoNullRows != 2 || first.FullNullRows != 1 ||
+			first.PartialNullRows != 1 || first.ValidRows != 0 {
+			t.Fatalf("first range = %+v", first)
+		}
+		if second.Rows != 5 || second.MetadataNoNullRows != 1 || second.ValidRows != 1 ||
+			second.RowNullRows != 1 || second.FullNullRows != 1 || second.PartialNullRows != 1 {
+			t.Fatalf("second range = %+v", second)
+		}
+	})
+
+	t.Run("exact path", func(t *testing.T) {
+		store := &reopeningObjectStore{data: parquetData.Bytes()}
+		result := <-scanExternalVectorNullRanges(
+			context.Background(), store, ranges, "vector",
+			schemapb.DataType_FloatVector, 2, 4, 2, true,
+		)
+		if store.opens.Load() != 1 || result.RowGroupsSkipped != 0 || result.RowGroupsScanned != 3 {
+			t.Fatalf("opens=%d result=%+v", store.opens.Load(), result)
+		}
+		if result.Ranges[0].MetadataNoNullRows != 0 || result.Ranges[0].ValidRows != 2 {
+			t.Fatalf("exact first range = %+v", result.Ranges[0])
+		}
+	})
+}
+
+func TestResolveExternalManifestLancePathPreservesFragmentID(t *testing.T) {
+	location := externalSourceLocation{
+		Scheme:   "s3",
+		Host:     "s3.us-west-2.amazonaws.com",
+		Bucket:   "bucket",
+		RootPath: "dataset",
+	}
+	full := "s3://s3.us-west-2.amazonaws.com/bucket/dataset?fragment_id=12"
+	got, err := resolveExternalManifestLancePath(location, full)
+	if err != nil || got != full {
+		t.Fatalf("resolve full path = %q, %v", got, err)
+	}
+	got, err = resolveExternalManifestLancePath(location, "dataset?fragment_id=13")
+	if err != nil || got != "s3://s3.us-west-2.amazonaws.com/bucket/dataset?fragment_id=13" {
+		t.Fatalf("resolve relative path = %q, %v", got, err)
+	}
+}
+
+func TestRedactExternalVectorObjectKey(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "preserve numeric Lance fragment ID",
+			raw:  "s3://endpoint/bucket/dataset?fragment_id=12",
+			want: "s3://endpoint/bucket/dataset?fragment_id=12",
+		},
+		{
+			name: "remove credentials and unrelated query",
+			raw:  "s3://user:password@endpoint/bucket/dataset?fragment_id=12&token=secret#private",
+			want: "s3://endpoint/bucket/dataset?fragment_id=12",
+		},
+		{
+			name: "remove signed parquet query",
+			raw:  "part.parquet?X-Amz-Signature=secret",
+			want: "part.parquet",
+		},
+		{
+			name: "drop invalid fragment ID",
+			raw:  "dataset?fragment_id=secret",
+			want: "dataset",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := redactExternalVectorObjectKey(test.raw); got != test.want {
+				t.Fatalf("redactExternalVectorObjectKey() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeExternalVectorInspectionError(t *testing.T) {
+	raw := "s3://user:password@endpoint/bucket/dataset?fragment_id=12&token=secret#private"
+	message := sanitizeExternalVectorInspectionError(
+		fmt.Errorf("open Lance reader for %s: access denied", raw),
+		raw,
+	)
+	if strings.Contains(message, "password") || strings.Contains(message, "secret") ||
+		strings.Contains(message, "token=") {
+		t.Fatalf("inspection error contains credentials: %s", message)
+	}
+	if !strings.Contains(message, "s3://endpoint/bucket/dataset?fragment_id=12") {
+		t.Fatalf("inspection error lost safe object identity: %s", message)
+	}
+}
+
+func TestBuildLancePropertyValuesMinioUsesS3CompatibleBackend(t *testing.T) {
+	values, err := buildLancePropertyValues(
+		externalSourceLocation{
+			Scheme:   "minio",
+			Host:     "localhost:9000",
+			Bucket:   "test-bucket",
+			RootPath: "dataset",
+		},
+		externalSourceSpec{
+			CloudProvider:  "minio",
+			AccessKeyID:    "minio-ak",
+			AccessKeyValue: "minio-sk",
+		},
+		1024,
+	)
+	if err != nil {
+		t.Fatalf("buildLancePropertyValues() error = %v", err)
+	}
+	if _, ok := values["extfs.birdwatcher.cloud_provider"]; ok {
+		t.Fatal("MinIO sentinel must not be forwarded to milvus-storage")
+	}
+	if values["extfs.birdwatcher.address"] != "localhost:9000" ||
+		values["extfs.birdwatcher.use_ssl"] != "false" ||
+		values["extfs.birdwatcher.use_virtual_host"] != "false" ||
+		values["reader.metadata_cache.enable"] != "true" {
+		t.Fatalf("unexpected MinIO Lance properties: %#v", values)
+	}
+}
+
+func TestBuildLancePropertyValuesForwardsSupportedProvider(t *testing.T) {
+	values, err := buildLancePropertyValues(
+		externalSourceLocation{
+			Scheme:   "s3",
+			Host:     "s3.us-west-2.amazonaws.com",
+			Bucket:   "test-bucket",
+			RootPath: "dataset",
+		},
+		externalSourceSpec{
+			CloudProvider:  "aws",
+			Region:         "us-west-2",
+			AccessKeyID:    "test-ak",
+			AccessKeyValue: "test-sk",
+		},
+		1024,
+	)
+	if err != nil {
+		t.Fatalf("buildLancePropertyValues() error = %v", err)
+	}
+	if values["extfs.birdwatcher.cloud_provider"] != "aws" {
+		t.Fatalf("cloud provider = %q, want aws", values["extfs.birdwatcher.cloud_provider"])
+	}
+}
+
+func TestBuildLancePropertyValuesForwardsAzureBroker(t *testing.T) {
+	values, err := buildLancePropertyValues(
+		externalSourceLocation{
+			Scheme:   "azure",
+			Host:     "core.windows.net",
+			Bucket:   "container",
+			RootPath: "dataset",
+		},
+		externalSourceSpec{
+			CloudProvider:           "azure",
+			Region:                  "westus3",
+			AccessKeyID:             "storage-account",
+			AzureClientID:           "client-id",
+			AzureTenantID:           "tenant-id",
+			AzureCredentialEndpoint: "https://broker.example.com/v1/credentials/assume-role",
+			LoadFrequency:           3600,
+		},
+		1024,
+	)
+	if err != nil {
+		t.Fatalf("buildLancePropertyValues() error = %v", err)
+	}
+	for key, want := range map[string]string{
+		"extfs.birdwatcher.cloud_provider":            "azure",
+		"extfs.birdwatcher.address":                   "core.windows.net",
+		"extfs.birdwatcher.bucket_name":               "container",
+		"extfs.birdwatcher.access_key_id":             "storage-account",
+		"extfs.birdwatcher.azure_client_id":           "client-id",
+		"extfs.birdwatcher.azure_tenant_id":           "tenant-id",
+		"extfs.birdwatcher.azure_credential_endpoint": "https://broker.example.com/v1/credentials/assume-role",
+		"extfs.birdwatcher.load_frequency":            "3600",
+		"extfs.birdwatcher.use_iam":                   "false",
+	} {
+		if got := values[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestRedactExternalVectorSource(t *testing.T) {
+	if got := redactExternalVectorSource("s3://bucket/dataset"); got != "s3://bucket/dataset" {
+		t.Fatalf("redactExternalVectorSource() = %q", got)
+	}
+	for _, source := range []string{
+		"s3://bucket/dataset?token=secret",
+		"s3://bucket/dataset#secret",
+		"s3://user:password@bucket/dataset",
+	} {
+		if got := redactExternalVectorSource(source); got != "<redacted>" {
+			t.Fatalf("redactExternalVectorSource(%q) = %q", source, got)
+		}
+	}
+}
+
+func TestSelectExternalCollectionSegments(t *testing.T) {
+	externalSegment := &models.Segment{SegmentInfo: &datapb.SegmentInfo{
+		ID:           1,
+		ManifestPath: `{"ver":1,"base_path":"files"}`,
+	}}
+	regular := &models.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 2}}
+
+	got, err := selectExternalCollectionSegments([]*models.Segment{regular, externalSegment}, 0)
+	if err != nil {
+		t.Fatalf("selectExternalCollectionSegments() error = %v", err)
+	}
+	if len(got) != 1 || got[0].GetID() != externalSegment.GetID() {
+		t.Fatalf("selectExternalCollectionSegments() = %v, want segment %d", got, externalSegment.GetID())
+	}
+
+	_, err = selectExternalCollectionSegments([]*models.Segment{regular}, regular.GetID())
+	if err == nil || !strings.Contains(err.Error(), "not an external collection segment") {
+		t.Fatalf("selectExternalCollectionSegments() error = %v, want explicit non-external error", err)
+	}
+}
+
+func TestScanExternalVectorNullSegmentsRejectsNonExternalCollectionFirst(t *testing.T) {
+	collection := models.NewCollection(&etcdpb.CollectionInfo{
+		ID:     42,
+		Schema: &schemapb.CollectionSchema{Name: "regular_collection"},
+	}, "")
+
+	_, err := (&InstanceState{}).scanExternalVectorNullSegments(
+		context.Background(), collection, &ScanBinlogParams{})
+	if err == nil || !strings.Contains(err.Error(),
+		"collection 42 is not an external collection: external_source is empty") {
+		t.Fatalf("scanExternalVectorNullSegments() error = %v", err)
+	}
+}

--- a/states/inspect_external_vector_nulls_test.go
+++ b/states/inspect_external_vector_nulls_test.go
@@ -589,6 +589,7 @@ func TestBuildLancePropertyValuesForwardsAzureBroker(t *testing.T) {
 			Bucket:   "container",
 			RootPath: "dataset",
 		},
+		// #nosec G101 -- Placeholder Azure configuration for property forwarding tests.
 		externalSourceSpec{
 			CloudProvider:           "azure",
 			Region:                  "westus3",
@@ -603,6 +604,7 @@ func TestBuildLancePropertyValuesForwardsAzureBroker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildLancePropertyValues() error = %v", err)
 	}
+	// #nosec G101 -- Expected placeholder Azure properties, not credentials.
 	for key, want := range map[string]string{
 		"extfs.birdwatcher.cloud_provider":            "azure",
 		"extfs.birdwatcher.address":                   "core.windows.net",

--- a/states/inspect_parquet.go
+++ b/states/inspect_parquet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path"
 	"slices"
 	"strconv"
@@ -15,7 +16,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/cockroachdb/errors"
-	"github.com/minio/minio-go/v7"
 
 	"github.com/milvus-io/birdwatcher/framework"
 	"github.com/milvus-io/birdwatcher/models"
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/birdwatcher/states/ossutil"
 	binlogv1 "github.com/milvus-io/birdwatcher/storage/binlog/v1"
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 )
 
 type InspectParquetParam struct {
@@ -75,12 +76,31 @@ func parseInspectStorageVersionOption(raw string) (inspectStorageVersionOption, 
 	return inspectStorageVersionOption{mode: inspectStorageVersionOverride, version: version}, nil
 }
 
-// externalSourceSpec is the parsed external collection specification.
-// It is an alias of ossutil.ExternalSourceSpec; kept for compatibility.
 type externalSourceSpec = ossutil.ExternalSourceSpec
 
-// externalSourceLocation is the parsed external_source URI.
-type externalSourceLocation = ossutil.ExternalSourceLocation
+type externalSourceLocation struct {
+	Scheme       string
+	SourceHost   string
+	Host         string
+	Bucket       string
+	RootPath     string
+	HostIsBucket bool
+}
+
+func toOSSUtilExternalSourceLocation(location externalSourceLocation) ossutil.ExternalSourceLocation {
+	form := ossutil.LocationFormMilvus
+	if location.HostIsBucket {
+		form = ossutil.LocationFormAWS
+	}
+	return ossutil.ExternalSourceLocation{
+		Scheme:   location.Scheme,
+		Host:     location.SourceHost,
+		Bucket:   location.Bucket,
+		RootPath: location.RootPath,
+		Address:  location.Host,
+		Form:     form,
+	}
+}
 
 func (s *InstanceState) InspectParquetCommand(ctx context.Context, p *InspectParquetParam) error {
 	if err := validateInspectParquetParam(p); err != nil {
@@ -228,14 +248,16 @@ func (s *InstanceState) inspectExternalCollectionParquet(ctx context.Context, p 
 	if err != nil {
 		return err
 	}
-	externalMinioClient, externalBucketName, externalRootPath, location, err := newExternalMinioClient(ctx, proto.GetSchema().GetExternalSource(), spec, p.SkipBucketCheck)
+	if spec.Format != "" && spec.Format != externalspec.FormatParquet {
+		return errors.Newf("inspect-parquet does not support external format %s", spec.Format)
+	}
+	externalStore, externalBucketName, externalRootPath, location, err := newExternalObjectStore(ctx, proto.GetSchema().GetExternalSource(), spec, p.SkipBucketCheck)
 	if err != nil {
 		return err
 	}
-	externalStore := oss.NewMinioObjectStoreWithBucket(externalMinioClient, externalBucketName)
 
 	fmt.Printf("External Collection %d: name=%s\n", proto.GetID(), proto.GetSchema().GetName())
-	fmt.Printf("External Source: %s\n", proto.GetSchema().GetExternalSource())
+	fmt.Printf("External Source: %s\n", redactExternalVectorSource(proto.GetSchema().GetExternalSource()))
 	fmt.Printf("Resolved Provider=%s Region=%s Host=%s Bucket=%s RootPath=%s\n", spec.CloudProvider, spec.Region, location.Host, externalBucketName, externalRootPath)
 
 	if p.ExternalFile != "" {
@@ -300,6 +322,9 @@ func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.Objec
 	if err != nil {
 		return errors.Wrap(err, "get manifest object")
 	}
+	if closer, ok := obj.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
 	m, err := parseManifest(obj)
 	if err != nil {
 		return errors.Wrap(err, "parse manifest")
@@ -310,7 +335,12 @@ func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.Objec
 		fieldFilter = strconv.FormatInt(p.FieldID, 10)
 	}
 
-	resolver := ossutil.NewManifestPathResolver(manifestStore, manifestBasePath, externalStore, location)
+	resolver := ossutil.NewManifestPathResolver(
+		manifestStore,
+		manifestBasePath,
+		externalStore,
+		toOSSUtilExternalSourceLocation(location),
+	)
 
 	for i, cg := range m.ColumnGroups {
 		if fieldFilter != "" && !slices.Contains(cg.Columns, fieldFilter) {
@@ -320,7 +350,10 @@ func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.Objec
 		for _, f := range cg.Files {
 			store, filePath, backend, err := resolver.Resolve(f.Path, "_data")
 			if err != nil {
-				fmt.Printf("failed to resolve manifest file path %s: %s\n", f.Path, err.Error())
+				fmt.Printf("failed to resolve manifest file path %s: %s\n",
+					redactExternalVectorObjectKey(f.Path),
+					sanitizeExternalVectorInspectionError(err, f.Path),
+				)
 				continue
 			}
 			fmt.Printf("\n----- File %s (rows: [%d, %d)) backend=%s -----\n", filePath, f.StartIndex, f.EndIndex, backend)
@@ -330,6 +363,37 @@ func inspectExternalManifestParquet(ctx context.Context, manifestStore oss.Objec
 		}
 	}
 	return nil
+}
+
+func resolveExternalManifestObjectKey(location externalSourceLocation, manifestBasePath, rawPath string) (string, error) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" {
+		return "", errors.New("manifest file path is empty")
+	}
+	if strings.Contains(trimmed, "://") {
+		return resolveExternalObjectKey(location, trimmed)
+	}
+	if strings.Contains(trimmed, "ROOT_PATH") {
+		replaced := strings.ReplaceAll(trimmed, "ROOT_PATH", location.RootPath)
+		return path.Clean(strings.TrimPrefix(replaced, "/")), nil
+	}
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if location.RootPath == "" {
+		return path.Clean(trimmed), nil
+	}
+	if trimmed == location.RootPath || strings.HasPrefix(trimmed, location.RootPath+"/") {
+		return path.Clean(trimmed), nil
+	}
+	if manifestBasePath != "" {
+		basePath := strings.TrimPrefix(strings.TrimSpace(manifestBasePath), "/")
+		if basePath != "" {
+			dataPath := path.Join(basePath, "_data", trimmed)
+			if strings.HasPrefix(dataPath, location.RootPath+"/") {
+				return path.Clean(dataPath), nil
+			}
+		}
+	}
+	return path.Join(location.RootPath, trimmed), nil
 }
 
 func inspectV3SegmentParquet(ctx context.Context, store oss.ObjectStore, rootPath string, segment *models.Segment, p *InspectParquetParam) error {
@@ -554,37 +618,290 @@ func arrowCellString(arr arrow.Array, idx int) string {
 }
 
 func parseExternalSpec(raw string) (externalSourceSpec, error) {
-	return ossutil.ParseExternalSpec(raw)
+	spec, err := ossutil.ParseExternalSpecLoose(raw)
+	if err != nil {
+		return externalSourceSpec{}, err
+	}
+	if spec.Format != "" && spec.Format != externalspec.FormatParquet &&
+		spec.Format != externalspec.FormatLanceTable {
+		return externalSourceSpec{}, errors.Newf("external collection format %s is not supported", spec.Format)
+	}
+	return spec, nil
 }
 
-func parseExternalSource(raw string) (externalSourceLocation, error) {
-	return ossutil.ParseExternalSource(raw)
+func parseExternalSource(raw string, spec externalSourceSpec) (externalSourceLocation, error) {
+	if err := externalspec.ValidateExternalSource(raw); err != nil {
+		return externalSourceLocation{}, errors.New(sanitizeExternalVectorInspectionError(err, raw))
+	}
+	resolved, err := ossutil.ResolveExternalSource(raw, spec)
+	if err != nil {
+		return externalSourceLocation{}, err
+	}
+	if spec.BucketName != "" {
+		resolved.Bucket = spec.BucketName
+	}
+	return externalSourceLocation{
+		Scheme:       resolved.Scheme,
+		SourceHost:   resolved.Host,
+		Host:         resolved.Address,
+		Bucket:       resolved.Bucket,
+		RootPath:     resolved.RootPath,
+		HostIsBucket: resolved.Form == ossutil.LocationFormAWS,
+	}, nil
 }
 
-func newExternalMinioClient(ctx context.Context, source string, spec externalSourceSpec, skipBucketCheck bool) (*minio.Client, string, string, externalSourceLocation, error) {
-	store, location, err := ossutil.NewResolvedExternalObjectStore(ctx, source, spec, skipBucketCheck)
+func newExternalObjectStore(ctx context.Context, source string, spec externalSourceSpec, skipBucketCheck bool) (oss.ObjectStore, string, string, externalSourceLocation, error) {
+	param, location, err := buildExternalMinioClientParam(source, spec, skipBucketCheck)
 	if err != nil {
 		return nil, "", "", externalSourceLocation{}, err
 	}
-	client, ok := oss.MinioClientFromObjectStore(store.Store)
-	if !ok {
-		return nil, "", "", externalSourceLocation{}, errors.New("external object store is not backed by minio client")
+	if param.CloudProvider == oss.CloudProviderAzure {
+		store, err := oss.NewAzureObjectStore(ctx, param)
+		if err != nil {
+			return nil, "", "", externalSourceLocation{}, err
+		}
+		return store, param.BucketName, param.RootPath, location, nil
 	}
-	return client, store.BucketName, store.RootPath, location, nil
+	client, err := oss.NewMinioClient(ctx, param)
+	if err != nil {
+		return nil, "", "", externalSourceLocation{}, err
+	}
+	return oss.NewMinioObjectStore(client), client.BucketName, client.RootPath, location, nil
 }
 
-func inferCloudProviderFromScheme(scheme string) string {
-	return ossutil.InferCloudProviderFromScheme(scheme)
+func externalSourceLocationForSpec(source string, spec externalSourceSpec) (externalSourceLocation, error) {
+	if err := ossutil.ValidateExternalStorageSpec(source, spec); err != nil {
+		if !ossutil.IsLegacyExternalSpec(spec) {
+			return externalSourceLocation{}, errors.New(
+				sanitizeExternalVectorInspectionError(err, source))
+		}
+		return parseLegacyExternalSource(source)
+	}
+	return parseExternalSource(source, spec)
+}
+
+func buildExternalMinioClientParam(source string, spec externalSourceSpec, skipBucketCheck bool) (oss.MinioClientParam, externalSourceLocation, error) {
+	if err := ossutil.ValidateExternalStorageSpec(source, spec); err != nil {
+		if !ossutil.IsLegacyExternalSpec(spec) {
+			return oss.MinioClientParam{}, externalSourceLocation{}, errors.New(
+				sanitizeExternalVectorInspectionError(err, source))
+		}
+		return buildLegacyExternalMinioClientParam(source, spec, skipBucketCheck)
+	}
+	location, err := parseExternalSource(source, spec)
+	if err != nil {
+		return oss.MinioClientParam{}, externalSourceLocation{}, err
+	}
+	provider := spec.CloudProvider
+	if location.Scheme == externalspec.SchemeMinIO && provider == "" {
+		provider = externalspec.CloudProviderMinIO
+	}
+	if spec.RoleARN != "" && provider != externalspec.CloudProviderAWS &&
+		provider != externalspec.CloudProviderMinIO &&
+		provider != externalspec.CloudProviderAliyun {
+		return oss.MinioClientParam{}, externalSourceLocation{}, errors.Newf(
+			"extfs.role_arn is not supported for cloud provider %s by Birdwatcher object storage client",
+			provider,
+		)
+	}
+	if spec.GCPTargetServiceAccount != "" {
+		return oss.MinioClientParam{}, externalSourceLocation{}, errors.New(
+			"extfs.gcp_target_service_account is not supported by Birdwatcher object storage client",
+		)
+	}
+	if spec.SSLCACert != "" {
+		return oss.MinioClientParam{}, externalSourceLocation{}, errors.New(
+			"extfs.ssl_ca_cert is not supported by Birdwatcher object storage client",
+		)
+	}
+
+	useSSL := location.Scheme != externalspec.SchemeMinIO
+	if spec.UseSSL != nil {
+		useSSL = *spec.UseSSL
+	}
+	param := oss.MinioClientParam{
+		Addr:                         location.Host,
+		AK:                           spec.AccessKeyID,
+		SK:                           spec.AccessKeyValue,
+		UseIAM:                       spec.UseIAM,
+		Anonymous:                    spec.Anonymous,
+		IAMEndpoint:                  spec.IAMEndpoint,
+		UseSSL:                       useSSL,
+		UseVirtualHost:               spec.UseVirtualHost,
+		CloudProvider:                provider,
+		Region:                       spec.Region,
+		RoleARN:                      spec.RoleARN,
+		RoleSessionName:              spec.RoleSessionName,
+		ExternalID:                   spec.ExternalID,
+		AliyunRoleAuthMode:           spec.AliyunRoleAuthMode,
+		LoadFrequency:                spec.LoadFrequency,
+		AzureClientID:                spec.AzureClientID,
+		AzureTenantID:                spec.AzureTenantID,
+		AzureCredentialEndpoint:      spec.AzureCredentialEndpoint,
+		AzureRequestTimeoutMs:        3000,
+		DisableAzureConnectionString: provider == externalspec.CloudProviderAzure,
+		BucketName:                   location.Bucket,
+		RootPath:                     location.RootPath,
+	}
+	if provider == oss.CloudProviderAliyun && param.RoleARN != "" && param.AliyunRoleAuthMode == "" {
+		param.AliyunRoleAuthMode = "oidc"
+	}
+	oss.WithSkipCheckBucket(skipBucketCheck)(&param)
+	return param, location, nil
+}
+
+func buildLegacyExternalMinioClientParam(source string, spec externalSourceSpec, skipBucketCheck bool) (oss.MinioClientParam, externalSourceLocation, error) {
+	location, err := parseLegacyExternalSource(source)
+	if err != nil {
+		return oss.MinioClientParam{}, externalSourceLocation{}, err
+	}
+	provider := spec.CloudProvider
+	if provider == "" {
+		provider = inferLegacyCloudProviderFromScheme(location.Scheme)
+	}
+	if provider == "" {
+		return oss.MinioClientParam{}, externalSourceLocation{}, errors.Newf(
+			"unsupported external source scheme/provider: %s/%s",
+			location.Scheme,
+			spec.CloudProvider,
+		)
+	}
+
+	useSSL := location.Scheme != externalspec.SchemeMinIO
+	if spec.UseSSL != nil {
+		useSSL = *spec.UseSSL
+	}
+	param := oss.MinioClientParam{
+		Addr:               location.Host,
+		AK:                 spec.AccessKeyID,
+		SK:                 spec.AccessKeyValue,
+		UseIAM:             spec.UseIAM,
+		Anonymous:          spec.Anonymous,
+		IAMEndpoint:        spec.IAMEndpoint,
+		UseSSL:             useSSL,
+		UseVirtualHost:     spec.UseVirtualHost,
+		CloudProvider:      provider,
+		Region:             spec.Region,
+		RoleARN:            spec.RoleARN,
+		RoleSessionName:    spec.RoleSessionName,
+		ExternalID:         spec.ExternalID,
+		AliyunRoleAuthMode: spec.AliyunRoleAuthMode,
+		LoadFrequency:      spec.LoadFrequency,
+		BucketName:         location.Bucket,
+		RootPath:           location.RootPath,
+	}
+	if provider == oss.CloudProviderAliyun && param.RoleARN != "" && param.AliyunRoleAuthMode == "" {
+		param.AliyunRoleAuthMode = "oidc"
+	}
+	if param.RoleARN == "" && param.AK == "" && param.SK == "" && !param.Anonymous {
+		param.UseIAM = true
+	}
+	oss.WithSkipCheckBucket(skipBucketCheck)(&param)
+	return param, location, nil
+}
+
+func parseLegacyExternalSource(raw string) (externalSourceLocation, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return externalSourceLocation{}, errors.Wrap(err, "parse external source")
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return externalSourceLocation{}, errors.Newf(
+			"invalid external source: %s", redactExternalVectorObjectKey(raw))
+	}
+	parts := strings.Split(strings.Trim(strings.TrimSpace(u.Path), "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return externalSourceLocation{}, errors.Newf(
+			"external source %s does not include bucket", redactExternalVectorObjectKey(raw))
+	}
+	location := externalSourceLocation{
+		Scheme:     strings.ToLower(u.Scheme),
+		SourceHost: u.Host,
+		Host:       u.Host,
+		Bucket:     parts[0],
+	}
+	if len(parts) > 1 {
+		location.RootPath = cleanExternalRootPath(path.Join(parts[1:]...))
+	}
+	return location, nil
+}
+
+func inferLegacyCloudProviderFromScheme(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case externalspec.SchemeOSS:
+		return oss.CloudProviderAliyun
+	case externalspec.SchemeS3, externalspec.SchemeS3A, externalspec.SchemeAWS:
+		return oss.CloudProviderAWS
+	case externalspec.SchemeGS, externalspec.SchemeGCS:
+		return oss.CloudProviderGCP
+	case externalspec.SchemeMinIO:
+		return oss.CloudProviderMinio
+	default:
+		return ""
+	}
+}
+
+func cleanExternalRootPath(value string) string {
+	cleaned := path.Clean(strings.Trim(value, "/"))
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
 }
 
 func resolveExternalObjectKey(location externalSourceLocation, externalFile string) (string, error) {
-	return ossutil.ResolveExternalObjectKey(location, externalFile)
-}
-
-func readMapString(payload map[string]any, key string) string {
-	return ossutil.ReadMapString(payload, key)
-}
-
-func readMapBool(payload map[string]any, key string) (bool, bool) {
-	return ossutil.ReadMapBool(payload, key)
+	trimmed := strings.TrimSpace(externalFile)
+	if trimmed == "" {
+		return "", errors.New("external file path is empty")
+	}
+	if strings.Contains(trimmed, "ROOT_PATH") {
+		return strings.ReplaceAll(trimmed, "ROOT_PATH", location.RootPath), nil
+	}
+	if strings.Contains(trimmed, "://") {
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return "", errors.Wrap(err, "parse external file path")
+		}
+		if location.HostIsBucket {
+			if u.Host != location.Bucket {
+				return "", errors.Newf(
+					"external file bucket %s does not match external source bucket %s",
+					u.Host,
+					location.Bucket,
+				)
+			}
+			trimmed = strings.Trim(u.Path, "/")
+		} else {
+			parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+			if len(parts) == 0 || parts[0] == "" {
+				return "", errors.Newf(
+					"external file path %s does not include bucket",
+					redactExternalVectorObjectKey(trimmed),
+				)
+			}
+			if u.Host != location.SourceHost {
+				return "", errors.Newf(
+					"external file host %s does not match external source host %s",
+					u.Host,
+					location.SourceHost,
+				)
+			}
+			if parts[0] != location.Bucket {
+				return "", errors.Newf(
+					"external file bucket %s does not match external source bucket %s",
+					parts[0],
+					location.Bucket,
+				)
+			}
+			trimmed = path.Join(parts[1:]...)
+		}
+	}
+	trimmed = strings.TrimPrefix(trimmed, "/")
+	if location.RootPath == "" {
+		return path.Clean(trimmed), nil
+	}
+	if trimmed == location.RootPath || strings.HasPrefix(trimmed, location.RootPath+"/") {
+		return path.Clean(trimmed), nil
+	}
+	return path.Join(location.RootPath, trimmed), nil
 }

--- a/states/inspect_parquet_test.go
+++ b/states/inspect_parquet_test.go
@@ -2,11 +2,43 @@ package states
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"strings"
 	"testing"
 
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
 	binlogv1 "github.com/milvus-io/birdwatcher/storage/binlog/v1"
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 )
+
+type closeTrackingReadSeeker struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (r *closeTrackingReadSeeker) Close() error {
+	r.closed = true
+	return nil
+}
+
+type singleObjectStore struct {
+	object storagecommon.ReadSeeker
+}
+
+func (s *singleObjectStore) Open(context.Context, string, ...oss.OpenOption) (storagecommon.ReadSeeker, error) {
+	return s.object, nil
+}
+
+func (*singleObjectStore) Stat(context.Context, string) (*models.FsStat, error) {
+	return nil, nil
+}
+
+func (*singleObjectStore) List(context.Context, string, bool) (<-chan oss.ObjectInfo, error) {
+	return nil, nil
+}
 
 func TestValidateInspectParquetParam(t *testing.T) {
 	tests := []struct {
@@ -180,7 +212,10 @@ func TestParseExternalSpec(t *testing.T) {
 			"external_id": "ext-123",
 			"region": "cn-hangzhou",
 			"role_arn": "acs:ram::1:role/demo",
-			"use_ssl": true
+			"session_name": "birdwatcher-test",
+			"use_ssl": "true",
+			"use_virtual_host": "true",
+			"load_frequency": "3600"
 		}
 	}`
 
@@ -203,35 +238,170 @@ func TestParseExternalSpec(t *testing.T) {
 	if spec.ExternalID != "ext-123" {
 		t.Fatalf("unexpected external id: %s", spec.ExternalID)
 	}
+	if spec.RoleSessionName != "birdwatcher-test" {
+		t.Fatalf("unexpected role session name: %s", spec.RoleSessionName)
+	}
 	if spec.UseSSL == nil || !*spec.UseSSL {
 		t.Fatalf("expected use_ssl=true, got %#v", spec.UseSSL)
+	}
+	if spec.UseVirtualHost == nil || !*spec.UseVirtualHost {
+		t.Fatal("expected use_virtual_host=true")
+	}
+	if spec.LoadFrequency != 3600 {
+		t.Fatalf("unexpected load frequency: %d", spec.LoadFrequency)
+	}
+}
+
+func TestParseExternalSpecPreservesAliyunRoleAuthMode(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "top level",
+			raw: `{
+				"format":"parquet",
+				"aliyun_role_auth_mode":"ram",
+				"extfs":{
+					"cloud_provider":"aliyun",
+					"region":"cn-hangzhou",
+					"role_arn":"acs:ram::1:role/demo",
+					"aliyun_role_auth_mode":"oidc"
+				}
+			}`,
+		},
+		{
+			name: "legacy extfs extension",
+			raw: `{
+				"format":"parquet",
+				"extfs":{
+					"cloud_provider":"aliyun",
+					"region":"cn-hangzhou",
+					"role_arn":"acs:ram::1:role/demo",
+					"aliyun_role_auth_mode":"ram"
+				}
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec, err := parseExternalSpec(test.raw)
+			if err != nil {
+				t.Fatalf("parseExternalSpec() error = %v", err)
+			}
+			if spec.AliyunRoleAuthMode != "ram" {
+				t.Fatalf("AliyunRoleAuthMode = %q, want ram", spec.AliyunRoleAuthMode)
+			}
+			if _, ok := spec.Extfs["aliyun_role_auth_mode"]; ok {
+				t.Fatal("legacy extension must not be forwarded to canonical extfs validation")
+			}
+
+			param, _, err := buildExternalMinioClientParam(
+				"s3://oss-cn-hangzhou.aliyuncs.com/test-bucket/testlake/parquet",
+				spec,
+				true,
+			)
+			if err != nil {
+				t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+			}
+			if param.AliyunRoleAuthMode != "ram" {
+				t.Fatalf("AliyunRoleAuthMode = %q, want ram", param.AliyunRoleAuthMode)
+			}
+		})
+	}
+}
+
+func TestBuildExternalMinioClientParamDefaultsAliyunRoleMode(t *testing.T) {
+	spec, err := parseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"aliyun",
+			"region":"cn-hangzhou",
+			"role_arn":"acs:ram::1:role/demo"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+	param, _, err := buildExternalMinioClientParam(
+		"s3://oss-cn-hangzhou.aliyuncs.com/test-bucket/testlake/parquet",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+	if param.AliyunRoleAuthMode != "oidc" {
+		t.Fatalf("AliyunRoleAuthMode = %q, want oidc", param.AliyunRoleAuthMode)
 	}
 }
 
 func TestParseExternalSource(t *testing.T) {
-	location, err := parseExternalSource("oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet")
-	if err != nil {
-		t.Fatalf("parseExternalSource() error = %v", err)
+	tests := []struct {
+		name         string
+		source       string
+		spec         externalSourceSpec
+		wantHost     string
+		wantBucket   string
+		wantRoot     string
+		hostIsBucket bool
+	}{
+		{
+			name:       "milvus form cloud endpoint",
+			source:     "oss://oss-cn-hangzhou.aliyuncs.com/test-oss-0815/testlake/parquet",
+			spec:       externalSourceSpec{CloudProvider: "aliyun", Region: "cn-hangzhou"},
+			wantHost:   "oss-cn-hangzhou.aliyuncs.com",
+			wantBucket: "test-oss-0815",
+			wantRoot:   "testlake/parquet",
+		},
+		{
+			name:         "aws form",
+			source:       "s3://customer-bucket/testlake/parquet",
+			spec:         externalSourceSpec{CloudProvider: "aws", Region: "eu-west-2"},
+			wantHost:     "s3.eu-west-2.amazonaws.com",
+			wantBucket:   "customer-bucket",
+			wantRoot:     "testlake/parquet",
+			hostIsBucket: true,
+		},
+		{
+			name:       "minio form",
+			source:     "minio://localhost:9000/test-bucket/testlake/parquet",
+			spec:       externalSourceSpec{CloudProvider: "minio"},
+			wantHost:   "localhost:9000",
+			wantBucket: "test-bucket",
+			wantRoot:   "testlake/parquet",
+		},
+		{
+			name:       "s3 scheme with minio provider",
+			source:     "s3://custom.example:9000/test-bucket/testlake/parquet",
+			spec:       externalSourceSpec{CloudProvider: "minio"},
+			wantHost:   "custom.example:9000",
+			wantBucket: "test-bucket",
+			wantRoot:   "testlake/parquet",
+		},
 	}
-	if location.Scheme != "oss" {
-		t.Fatalf("unexpected scheme: %s", location.Scheme)
-	}
-	if location.Host != "oss-cn-hangzhou.aliyuncs.com" {
-		t.Fatalf("unexpected host: %s", location.Host)
-	}
-	if location.Bucket != "test-oss-0815" {
-		t.Fatalf("unexpected bucket: %s", location.Bucket)
-	}
-	if location.RootPath != "testlake/parquet" {
-		t.Fatalf("unexpected root path: %s", location.RootPath)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			location, err := parseExternalSource(tt.source, tt.spec)
+			if err != nil {
+				t.Fatalf("parseExternalSource() error = %v", err)
+			}
+			if location.Host != tt.wantHost || location.Bucket != tt.wantBucket ||
+				location.RootPath != tt.wantRoot || location.HostIsBucket != tt.hostIsBucket {
+				t.Fatalf("parseExternalSource() = %#v", location)
+			}
+		})
 	}
 }
 
 func TestResolveExternalObjectKey(t *testing.T) {
 	location := externalSourceLocation{
-		Host:     "oss-cn-hangzhou.aliyuncs.com",
-		Bucket:   "test-oss-0815",
-		RootPath: "testlake/parquet",
+		SourceHost: "oss-cn-hangzhou.aliyuncs.com",
+		Host:       "oss-cn-hangzhou.aliyuncs.com",
+		Bucket:     "test-oss-0815",
+		RootPath:   "testlake/parquet",
 	}
 
 	tests := []struct {
@@ -266,5 +436,354 @@ func TestResolveExternalObjectKey(t *testing.T) {
 				t.Fatalf("resolveExternalObjectKey() = %s, want %s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveExternalObjectKey_AWSForm(t *testing.T) {
+	location, err := parseExternalSource(
+		"s3://customer-bucket/testlake/parquet",
+		externalSourceSpec{CloudProvider: "aws", Region: "eu-west-2"},
+	)
+	if err != nil {
+		t.Fatalf("parseExternalSource() error = %v", err)
+	}
+
+	got, err := resolveExternalObjectKey(
+		location,
+		"s3://customer-bucket/testlake/parquet/part-0001.parquet",
+	)
+	if err != nil {
+		t.Fatalf("resolveExternalObjectKey() error = %v", err)
+	}
+	if got != "testlake/parquet/part-0001.parquet" {
+		t.Fatalf("resolveExternalObjectKey() = %s", got)
+	}
+}
+
+func TestBuildExternalMinioClientParam(t *testing.T) {
+	spec, err := parseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"aws",
+			"region":"eu-west-2",
+			"access_key_id":"test-ak",
+			"access_key_value":"test-sk",
+			"iam_endpoint":"http://169.254.169.254",
+			"use_ssl":"true",
+			"use_virtual_host":"true"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+
+	param, location, err := buildExternalMinioClientParam(
+		"s3://customer-bucket/testlake/parquet",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+	if param.Addr != "s3.eu-west-2.amazonaws.com" ||
+		param.BucketName != "customer-bucket" ||
+		param.RootPath != "testlake/parquet" {
+		t.Fatalf("unexpected storage location: location=%#v", location)
+	}
+	if param.AK != "test-ak" || param.SK != "test-sk" || !param.UseSSL {
+		t.Fatal("static credentials or SSL settings were not propagated")
+	}
+	if param.UseVirtualHost == nil || !*param.UseVirtualHost {
+		t.Fatal("use_virtual_host was not propagated")
+	}
+}
+
+func TestBuildExternalMinioClientParamAzureBroker(t *testing.T) {
+	spec, err := parseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"azure",
+			"region":"westus3",
+			"access_key_id":"storage-account",
+			"azure_client_id":"client-ID",
+			"azure_tenant_id":"tenant-ID",
+			"azure_credential_endpoint":"https://broker.example.com/v1/Credentials",
+			"load_frequency":"3600"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+	if spec.AzureClientID != "client-ID" || spec.AzureTenantID != "tenant-ID" ||
+		spec.AzureCredentialEndpoint != "https://broker.example.com/v1/Credentials" {
+		t.Fatalf("Azure broker spec = %#v", spec)
+	}
+
+	param, location, err := buildExternalMinioClientParam(
+		"azure://core.windows.net/container/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+	if param.CloudProvider != "azure" || param.Addr != "core.windows.net" ||
+		param.BucketName != "container" || param.RootPath != "root/path" ||
+		param.AK != "storage-account" || param.AzureClientID != "client-ID" ||
+		param.AzureTenantID != "tenant-ID" ||
+		param.AzureCredentialEndpoint != "https://broker.example.com/v1/Credentials" ||
+		!param.DisableAzureConnectionString {
+		t.Fatalf("Azure client parameters = %#v, location = %#v", param, location)
+	}
+	store, _, _, _, err := newExternalObjectStore(
+		t.Context(),
+		"azure://core.windows.net/container/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("newExternalObjectStore() error = %v", err)
+	}
+	if store == nil {
+		t.Fatal("newExternalObjectStore() returned nil store")
+	}
+}
+
+func TestBuildExternalMinioClientParam_LegacyFallback(t *testing.T) {
+	spec, err := parseExternalSpec("")
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+
+	param, location, err := buildExternalMinioClientParam(
+		"s3://legacy-endpoint/legacy-bucket/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+	if location.Host != "legacy-endpoint" || location.Bucket != "legacy-bucket" ||
+		location.RootPath != "root/path" {
+		t.Fatalf("unexpected legacy storage location: %#v", location)
+	}
+	if param.CloudProvider != "aws" || !param.UseIAM || !param.UseSSL {
+		t.Fatalf("unexpected legacy client parameters: %#v", param)
+	}
+}
+
+func TestBuildExternalMinioClientParam_EmptyExtfsLegacyFallback(t *testing.T) {
+	spec, err := parseExternalSpec(`{"format":"parquet","extfs":{}}`)
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+
+	param, location, err := buildExternalMinioClientParam(
+		"s3://legacy-endpoint/legacy-bucket/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+	if location.Host != "legacy-endpoint" || location.Bucket != "legacy-bucket" ||
+		location.RootPath != "root/path" {
+		t.Fatalf("unexpected legacy storage location: %#v", location)
+	}
+	if param.CloudProvider != "aws" || !param.UseIAM || !param.UseSSL {
+		t.Fatalf("unexpected legacy client parameters: %#v", param)
+	}
+}
+
+func TestBuildExternalMinioClientParamRejectsIncompleteExtfs(t *testing.T) {
+	spec, err := parseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"aws",
+			"region":"eu-west-2",
+			"access_key_id":"test-ak"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parseExternalSpec() error = %v", err)
+	}
+
+	_, _, err = buildExternalMinioClientParam(
+		"s3://customer-bucket/testlake/parquet",
+		spec,
+		true,
+	)
+	if err == nil || !strings.Contains(err.Error(), "must be set together") {
+		t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+	}
+}
+
+func TestBuildExternalMinioClientParam_AuthAndMinioModes(t *testing.T) {
+	t.Run("iam", func(t *testing.T) {
+		spec, err := parseExternalSpec(`{
+			"format":"parquet",
+			"extfs":{
+				"cloud_provider":"aws",
+				"region":"eu-west-2",
+				"use_iam":"true",
+				"iam_endpoint":"http://169.254.169.254",
+				"use_virtual_host":"false"
+			}
+		}`)
+		if err != nil {
+			t.Fatalf("parseExternalSpec() error = %v", err)
+		}
+
+		param, _, err := buildExternalMinioClientParam(
+			"s3://customer-bucket/testlake/parquet",
+			spec,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+		}
+		if !param.UseIAM || param.IAMEndpoint != "http://169.254.169.254" {
+			t.Fatal("IAM settings were not propagated")
+		}
+		if param.UseVirtualHost == nil || *param.UseVirtualHost {
+			t.Fatal("path-style bucket lookup was not propagated")
+		}
+	})
+
+	t.Run("minio", func(t *testing.T) {
+		spec, err := parseExternalSpec(`{
+			"format":"parquet",
+			"extfs":{
+				"cloud_provider":"minio",
+				"access_key_id":"minio-ak",
+				"access_key_value":"minio-sk"
+			}
+		}`)
+		if err != nil {
+			t.Fatalf("parseExternalSpec() error = %v", err)
+		}
+
+		param, _, err := buildExternalMinioClientParam(
+			"minio://localhost:9000/test-bucket/testlake/parquet",
+			spec,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+		}
+		if param.CloudProvider != "minio" || param.Addr != "localhost:9000" ||
+			param.BucketName != "test-bucket" || param.UseSSL {
+			t.Fatal("MinIO source settings were not propagated")
+		}
+		if param.UseVirtualHost != nil {
+			t.Fatal("unspecified use_virtual_host must preserve the provider default")
+		}
+	})
+
+	t.Run("aliyun provider default", func(t *testing.T) {
+		spec, err := parseExternalSpec(`{
+			"format":"parquet",
+			"extfs":{
+				"cloud_provider":"aliyun",
+				"region":"cn-hangzhou",
+				"access_key_id":"aliyun-ak",
+				"access_key_value":"aliyun-sk"
+			}
+		}`)
+		if err != nil {
+			t.Fatalf("parseExternalSpec() error = %v", err)
+		}
+
+		param, _, err := buildExternalMinioClientParam(
+			"s3://oss-cn-hangzhou.aliyuncs.com/test-bucket/testlake/parquet",
+			spec,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+		}
+		if param.CloudProvider != "aliyun" || param.UseVirtualHost != nil {
+			t.Fatal("unspecified use_virtual_host must preserve Aliyun DNS bucket lookup")
+		}
+	})
+
+	t.Run("anonymous", func(t *testing.T) {
+		spec, err := parseExternalSpec(`{
+			"format":"parquet",
+			"extfs":{
+				"cloud_provider":"aws",
+				"region":"eu-west-2",
+				"anonymous":"true"
+			}
+		}`)
+		if err != nil {
+			t.Fatalf("parseExternalSpec() error = %v", err)
+		}
+
+		param, _, err := buildExternalMinioClientParam(
+			"s3://public-bucket/testlake/parquet",
+			spec,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+		}
+		if !param.Anonymous || param.AK != "" || param.SK != "" {
+			t.Fatal("anonymous credential mode was not propagated")
+		}
+	})
+
+	t.Run("role arn", func(t *testing.T) {
+		spec, err := parseExternalSpec(`{
+			"format":"parquet",
+			"extfs":{
+				"cloud_provider":"aws",
+				"region":"eu-west-2",
+				"role_arn":"arn:aws:iam::123456789012:role/test",
+				"session_name":"birdwatcher-test",
+				"external_id":"external-test"
+			}
+		}`)
+		if err != nil {
+			t.Fatalf("parseExternalSpec() error = %v", err)
+		}
+
+		param, _, err := buildExternalMinioClientParam(
+			"s3://customer-bucket/testlake/parquet",
+			spec,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("buildExternalMinioClientParam() error = %v", err)
+		}
+		if param.RoleARN == "" || param.RoleSessionName != "birdwatcher-test" ||
+			param.ExternalID != "external-test" || param.UseIAM {
+			t.Fatal("role ARN credential mode was not propagated independently from IAM")
+		}
+	})
+}
+
+func TestInspectExternalManifestParquetClosesManifestObject(t *testing.T) {
+	object := &closeTrackingReadSeeker{Reader: bytes.NewReader([]byte("invalid manifest"))}
+	store := &singleObjectStore{object: object}
+	segment := &models.Segment{SegmentInfo: &datapb.SegmentInfo{
+		ID:           10,
+		ManifestPath: `{"ver":1,"base_path":"files"}`,
+	}}
+
+	err := inspectExternalManifestParquet(
+		context.Background(),
+		store,
+		"root",
+		nil,
+		externalSourceLocation{},
+		segment,
+		&InspectParquetParam{},
+	)
+	if err == nil {
+		t.Fatal("inspectExternalManifestParquet() expected manifest parse error")
+	}
+	if !object.closed {
+		t.Fatal("inspectExternalManifestParquet() did not close the manifest object")
 	}
 }

--- a/states/inspect_vector_index.go
+++ b/states/inspect_vector_index.go
@@ -1,0 +1,760 @@
+package states
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/bits"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/birdwatcher/models"
+	"github.com/milvus-io/birdwatcher/oss"
+	"github.com/milvus-io/birdwatcher/states/etcd/common"
+	binlogv1 "github.com/milvus-io/birdwatcher/storage/binlog/v1"
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const (
+	vectorValidDataCount = "valid_data_count"
+	vectorValidData      = "valid_data"
+)
+
+type InspectVectorIndexParams struct {
+	framework.DataSetParam `use:"inspect-vector-index" desc:"inspect vector index validity bitmaps and count indexed versus null rows"`
+	CollectionID           int64  `name:"collection" default:"0" desc:"collection id to filter with"`
+	PartitionID            int64  `name:"partition" default:"0" desc:"partition id to filter with"`
+	SegmentID              int64  `name:"segment" default:"0" desc:"segment id to filter with"`
+	FieldID                int64  `name:"field" default:"0" desc:"field id to filter with"`
+	IndexID                int64  `name:"indexID" default:"0" desc:"collection index id to filter with"`
+	BuildID                int64  `name:"buildID" default:"0" desc:"index build id to filter with"`
+	MinioAddress           string `name:"minioAddr" default:"" desc:"override minio address"`
+	SkipBucketCheck        bool   `name:"skipBucketCheck" default:"false" desc:"skip bucket existence check due to permission restrictions"`
+	IncludeDeleted         bool   `name:"includeDeleted" default:"false" desc:"include deleted SegmentIndex metadata"`
+	MismatchOnly           bool   `name:"mismatchOnly" default:"false" desc:"only output segment_id, segment_rows, and valid_rows when valid_rows differs from segment_rows; requires field"`
+}
+
+type VectorIndexValidityRecord struct {
+	CollectionID    int64    `json:"collection_id"`
+	PartitionID     int64    `json:"partition_id"`
+	SegmentID       int64    `json:"segment_id"`
+	FieldID         int64    `json:"field_id"`
+	FieldName       string   `json:"field_name,omitempty"`
+	FieldType       string   `json:"field_type,omitempty"`
+	Nullable        bool     `json:"nullable"`
+	IndexID         int64    `json:"index_id"`
+	IndexType       string   `json:"index_type,omitempty"`
+	BuildID         int64    `json:"build_id"`
+	IndexVersion    int64    `json:"index_version"`
+	IndexState      string   `json:"index_state"`
+	FailReason      string   `json:"fail_reason,omitempty"`
+	SegmentRows     int64    `json:"segment_rows"`
+	LogicalRows     int64    `json:"logical_rows"`
+	ValidRows       int64    `json:"valid_rows"`
+	NullRows        int64    `json:"null_rows"`
+	BitmapPresent   bool     `json:"bitmap_present"`
+	CountSource     string   `json:"count_source"`
+	Status          string   `json:"status"`
+	Message         string   `json:"message,omitempty"`
+	ObjectKeys      []string `json:"object_keys,omitempty"`
+	InspectionError string   `json:"inspection_error,omitempty"`
+}
+
+type VectorIndexValidityReport struct {
+	Records []*VectorIndexValidityRecord `json:"records"`
+}
+
+type SegmentIndexRowsMismatchRecord struct {
+	SegmentID   int64 `json:"segment_id"`
+	SegmentRows int64 `json:"segment_rows"`
+	ValidRows   int64 `json:"valid_rows"`
+}
+
+type SegmentIndexRowsMismatchReport struct {
+	Records             []*SegmentIndexRowsMismatchRecord `json:"records"`
+	UninspectedSegments int64                             `json:"uninspected_segments"`
+}
+
+func (r *SegmentIndexRowsMismatchReport) Entities() any {
+	return r
+}
+
+func (r *SegmentIndexRowsMismatchReport) PrintAs(format framework.Format) string {
+	switch format {
+	case framework.FormatJSON:
+		return framework.MarshalJSON(r)
+	case framework.FormatLine:
+		var sb strings.Builder
+		appendLine := func(data []byte) {
+			if sb.Len() > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.Write(data)
+		}
+		for _, record := range r.Records {
+			data, err := json.Marshal(record)
+			if err != nil {
+				continue
+			}
+			appendLine(data)
+		}
+		if r.UninspectedSegments > 0 {
+			data, _ := json.Marshal(struct {
+				UninspectedSegments int64 `json:"uninspected_segments"`
+			}{UninspectedSegments: r.UninspectedSegments})
+			appendLine(data)
+		}
+		return sb.String()
+	default:
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "Vector index row mismatches: %d segment(s)", len(r.Records))
+		if r.UninspectedSegments > 0 {
+			fmt.Fprintf(&sb, "\nWarning: %d Finished segment index(es) could not be inspected", r.UninspectedSegments)
+		}
+		for _, record := range r.Records {
+			fmt.Fprintf(&sb, "\nsegment=%d segment_rows=%d valid_rows=%d",
+				record.SegmentID, record.SegmentRows, record.ValidRows)
+		}
+		return sb.String()
+	}
+}
+
+func (r *SegmentIndexRowsMismatchReport) TableHeaders() table.Row {
+	return table.Row{"Segment", "Segment rows", "Valid rows"}
+}
+
+func (r *SegmentIndexRowsMismatchReport) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(r.Records))
+	for _, record := range r.Records {
+		rows = append(rows, table.Row{record.SegmentID, record.SegmentRows, record.ValidRows})
+	}
+	return rows
+}
+
+func (r *SegmentIndexRowsMismatchReport) TableTitle() string {
+	return fmt.Sprintf(
+		"Vector index row mismatches: %d segment(s), uninspected: %d",
+		len(r.Records), r.UninspectedSegments,
+	)
+}
+
+func buildSegmentIndexRowsMismatchReport(report *VectorIndexValidityReport) *SegmentIndexRowsMismatchReport {
+	mismatches := &SegmentIndexRowsMismatchReport{
+		Records: make([]*SegmentIndexRowsMismatchRecord, 0),
+	}
+	for _, record := range report.Records {
+		if record.IndexState != commonpb.IndexState_Finished.String() {
+			continue
+		}
+		if record.InspectionError != "" ||
+			(!record.BitmapPresent && record.Status != "INFERRED_ALL_VALID") {
+			mismatches.UninspectedSegments++
+			continue
+		}
+		if record.ValidRows == record.SegmentRows {
+			continue
+		}
+		mismatches.Records = append(mismatches.Records, &SegmentIndexRowsMismatchRecord{
+			SegmentID:   record.SegmentID,
+			SegmentRows: record.SegmentRows,
+			ValidRows:   record.ValidRows,
+		})
+	}
+	return mismatches
+}
+
+func (r *VectorIndexValidityReport) Entities() any {
+	return r
+}
+
+func (r *VectorIndexValidityReport) PrintAs(format framework.Format) string {
+	switch format {
+	case framework.FormatJSON:
+		return framework.MarshalJSON(r)
+	case framework.FormatLine:
+		var sb strings.Builder
+		for _, record := range r.Records {
+			data, err := json.Marshal(record)
+			if err != nil {
+				continue
+			}
+			sb.Write(data)
+			sb.WriteByte('\n')
+		}
+		return strings.TrimSuffix(sb.String(), "\n")
+	default:
+		return r.printPlain()
+	}
+}
+
+func (r *VectorIndexValidityReport) TableHeaders() table.Row {
+	return table.Row{"Segment", "Field", "Index", "Build", "Index state", "Nullable", "Logical", "Valid", "Null", "Source", "Status"}
+}
+
+func (r *VectorIndexValidityReport) TableRows() []table.Row {
+	rows := make([]table.Row, 0, len(r.Records))
+	for _, record := range r.Records {
+		rows = append(rows, table.Row{
+			record.SegmentID,
+			fmt.Sprintf("%s(%d)", record.FieldName, record.FieldID),
+			fmt.Sprintf("%s(%d)", record.IndexType, record.IndexID),
+			record.BuildID,
+			record.IndexState,
+			record.Nullable,
+			record.LogicalRows,
+			record.ValidRows,
+			record.NullRows,
+			record.CountSource,
+			record.Status,
+		})
+	}
+	return rows
+}
+
+func (r *VectorIndexValidityReport) TableTitle() string {
+	return fmt.Sprintf("Vector index validity: %d record(s)", len(r.Records))
+}
+
+func (r *VectorIndexValidityReport) printPlain() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Vector index validity: %d record(s)\n", len(r.Records))
+	for _, record := range r.Records {
+		fmt.Fprintf(&sb,
+			"segment=%d field=%s(%d) index=%s(%d) build=%d index_state=%s logical=%d valid=%d null=%d source=%s status=%s\n",
+			record.SegmentID, record.FieldName, record.FieldID, record.IndexType, record.IndexID,
+			record.BuildID, record.IndexState, record.LogicalRows, record.ValidRows, record.NullRows,
+			record.CountSource, record.Status)
+		if record.FailReason != "" {
+			fmt.Fprintf(&sb, "  fail reason: %s\n", record.FailReason)
+		}
+		if record.Message != "" {
+			fmt.Fprintf(&sb, "  message: %s\n", record.Message)
+		}
+		if record.InspectionError != "" {
+			fmt.Fprintf(&sb, "  error: %s\n", record.InspectionError)
+		}
+		for _, objectKey := range record.ObjectKeys {
+			fmt.Fprintf(&sb, "  object: %s\n", objectKey)
+		}
+	}
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+type vectorIndexMetadata struct {
+	segmentIndexes []*indexpb.SegmentIndex
+	fieldIndexes   map[v3IndexKey]*indexpb.IndexInfo
+	collections    map[int64]*models.Collection
+}
+
+func (s *InstanceState) InspectVectorIndexCommand(ctx context.Context, p *InspectVectorIndexParams) (*framework.PresetResultSet, error) {
+	if p.CollectionID == 0 && p.SegmentID == 0 && p.BuildID == 0 {
+		return nil, fmt.Errorf("at least one of collection, segment, or buildID must be specified")
+	}
+	if p.MismatchOnly && p.FieldID == 0 {
+		return nil, fmt.Errorf("mismatchOnly requires field because valid_rows is field-specific")
+	}
+
+	metadata, err := s.loadVectorIndexMetadata(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	report := &VectorIndexValidityReport{Records: make([]*VectorIndexValidityRecord, 0)}
+	var resolvedStore *oss.ResolvedObjectStore
+	for _, segmentIndex := range metadata.segmentIndexes {
+		fieldIndex := metadata.fieldIndexes[v3IndexKey{
+			collectionID: segmentIndex.GetCollectionID(),
+			indexID:      segmentIndex.GetIndexID(),
+		}]
+		if fieldIndex == nil {
+			report.Records = append(report.Records, newUninspectableVectorIndexRecord(
+				segmentIndex,
+				nil,
+				nil,
+				fmt.Sprintf(
+					"collection index metadata is missing for collection %d index %d",
+					segmentIndex.GetCollectionID(),
+					segmentIndex.GetIndexID(),
+				),
+			))
+			continue
+		}
+		if p.FieldID != 0 && fieldIndex.GetFieldID() != p.FieldID {
+			continue
+		}
+
+		collection := metadata.collections[segmentIndex.GetCollectionID()]
+		if collection == nil {
+			report.Records = append(report.Records, newUninspectableVectorIndexRecord(
+				segmentIndex,
+				fieldIndex,
+				nil,
+				fmt.Sprintf("collection metadata is missing for collection %d", segmentIndex.GetCollectionID()),
+			))
+			continue
+		}
+		field := findVectorField(collection, fieldIndex.GetFieldID())
+		if field == nil {
+			report.Records = append(report.Records, newUninspectableVectorIndexRecord(
+				segmentIndex,
+				fieldIndex,
+				nil,
+				fmt.Sprintf(
+					"field metadata is missing for collection %d field %d",
+					segmentIndex.GetCollectionID(),
+					fieldIndex.GetFieldID(),
+				),
+			))
+			continue
+		}
+		if !typeutil.IsVectorType(field.GetDataType()) {
+			continue
+		}
+		if vectorIndexNeedsObjectStore(segmentIndex) && resolvedStore == nil {
+			params := []oss.MinioConnectParam{oss.WithSkipCheckBucket(p.SkipBucketCheck)}
+			if p.MinioAddress != "" {
+				params = append(params, oss.WithMinioAddr(p.MinioAddress))
+			}
+			resolvedStore, err = s.GetObjectStore(ctx, params...)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		record := inspectVectorIndexValidity(ctx, resolvedStore, segmentIndex, fieldIndex, field)
+		report.Records = append(report.Records, record)
+	}
+
+	if len(report.Records) == 0 {
+		return nil, fmt.Errorf("no vector SegmentIndex matched the supplied filters")
+	}
+	sort.Slice(report.Records, func(i, j int) bool {
+		if report.Records[i].SegmentID != report.Records[j].SegmentID {
+			return report.Records[i].SegmentID < report.Records[j].SegmentID
+		}
+		if report.Records[i].FieldID != report.Records[j].FieldID {
+			return report.Records[i].FieldID < report.Records[j].FieldID
+		}
+		return report.Records[i].IndexID < report.Records[j].IndexID
+	})
+
+	if p.MismatchOnly {
+		return framework.NewPresetResultSet(
+			buildSegmentIndexRowsMismatchReport(report), framework.NameFormat(p.Format)), nil
+	}
+	return framework.NewPresetResultSet(report, framework.NameFormat(p.Format)), nil
+}
+
+func vectorIndexNeedsObjectStore(segmentIndex *indexpb.SegmentIndex) bool {
+	if segmentIndex.GetState() != commonpb.IndexState_Finished {
+		return false
+	}
+	artifacts, err := classifyVectorValidityArtifacts(segmentIndex.GetIndexFileKeys())
+	return err == nil && artifacts.kind != vectorValidityAbsent
+}
+
+func (s *InstanceState) loadVectorIndexMetadata(ctx context.Context, p *InspectVectorIndexParams) (*vectorIndexMetadata, error) {
+	segmentIndexes, err := common.ListSegmentIndex(ctx, s.client, s.basePath, func(index *models.SegmentIndex) bool {
+		proto := index.GetProto()
+		return (p.IncludeDeleted || !proto.GetDeleted()) &&
+			(p.CollectionID == 0 || proto.GetCollectionID() == p.CollectionID) &&
+			(p.PartitionID == 0 || proto.GetPartitionID() == p.PartitionID) &&
+			(p.SegmentID == 0 || proto.GetSegmentID() == p.SegmentID) &&
+			(p.IndexID == 0 || proto.GetIndexID() == p.IndexID) &&
+			(p.BuildID == 0 || proto.GetBuildID() == p.BuildID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	wantedIndexes := make(map[v3IndexKey]struct{}, len(segmentIndexes))
+	wantedCollections := make(map[int64]struct{}, len(segmentIndexes))
+	for _, index := range segmentIndexes {
+		proto := index.GetProto()
+		wantedIndexes[v3IndexKey{collectionID: proto.GetCollectionID(), indexID: proto.GetIndexID()}] = struct{}{}
+		wantedCollections[proto.GetCollectionID()] = struct{}{}
+	}
+	fieldIndexes, err := common.ListIndex(ctx, s.client, s.basePath, func(index *models.FieldIndex) bool {
+		info := index.GetProto().GetIndexInfo()
+		if info == nil {
+			return false
+		}
+		_, ok := wantedIndexes[v3IndexKey{collectionID: info.GetCollectionID(), indexID: info.GetIndexID()}]
+		return ok
+	})
+	if err != nil {
+		return nil, err
+	}
+	collections, err := common.ListCollections(ctx, s.client, s.basePath, func(collection *models.Collection) bool {
+		_, ok := wantedCollections[collection.GetProto().GetID()]
+		return ok
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := &vectorIndexMetadata{
+		segmentIndexes: make([]*indexpb.SegmentIndex, 0, len(segmentIndexes)),
+		fieldIndexes:   make(map[v3IndexKey]*indexpb.IndexInfo),
+		collections:    make(map[int64]*models.Collection),
+	}
+	for _, index := range segmentIndexes {
+		metadata.segmentIndexes = append(metadata.segmentIndexes, index.GetProto())
+	}
+	for _, index := range fieldIndexes {
+		info := index.GetProto().GetIndexInfo()
+		if info != nil {
+			metadata.fieldIndexes[v3IndexKey{collectionID: info.GetCollectionID(), indexID: info.GetIndexID()}] = info
+		}
+	}
+	for _, collection := range collections {
+		metadata.collections[collection.GetProto().GetID()] = collection
+	}
+	return metadata, nil
+}
+
+func findVectorField(collection *models.Collection, fieldID int64) *schemapb.FieldSchema {
+	if collection == nil || collection.GetProto().GetSchema() == nil {
+		return nil
+	}
+	for _, field := range collection.GetProto().GetSchema().GetFields() {
+		if field.GetFieldID() == fieldID {
+			return field
+		}
+	}
+	return nil
+}
+
+func newUninspectableVectorIndexRecord(
+	segmentIndex *indexpb.SegmentIndex,
+	fieldIndex *indexpb.IndexInfo,
+	field *schemapb.FieldSchema,
+	reason string,
+) *VectorIndexValidityRecord {
+	record := newVectorIndexValidityRecord(segmentIndex, fieldIndex, field)
+	record.InspectionError = reason
+	return record
+}
+
+func newVectorIndexValidityRecord(
+	segmentIndex *indexpb.SegmentIndex,
+	fieldIndex *indexpb.IndexInfo,
+	field *schemapb.FieldSchema,
+) *VectorIndexValidityRecord {
+	indexType := segmentIndex.GetIndexType()
+	if indexType == "" && fieldIndex != nil {
+		indexType = common.GetKVPair(fieldIndex.GetIndexParams(), "index_type")
+	}
+	record := &VectorIndexValidityRecord{
+		CollectionID: segmentIndex.GetCollectionID(),
+		PartitionID:  segmentIndex.GetPartitionID(),
+		SegmentID:    segmentIndex.GetSegmentID(),
+		IndexID:      segmentIndex.GetIndexID(),
+		IndexType:    indexType,
+		BuildID:      segmentIndex.GetBuildID(),
+		IndexVersion: segmentIndex.GetIndexVersion(),
+		IndexState:   segmentIndex.GetState().String(),
+		FailReason:   segmentIndex.GetFailReason(),
+		SegmentRows:  segmentIndex.GetNumRows(),
+		Status:       "ERROR",
+	}
+	if fieldIndex != nil {
+		record.FieldID = fieldIndex.GetFieldID()
+	}
+	if field != nil {
+		record.FieldID = field.GetFieldID()
+		record.FieldName = field.GetName()
+		record.FieldType = field.GetDataType().String()
+		record.Nullable = field.GetNullable()
+	}
+	return record
+}
+
+func inspectVectorIndexValidity(ctx context.Context, resolvedStore *oss.ResolvedObjectStore, segmentIndex *indexpb.SegmentIndex, fieldIndex *indexpb.IndexInfo, field *schemapb.FieldSchema) *VectorIndexValidityRecord {
+	record := newVectorIndexValidityRecord(segmentIndex, fieldIndex, field)
+	if segmentIndex.GetState() != commonpb.IndexState_Finished {
+		if segmentIndex.GetState() == commonpb.IndexState_Failed {
+			record.Status = "INDEX_FAILED"
+			record.Message = "index build failed; validity artifacts are not inspected"
+		} else {
+			record.Status = "INDEX_NOT_FINISHED"
+			record.Message = fmt.Sprintf(
+				"index build state is %s; validity artifacts are only inspected for Finished indexes",
+				segmentIndex.GetState(),
+			)
+		}
+		return record
+	}
+
+	artifacts, err := classifyVectorValidityArtifacts(segmentIndex.GetIndexFileKeys())
+	if err != nil {
+		record.InspectionError = err.Error()
+		return record
+	}
+	if artifacts.kind == vectorValidityAbsent {
+		if field.GetNullable() {
+			record.InspectionError = "nullable vector index has no valid_data artifacts"
+			return record
+		}
+		if segmentIndex.GetNumRows() < 0 {
+			record.InspectionError = fmt.Sprintf("SegmentIndex has invalid num_rows %d", segmentIndex.GetNumRows())
+			return record
+		}
+		record.LogicalRows = segmentIndex.GetNumRows()
+		record.ValidRows = segmentIndex.GetNumRows()
+		record.NullRows = 0
+		record.CountSource = "segment_index_metadata"
+		record.Status = "INFERRED_ALL_VALID"
+		record.Message = "non-nullable vector index has no validity bitmap; valid rows are inferred from SegmentIndex.num_rows"
+		return record
+	}
+	if resolvedStore == nil {
+		record.InspectionError = "object store is required to inspect valid_data artifacts"
+		return record
+	}
+
+	var totalRows, validRows uint64
+	switch artifacts.kind {
+	case vectorValidityMemory:
+		countPayload, countKeys, err := readVectorArtifactParts(ctx, resolvedStore, segmentIndex, artifacts.countParts)
+		record.ObjectKeys = append(record.ObjectKeys, countKeys...)
+		if err != nil {
+			record.InspectionError = err.Error()
+			return record
+		}
+		bitmapPayload, bitmapKeys, err := readVectorArtifactParts(ctx, resolvedStore, segmentIndex, artifacts.dataParts)
+		record.ObjectKeys = append(record.ObjectKeys, bitmapKeys...)
+		if err != nil {
+			record.InspectionError = err.Error()
+			return record
+		}
+		totalRows, validRows, err = decodeMemoryVectorValidity(countPayload, bitmapPayload)
+		if err != nil {
+			record.InspectionError = err.Error()
+			return record
+		}
+		record.CountSource = "memory_valid_data_bitmap"
+	case vectorValidityDisk:
+		payload, objectKeys, err := readVectorArtifactParts(ctx, resolvedStore, segmentIndex, artifacts.dataParts)
+		record.ObjectKeys = append(record.ObjectKeys, objectKeys...)
+		if err != nil {
+			record.InspectionError = err.Error()
+			return record
+		}
+		totalRows, validRows, err = decodeDiskVectorValidity(payload)
+		if err != nil {
+			record.InspectionError = err.Error()
+			return record
+		}
+		record.CountSource = "disk_valid_data_bitmap"
+	}
+
+	if totalRows > math.MaxInt64 || validRows > math.MaxInt64 {
+		record.InspectionError = "valid_data row count exceeds int64"
+		return record
+	}
+	record.LogicalRows = int64(totalRows)
+	record.ValidRows = int64(validRows)
+	record.NullRows = int64(totalRows - validRows)
+	record.BitmapPresent = true
+	record.Status = "OK"
+	if record.LogicalRows != segmentIndex.GetNumRows() {
+		record.Status = "COUNT_MISMATCH"
+		record.Message = fmt.Sprintf("valid_data logical rows %d differ from SegmentIndex.num_rows %d", record.LogicalRows, segmentIndex.GetNumRows())
+	}
+	return record
+}
+
+type vectorValidityKind int
+
+const (
+	vectorValidityAbsent vectorValidityKind = iota
+	vectorValidityMemory
+	vectorValidityDisk
+)
+
+type vectorArtifactPart struct {
+	key   string
+	exact bool
+	index int
+}
+
+type vectorValidityArtifacts struct {
+	kind       vectorValidityKind
+	countParts []vectorArtifactPart
+	dataParts  []vectorArtifactPart
+}
+
+func classifyVectorValidityArtifacts(keys []string) (vectorValidityArtifacts, error) {
+	artifacts := vectorValidityArtifacts{kind: vectorValidityAbsent}
+	for _, key := range keys {
+		name := path.Base(strings.TrimSpace(key))
+		if exact, index, ok := parseVectorArtifactName(name, vectorValidDataCount); ok {
+			artifacts.countParts = append(artifacts.countParts, vectorArtifactPart{key: key, exact: exact, index: index})
+			continue
+		}
+		if exact, index, ok := parseVectorArtifactName(name, vectorValidData); ok {
+			artifacts.dataParts = append(artifacts.dataParts, vectorArtifactPart{key: key, exact: exact, index: index})
+		}
+	}
+
+	if err := validateAndSortVectorArtifactParts(artifacts.countParts, vectorValidDataCount); err != nil {
+		return artifacts, err
+	}
+	if err := validateAndSortVectorArtifactParts(artifacts.dataParts, vectorValidData); err != nil {
+		return artifacts, err
+	}
+
+	switch {
+	case len(artifacts.countParts) > 0 && len(artifacts.dataParts) > 0:
+		artifacts.kind = vectorValidityMemory
+	case len(artifacts.countParts) > 0:
+		return artifacts, fmt.Errorf("vector index has %s but no %s artifact", vectorValidDataCount, vectorValidData)
+	case len(artifacts.dataParts) > 0 && !artifacts.dataParts[0].exact:
+		artifacts.kind = vectorValidityDisk
+	case len(artifacts.dataParts) > 0:
+		return artifacts, fmt.Errorf("vector index has %s but no %s artifact", vectorValidData, vectorValidDataCount)
+	}
+	return artifacts, nil
+}
+
+func parseVectorArtifactName(name, prefix string) (bool, int, bool) {
+	if name == prefix {
+		return true, 0, true
+	}
+	if !strings.HasPrefix(name, prefix+"_") {
+		return false, 0, false
+	}
+	index, err := strconv.Atoi(strings.TrimPrefix(name, prefix+"_"))
+	if err != nil || index < 0 {
+		return false, 0, false
+	}
+	return false, index, true
+}
+
+func validateAndSortVectorArtifactParts(parts []vectorArtifactPart, name string) error {
+	if len(parts) == 0 {
+		return nil
+	}
+	exact := 0
+	for _, part := range parts {
+		if part.exact {
+			exact++
+		}
+	}
+	if exact > 0 {
+		if len(parts) != 1 {
+			return fmt.Errorf("%s has both an unsliced object and slice objects", name)
+		}
+		return nil
+	}
+	sort.Slice(parts, func(i, j int) bool { return parts[i].index < parts[j].index })
+	for index, part := range parts {
+		if part.index != index {
+			return fmt.Errorf("%s slices are incomplete: expected slice %d, got %d", name, index, part.index)
+		}
+	}
+	return nil
+}
+
+func readVectorArtifactParts(ctx context.Context, resolvedStore *oss.ResolvedObjectStore, segmentIndex *indexpb.SegmentIndex, parts []vectorArtifactPart) ([]byte, []string, error) {
+	var payload []byte
+	objectKeys := make([]string, 0, len(parts))
+	for _, part := range parts {
+		filename := path.Base(strings.TrimSpace(part.key))
+		resolved := buildV3ResolvedPath(int32(segmentIndex.GetIndexStorePathVersion()), segmentIndex, filename, resolvedStore.RootPath)
+		objectKey := normalizeV3AdvertisedPath(resolvedStore.RootPath, part.key, resolved)
+		objectKey = oss.ResolveObjectKey("", objectKey)
+		data, err := readVectorIndexObject(ctx, resolvedStore.Store, objectKey)
+		if err != nil {
+			return nil, objectKeys, fmt.Errorf("read index object %s: %w", objectKey, err)
+		}
+		objectKeys = append(objectKeys, objectKey)
+		payload = append(payload, data...)
+	}
+	return payload, objectKeys, nil
+}
+
+func readVectorIndexObject(ctx context.Context, store oss.ObjectStore, objectKey string) ([]byte, error) {
+	object, err := store.Open(ctx, objectKey)
+	if err != nil {
+		return nil, err
+	}
+	if closer, ok := object.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	reader, descriptor, err := binlogv1.NewIndexReader(object)
+	if err != nil {
+		return nil, err
+	}
+	if value, ok := descriptor.Extras["edek"]; ok && fmt.Sprint(value) != "" {
+		return nil, fmt.Errorf("encrypted index object is not supported")
+	}
+	switch descriptor.PayloadDataType {
+	case schemapb.DataType_None:
+		return reader.NextRawEventReader(object)
+	case schemapb.DataType_Int8:
+		payloads, err := reader.NextEventReader(object, descriptor.PayloadDataType)
+		if err != nil {
+			return nil, err
+		}
+		if len(payloads) != 1 {
+			return nil, fmt.Errorf("expected one index payload, got %d", len(payloads))
+		}
+		return payloads[0], nil
+	default:
+		return nil, fmt.Errorf("unsupported index payload data type %s", descriptor.PayloadDataType.String())
+	}
+}
+
+func decodeMemoryVectorValidity(countPayload, bitmapPayload []byte) (uint64, uint64, error) {
+	if len(countPayload) != 8 {
+		return 0, 0, fmt.Errorf("valid_data_count payload must be 8 bytes, got %d", len(countPayload))
+	}
+	totalRows := binary.LittleEndian.Uint64(countPayload)
+	validRows, err := countVectorValidityBitmap(totalRows, bitmapPayload)
+	return totalRows, validRows, err
+}
+
+func decodeDiskVectorValidity(payload []byte) (uint64, uint64, error) {
+	if len(payload) < 8 {
+		return 0, 0, fmt.Errorf("disk valid_data payload must contain an 8-byte count, got %d bytes", len(payload))
+	}
+	totalRows := binary.LittleEndian.Uint64(payload[:8])
+	validRows, err := countVectorValidityBitmap(totalRows, payload[8:])
+	return totalRows, validRows, err
+}
+
+func countVectorValidityBitmap(totalRows uint64, bitmap []byte) (uint64, error) {
+	requiredBytes := totalRows / 8
+	if totalRows%8 != 0 {
+		requiredBytes++
+	}
+	if requiredBytes > uint64(len(bitmap)) {
+		return 0, fmt.Errorf("valid_data bitmap needs %d bytes for %d rows, got %d", requiredBytes, totalRows, len(bitmap))
+	}
+	if requiredBytes > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("valid_data bitmap is too large")
+	}
+
+	fullBytes := totalRows / 8
+	var validRows uint64
+	for _, value := range bitmap[:int(fullBytes)] {
+		validRows += uint64(bits.OnesCount8(value))
+	}
+	if remainder := totalRows % 8; remainder != 0 {
+		mask := byte((uint16(1) << remainder) - 1)
+		validRows += uint64(bits.OnesCount8(bitmap[fullBytes] & mask))
+	}
+	return validRows, nil
+}

--- a/states/inspect_vector_index.go
+++ b/states/inspect_vector_index.go
@@ -749,6 +749,7 @@ func countVectorValidityBitmap(totalRows uint64, bitmap []byte) (uint64, error) 
 
 	fullBytes := totalRows / 8
 	var validRows uint64
+	// #nosec G602 -- fullBytes <= requiredBytes <= len(bitmap), checked above.
 	for _, value := range bitmap[:int(fullBytes)] {
 		validRows += uint64(bits.OnesCount8(value))
 	}

--- a/states/inspect_vector_index_test.go
+++ b/states/inspect_vector_index_test.go
@@ -1,0 +1,329 @@
+package states
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/birdwatcher/framework"
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+)
+
+func TestInspectVectorIndexValidityRequiresFinishedIndex(t *testing.T) {
+	field := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "embedding",
+		DataType: schemapb.DataType_FloatVector,
+	}
+	fieldIndex := &indexpb.IndexInfo{FieldID: field.GetFieldID()}
+
+	t.Run("in progress", func(t *testing.T) {
+		segmentIndex := &indexpb.SegmentIndex{
+			SegmentID: 1,
+			NumRows:   1000,
+			State:     commonpb.IndexState_InProgress,
+			IndexType: "HNSW",
+		}
+		record := inspectVectorIndexValidity(
+			context.Background(), nil, segmentIndex, fieldIndex, field)
+
+		require.Equal(t, "InProgress", record.IndexState)
+		require.Equal(t, "INDEX_NOT_FINISHED", record.Status)
+		require.Zero(t, record.ValidRows)
+		require.Zero(t, record.NullRows)
+		require.Empty(t, record.InspectionError)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		segmentIndex := &indexpb.SegmentIndex{
+			SegmentID:  2,
+			NumRows:    1000,
+			State:      commonpb.IndexState_Failed,
+			FailReason: "invalid vector row",
+			IndexType:  "HNSW",
+		}
+		record := inspectVectorIndexValidity(
+			context.Background(), nil, segmentIndex, fieldIndex, field)
+
+		require.Equal(t, "Failed", record.IndexState)
+		require.Equal(t, "INDEX_FAILED", record.Status)
+		require.Equal(t, "invalid vector row", record.FailReason)
+		require.Zero(t, record.ValidRows)
+		require.Zero(t, record.NullRows)
+		require.Empty(t, record.InspectionError)
+	})
+
+	t.Run("finished", func(t *testing.T) {
+		segmentIndex := &indexpb.SegmentIndex{
+			SegmentID: 3,
+			NumRows:   1000,
+			State:     commonpb.IndexState_Finished,
+			IndexType: "HNSW",
+		}
+		record := inspectVectorIndexValidity(
+			context.Background(), nil, segmentIndex, fieldIndex, field)
+
+		require.Equal(t, "Finished", record.IndexState)
+		require.Equal(t, "INFERRED_ALL_VALID", record.Status)
+		require.Equal(t, int64(1000), record.ValidRows)
+	})
+
+	t.Run("finished with artifacts requires object store", func(t *testing.T) {
+		segmentIndex := &indexpb.SegmentIndex{
+			SegmentID:     4,
+			NumRows:       1000,
+			State:         commonpb.IndexState_Finished,
+			IndexType:     "HNSW",
+			IndexFileKeys: []string{"valid_data_count", "valid_data"},
+		}
+		record := inspectVectorIndexValidity(
+			context.Background(), nil, segmentIndex, fieldIndex, field)
+
+		require.Equal(t, "ERROR", record.Status)
+		require.Equal(t,
+			"object store is required to inspect valid_data artifacts",
+			record.InspectionError,
+		)
+	})
+}
+
+func TestNewUninspectableVectorIndexRecord(t *testing.T) {
+	segmentIndex := &indexpb.SegmentIndex{
+		CollectionID: 10,
+		PartitionID:  20,
+		SegmentID:    30,
+		IndexID:      40,
+		BuildID:      50,
+		NumRows:      1000,
+		State:        commonpb.IndexState_Finished,
+	}
+	fieldIndex := &indexpb.IndexInfo{
+		FieldID: 101,
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: "index_type", Value: "HNSW"},
+		},
+	}
+	record := newUninspectableVectorIndexRecord(
+		segmentIndex,
+		fieldIndex,
+		nil,
+		"field metadata is missing",
+	)
+
+	require.Equal(t, int64(30), record.SegmentID)
+	require.Equal(t, int64(101), record.FieldID)
+	require.Equal(t, "HNSW", record.IndexType)
+	require.Equal(t, "ERROR", record.Status)
+	require.Equal(t, "field metadata is missing", record.InspectionError)
+
+	report := buildSegmentIndexRowsMismatchReport(&VectorIndexValidityReport{
+		Records: []*VectorIndexValidityRecord{record},
+	})
+	require.Empty(t, report.Records)
+	require.Equal(t, int64(1), report.UninspectedSegments)
+}
+
+func TestDecodeMemoryVectorValidity(t *testing.T) {
+	countPayload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(countPayload, 1000)
+	bitmap := make([]byte, 125)
+	for index := 0; index < 118; index++ {
+		bitmap[index] = 0xff
+	}
+	bitmap[118] = 0x3f
+
+	totalRows, validRows, err := decodeMemoryVectorValidity(countPayload, bitmap)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), totalRows)
+	require.Equal(t, uint64(950), validRows)
+}
+
+func TestDecodeDiskVectorValidityAllNull(t *testing.T) {
+	payload := make([]byte, 8+125)
+	binary.LittleEndian.PutUint64(payload, 1000)
+
+	totalRows, validRows, err := decodeDiskVectorValidity(payload)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), totalRows)
+	require.Zero(t, validRows)
+}
+
+func TestCountVectorValidityBitmapIgnoresTailPadding(t *testing.T) {
+	validRows, err := countVectorValidityBitmap(10, []byte{0xff, 0xff})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), validRows)
+}
+
+func TestDecodeVectorValidityRejectsInvalidPayloads(t *testing.T) {
+	_, _, err := decodeMemoryVectorValidity(make([]byte, 7), nil)
+	require.ErrorContains(t, err, "must be 8 bytes")
+
+	countPayload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(countPayload, 9)
+	_, _, err = decodeMemoryVectorValidity(countPayload, []byte{0xff})
+	require.ErrorContains(t, err, "needs 2 bytes")
+
+	_, _, err = decodeDiskVectorValidity(make([]byte, 7))
+	require.ErrorContains(t, err, "8-byte count")
+}
+
+func TestClassifyVectorValidityArtifacts(t *testing.T) {
+	t.Run("memory", func(t *testing.T) {
+		artifacts, err := classifyVectorValidityArtifacts([]string{
+			"other-index-file",
+			"valid_data",
+			"valid_data_count",
+		})
+		require.NoError(t, err)
+		require.Equal(t, vectorValidityMemory, artifacts.kind)
+		require.Len(t, artifacts.countParts, 1)
+		require.Len(t, artifacts.dataParts, 1)
+	})
+
+	t.Run("disk slices are sorted", func(t *testing.T) {
+		artifacts, err := classifyVectorValidityArtifacts([]string{
+			"valid_data_1",
+			"valid_data_0",
+		})
+		require.NoError(t, err)
+		require.Equal(t, vectorValidityDisk, artifacts.kind)
+		require.Equal(t, 0, artifacts.dataParts[0].index)
+		require.Equal(t, 1, artifacts.dataParts[1].index)
+	})
+
+	t.Run("missing slice", func(t *testing.T) {
+		_, err := classifyVectorValidityArtifacts([]string{"valid_data_1"})
+		require.ErrorContains(t, err, "expected slice 0")
+	})
+
+	t.Run("incomplete memory artifacts", func(t *testing.T) {
+		_, err := classifyVectorValidityArtifacts([]string{"valid_data_count"})
+		require.ErrorContains(t, err, "no valid_data artifact")
+	})
+
+	t.Run("unrelated files", func(t *testing.T) {
+		artifacts, err := classifyVectorValidityArtifacts([]string{"index_data"})
+		require.NoError(t, err)
+		require.Equal(t, vectorValidityAbsent, artifacts.kind)
+	})
+}
+
+func TestVectorIndexNeedsObjectStore(t *testing.T) {
+	tests := []struct {
+		name  string
+		index *indexpb.SegmentIndex
+		want  bool
+	}{
+		{
+			name: "finished with memory validity artifacts",
+			index: &indexpb.SegmentIndex{
+				State:         commonpb.IndexState_Finished,
+				IndexFileKeys: []string{"valid_data_count", "valid_data"},
+			},
+			want: true,
+		},
+		{
+			name: "finished without validity artifacts",
+			index: &indexpb.SegmentIndex{
+				State: commonpb.IndexState_Finished,
+			},
+		},
+		{
+			name: "unfinished with validity artifacts",
+			index: &indexpb.SegmentIndex{
+				State:         commonpb.IndexState_InProgress,
+				IndexFileKeys: []string{"valid_data_count", "valid_data"},
+			},
+		},
+		{
+			name: "malformed validity artifacts",
+			index: &indexpb.SegmentIndex{
+				State:         commonpb.IndexState_Finished,
+				IndexFileKeys: []string{"valid_data_count"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, vectorIndexNeedsObjectStore(test.index))
+		})
+	}
+}
+
+func TestBuildSegmentIndexRowsMismatchReport(t *testing.T) {
+	report := &VectorIndexValidityReport{Records: []*VectorIndexValidityRecord{
+		{
+			SegmentID:     1,
+			SegmentRows:   1000,
+			ValidRows:     950,
+			BitmapPresent: true,
+			IndexState:    commonpb.IndexState_Finished.String(),
+		},
+		{
+			SegmentID:     2,
+			SegmentRows:   1000,
+			ValidRows:     1000,
+			BitmapPresent: true,
+			IndexState:    commonpb.IndexState_Finished.String(),
+		},
+		{
+			SegmentID:   3,
+			SegmentRows: 1000,
+			ValidRows:   0,
+			IndexState:  commonpb.IndexState_Failed.String(),
+		},
+		{
+			SegmentID:       4,
+			SegmentRows:     1000,
+			ValidRows:       900,
+			BitmapPresent:   true,
+			IndexState:      commonpb.IndexState_Finished.String(),
+			InspectionError: "cannot read bitmap",
+		},
+		{
+			SegmentID:   5,
+			SegmentRows: 1000,
+			ValidRows:   1000,
+			IndexState:  commonpb.IndexState_Finished.String(),
+			Status:      "INFERRED_ALL_VALID",
+		},
+	}}
+
+	got := buildSegmentIndexRowsMismatchReport(report)
+	require.Len(t, got.Records, 1)
+	require.Equal(t, int64(1), got.UninspectedSegments)
+	require.Equal(t, &SegmentIndexRowsMismatchRecord{
+		SegmentID: 1, SegmentRows: 1000, ValidRows: 950,
+	}, got.Records[0])
+	require.Equal(t,
+		"Vector index row mismatches: 1 segment(s)\n"+
+			"Warning: 1 Finished segment index(es) could not be inspected\n"+
+			"segment=1 segment_rows=1000 valid_rows=950",
+		got.PrintAs(framework.FormatPlain))
+	require.JSONEq(t,
+		`{"records":[{"segment_id":1,"segment_rows":1000,"valid_rows":950}],"uninspected_segments":1}`,
+		got.PrintAs(framework.FormatJSON))
+	require.Equal(t,
+		"{\"segment_id\":1,\"segment_rows\":1000,\"valid_rows\":950}\n"+
+			`{"uninspected_segments":1}`,
+		got.PrintAs(framework.FormatLine))
+	require.Equal(t, table.Row{"Segment", "Segment rows", "Valid rows"}, got.TableHeaders())
+	require.Equal(t, []table.Row{{int64(1), int64(1000), int64(950)}}, got.TableRows())
+	require.Equal(t,
+		"Vector index row mismatches: 1 segment(s), uninspected: 1",
+		got.TableTitle())
+}
+
+func TestInspectVectorIndexMismatchOnlyRequiresField(t *testing.T) {
+	_, err := (&InstanceState{}).InspectVectorIndexCommand(context.Background(), &InspectVectorIndexParams{
+		CollectionID: 1,
+		MismatchOnly: true,
+	})
+	require.ErrorContains(t, err, "mismatchOnly requires field")
+}

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -6,34 +6,41 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
+	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 )
 
 // ExternalSourceSpec is the parsed external collection specification
 // (schema.ExternalSpec). extfs keys mirror milvus
 // pkg/util/externalspec/specutil.ExtfsKey*.
 type ExternalSourceSpec struct {
-	Format             string
-	CloudProvider      string
-	Region             string
-	RoleARN            string
-	RoleSessionName    string
-	ExternalID         string
-	AliyunRoleAuthMode string
-	AK                 string
-	SK                 string
-	UseIAM             bool
-	IAMEndpoint        string
-	UseSSL             *bool
-	Anonymous          bool
-	BucketName         string
-	StorageType        string
-	LoadFrequency      int
+	Format                  string
+	Extfs                   map[string]string
+	CloudProvider           string
+	Region                  string
+	RoleARN                 string
+	RoleSessionName         string
+	ExternalID              string
+	AliyunRoleAuthMode      string
+	AccessKeyID             string
+	AccessKeyValue          string
+	UseIAM                  bool
+	IAMEndpoint             string
+	UseSSL                  *bool
+	UseVirtualHost          *bool
+	Anonymous               bool
+	BucketName              string
+	StorageType             string
+	GCPTargetServiceAccount string
+	SSLCACert               string
+	LoadFrequency           int
+	AzureClientID           string
+	AzureTenantID           string
+	AzureCredentialEndpoint string
 }
 
 // LocationForm distinguishes the two accepted external_source URI shapes,
@@ -56,7 +63,7 @@ type ExternalSourceLocation struct {
 	Bucket   string
 	RootPath string
 	// Address is the storage endpoint used to build the object store client:
-	// the URI host for the Milvus form, or DeriveEndpoint(provider, region)
+	// the URI host for the Milvus form, or externalspec.DeriveEndpoint(provider, region)
 	// for the AWS form.
 	Address string
 	Form    LocationForm
@@ -79,52 +86,196 @@ func parseExternalSpec(raw string, validateFormat bool) (ExternalSourceSpec, err
 		return ExternalSourceSpec{}, nil
 	}
 
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return ExternalSourceSpec{}, fmt.Errorf("parse external spec: %w", err)
+	normalized, extensions, err := extractExternalSpecExtensions(raw)
+	if err != nil {
+		return ExternalSourceSpec{}, err
+	}
+	parsed, err := externalspec.ParseExternalSpec(normalized)
+	if err != nil {
+		return ExternalSourceSpec{}, err
+	}
+	if validateFormat && parsed.Format != "" && parsed.Format != externalspec.FormatParquet {
+		return ExternalSourceSpec{}, fmt.Errorf("external collection format %s is not supported", parsed.Format)
 	}
 
+	extfs := parsed.Extfs
 	spec := ExternalSourceSpec{
-		Format:             ReadMapString(payload, "format"),
-		AliyunRoleAuthMode: ReadMapString(payload, "aliyun_role_auth_mode"),
+		Format:                  parsed.Format,
+		Extfs:                   extfs,
+		CloudProvider:           strings.ToLower(strings.TrimSpace(extfs[externalspec.ExtfsKeyCloudProvider])),
+		Region:                  extfs[externalspec.ExtfsKeyRegion],
+		RoleARN:                 extfs[externalspec.ExtfsKeyRoleARN],
+		RoleSessionName:         extfs[externalspec.ExtfsKeySessionName],
+		ExternalID:              extfs[externalspec.ExtfsKeyExternalID],
+		AliyunRoleAuthMode:      extensions.aliyunRoleAuthMode,
+		AccessKeyID:             extfs[externalspec.ExtfsKeyAccessKeyID],
+		AccessKeyValue:          extfs[externalspec.ExtfsKeyAccessKeyValue],
+		UseIAM:                  extfs[externalspec.ExtfsKeyUseIAM] == "true",
+		IAMEndpoint:             extfs[externalspec.ExtfsKeyIAMEndpoint],
+		Anonymous:               extfs[externalspec.ExtfsKeyAnonymous] == "true",
+		BucketName:              extfs[externalspec.ExtfsKeyBucketName],
+		StorageType:             extfs[externalspec.ExtfsKeyStorageType],
+		GCPTargetServiceAccount: extfs[externalspec.ExtfsKeyGCPTargetServiceAccount],
+		SSLCACert:               extfs[externalspec.ExtfsKeySSLCACert],
+		AzureClientID:           extensions.azureClientID,
+		AzureTenantID:           extensions.azureTenantID,
+		AzureCredentialEndpoint: extensions.azureCredentialEndpoint,
 	}
-	if validateFormat && spec.Format != "" && !strings.EqualFold(spec.Format, "parquet") {
-		return ExternalSourceSpec{}, fmt.Errorf("external collection format %s is not supported", spec.Format)
+	if rawUseSSL, ok := extfs[externalspec.ExtfsKeyUseSSL]; ok {
+		useSSL := rawUseSSL == "true"
+		spec.UseSSL = &useSSL
 	}
-
-	extfs, _ := payload["extfs"].(map[string]any)
-	if len(extfs) > 0 {
-		spec.CloudProvider = ReadMapString(extfs, "cloud_provider")
-		spec.Region = ReadMapString(extfs, "region")
-		spec.RoleARN = ReadMapString(extfs, "role_arn")
-		spec.RoleSessionName = ReadMapString(extfs, "session_name")
-		spec.ExternalID = ReadMapString(extfs, "external_id")
-		spec.AK = ReadMapString(extfs, "access_key_id")
-		spec.SK = ReadMapString(extfs, "access_key_value")
-		spec.IAMEndpoint = ReadMapString(extfs, "iam_endpoint")
-		spec.BucketName = ReadMapString(extfs, "bucket_name")
-		spec.StorageType = ReadMapString(extfs, "storage_type")
-		if spec.AliyunRoleAuthMode == "" {
-			spec.AliyunRoleAuthMode = ReadMapString(extfs, "aliyun_role_auth_mode")
+	if rawUseVirtualHost, ok := extfs[externalspec.ExtfsKeyUseVirtualHost]; ok {
+		useVirtualHost := rawUseVirtualHost == "true"
+		spec.UseVirtualHost = &useVirtualHost
+	}
+	if rawLoadFrequency := extfs[externalspec.ExtfsKeyLoadFrequency]; rawLoadFrequency != "" {
+		loadFrequency, err := strconv.Atoi(rawLoadFrequency)
+		if err != nil || loadFrequency <= 0 {
+			return ExternalSourceSpec{}, fmt.Errorf(
+				"extfs.%s must be a positive integer, got %q",
+				externalspec.ExtfsKeyLoadFrequency,
+				rawLoadFrequency,
+			)
 		}
-		if useIAM, ok := ReadMapBool(extfs, "use_iam"); ok {
-			spec.UseIAM = useIAM
-		}
-		if anonymous, ok := ReadMapBool(extfs, "anonymous"); ok {
-			spec.Anonymous = anonymous
-		}
-		if useSSL, ok := ReadMapBool(extfs, "use_ssl"); ok {
-			spec.UseSSL = &useSSL
-		}
-		if lf := ReadMapString(extfs, "load_frequency"); lf != "" {
-			v, err := strconv.Atoi(lf)
-			if err != nil {
-				return ExternalSourceSpec{}, fmt.Errorf("invalid extfs.load_frequency %q: %w", lf, err)
-			}
-			spec.LoadFrequency = v
-		}
+		spec.LoadFrequency = loadFrequency
 	}
 	return spec, nil
+}
+
+type externalSpecExtensions struct {
+	aliyunRoleAuthMode      string
+	azureClientID           string
+	azureTenantID           string
+	azureCredentialEndpoint string
+}
+
+// extractExternalSpecExtensions removes fields that are newer than the pinned
+// Milvus parser, then returns them separately for Birdwatcher's storage layer.
+// Aliyun role mode may also appear at the top level in legacy metadata.
+func extractExternalSpecExtensions(raw string) (string, externalSpecExtensions, error) {
+	const aliyunRoleAuthModeKey = "aliyun_role_auth_mode"
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", externalSpecExtensions{}, fmt.Errorf("parse external spec: %w", err)
+	}
+
+	readString := func(field string, value json.RawMessage) (string, error) {
+		if len(value) == 0 {
+			return "", nil
+		}
+		var result string
+		if err := json.Unmarshal(value, &result); err != nil {
+			return "", fmt.Errorf("%s must be a string: %w", field, err)
+		}
+		return strings.TrimSpace(result), nil
+	}
+	readMode := func(value json.RawMessage) (string, error) {
+		result, err := readString(aliyunRoleAuthModeKey, value)
+		return strings.ToLower(result), err
+	}
+
+	extensions := externalSpecExtensions{}
+	mode, err := readMode(payload[aliyunRoleAuthModeKey])
+	if err != nil {
+		return "", externalSpecExtensions{}, err
+	}
+	extensions.aliyunRoleAuthMode = mode
+	if rawExtfs, ok := payload["extfs"]; ok && len(rawExtfs) > 0 && string(rawExtfs) != "null" {
+		var extfs map[string]json.RawMessage
+		if err := json.Unmarshal(rawExtfs, &extfs); err != nil {
+			return "", externalSpecExtensions{}, fmt.Errorf("parse external spec extfs: %w", err)
+		}
+		if rawMode, ok := extfs[aliyunRoleAuthModeKey]; ok {
+			if extensions.aliyunRoleAuthMode == "" {
+				extensions.aliyunRoleAuthMode, err = readMode(rawMode)
+				if err != nil {
+					return "", externalSpecExtensions{}, err
+				}
+			}
+			delete(extfs, aliyunRoleAuthModeKey)
+		}
+		for field, target := range map[string]*string{
+			"azure_client_id":           &extensions.azureClientID,
+			"azure_tenant_id":           &extensions.azureTenantID,
+			"azure_credential_endpoint": &extensions.azureCredentialEndpoint,
+		} {
+			if rawValue, ok := extfs[field]; ok {
+				*target, err = readString(field, rawValue)
+				if err != nil {
+					return "", externalSpecExtensions{}, err
+				}
+				delete(extfs, field)
+			}
+		}
+		normalizedExtfs, err := json.Marshal(extfs)
+		if err != nil {
+			return "", externalSpecExtensions{}, fmt.Errorf("normalize external spec extfs: %w", err)
+		}
+		payload["extfs"] = normalizedExtfs
+	}
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return "", externalSpecExtensions{}, fmt.Errorf("normalize external spec: %w", err)
+	}
+	return string(normalized), extensions, nil
+}
+
+// ValidateExternalStorageSpec validates the shared external storage contract,
+// including Birdwatcher's Azure credential broker extension.
+func ValidateExternalStorageSpec(source string, spec ExternalSourceSpec) error {
+	if !hasAzureCredentialBrokerSpec(spec) {
+		return externalspec.ValidateExtfsComplete(source, spec.Extfs)
+	}
+	if err := externalspec.ValidateExternalSource(source); err != nil {
+		return err
+	}
+	u, err := url.Parse(source)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(u.Scheme, externalspec.SchemeAzure) ||
+		!strings.EqualFold(spec.CloudProvider, externalspec.CloudProviderAzure) {
+		return fmt.Errorf("Azure credential broker requires scheme=azure and extfs.cloud_provider=azure")
+	}
+	required := []struct {
+		name  string
+		value string
+	}{
+		{name: "access_key_id", value: spec.AccessKeyID},
+		{name: "region", value: spec.Region},
+		{name: "azure_client_id", value: spec.AzureClientID},
+		{name: "azure_tenant_id", value: spec.AzureTenantID},
+		{name: "azure_credential_endpoint", value: spec.AzureCredentialEndpoint},
+	}
+	for _, field := range required {
+		if field.value == "" {
+			return fmt.Errorf("extfs.%s is required for Azure credential broker mode", field.name)
+		}
+	}
+	if spec.AccessKeyValue != "" || spec.RoleARN != "" || spec.UseIAM ||
+		spec.GCPTargetServiceAccount != "" || spec.Anonymous {
+		return fmt.Errorf("Azure credential broker cannot be combined with another credential mode")
+	}
+	endpoint, err := url.Parse(spec.AzureCredentialEndpoint)
+	if err != nil || endpoint.Host == "" ||
+		(endpoint.Scheme != "http" && endpoint.Scheme != "https") {
+		return fmt.Errorf("extfs.azure_credential_endpoint must be a valid HTTP(S) URL")
+	}
+	return nil
+}
+
+// IsLegacyExternalSpec reports whether an external collection predates the
+// self-contained extfs storage configuration. An explicitly empty extfs object
+// is equivalent to an omitted one; Azure broker extensions are self-contained
+// even after their fields are removed from the canonical extfs map.
+func IsLegacyExternalSpec(spec ExternalSourceSpec) bool {
+	return len(spec.Extfs) == 0 && !hasAzureCredentialBrokerSpec(spec)
+}
+
+func hasAzureCredentialBrokerSpec(spec ExternalSourceSpec) bool {
+	return spec.AzureClientID != "" || spec.AzureTenantID != "" || spec.AzureCredentialEndpoint != ""
 }
 
 // ParseExternalSource parses the external_source URI into scheme / host /
@@ -144,7 +295,7 @@ func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 		return ExternalSourceLocation{}, fmt.Errorf("external source %s does not include bucket", raw)
 	}
 	location := ExternalSourceLocation{
-		Scheme:   u.Scheme,
+		Scheme:   strings.ToLower(u.Scheme),
 		Host:     u.Host,
 		Bucket:   parts[0],
 		RootPath: "",
@@ -152,7 +303,7 @@ func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 		Form:     LocationFormMilvus,
 	}
 	if len(parts) > 1 {
-		location.RootPath = path.Clean(filepath.Join(parts[1:]...))
+		location.RootPath = path.Join(parts[1:]...)
 		if location.RootPath == "." {
 			location.RootPath = ""
 		}
@@ -163,9 +314,9 @@ func ParseExternalSource(raw string) (ExternalSourceLocation, error) {
 // ResolveExternalSource applies the two-form URI contract on top of
 // ParseExternalSource. It mirrors milvus-storage's Layer-3 swap decision:
 //
-//	derived := DeriveEndpoint(spec.CloudProvider, spec.Region)
+//	derived := externalspec.DeriveEndpoint(spec.CloudProvider, spec.Region)
 //	if derived != "" && StripURIScheme(derived) != host &&
-//	   !IsCloudEndpointHost(host) {
+//	   !externalspec.IsCloudEndpointHost(host) {
 //	    // AWS form: host is the bucket, endpoint is derived
 //	}
 //
@@ -177,13 +328,18 @@ func ResolveExternalSource(raw string, spec ExternalSourceSpec) (ExternalSourceL
 		return ExternalSourceLocation{}, err
 	}
 
-	derived := DeriveEndpoint(spec.CloudProvider, spec.Region)
-	if derived != "" && StripURIScheme(derived) != location.Host && !IsCloudEndpointHost(location.Host) {
+	derived := externalspec.DeriveEndpoint(spec.CloudProvider, spec.Region)
+	derivedAddress := StripURIScheme(derived)
+	if derivedAddress != "" && !strings.EqualFold(derivedAddress, location.Host) &&
+		!externalspec.IsCloudEndpointHost(location.Host) {
 		// AWS form: host is the bucket, path is the key (may be empty).
 		location.Form = LocationFormAWS
 		location.Bucket = location.Host
-		trimmed := strings.TrimPrefix(strings.TrimSpace(raw), location.Scheme+"://"+location.Host)
-		trimmed = strings.TrimPrefix(trimmed, "/")
+		u, err := url.Parse(raw)
+		if err != nil {
+			return ExternalSourceLocation{}, fmt.Errorf("parse external source: %w", err)
+		}
+		trimmed := strings.TrimPrefix(u.Path, "/")
 		if trimmed != "" {
 			location.RootPath = path.Clean(trimmed)
 			if location.RootPath == "." {
@@ -192,7 +348,7 @@ func ResolveExternalSource(raw string, spec ExternalSourceSpec) (ExternalSourceL
 		} else {
 			location.RootPath = ""
 		}
-		location.Address = derived
+		location.Address = derivedAddress
 	}
 	return location, nil
 }
@@ -205,78 +361,6 @@ func StripURIScheme(addr string) string {
 		}
 	}
 	return addr
-}
-
-// IsCloudEndpointHost reports whether host belongs to a known cloud provider
-// endpoint family (i.e. the URI is Milvus-form regardless of the derived
-// endpoint). Mirrors milvus externalspec.IsCloudEndpointHost.
-func IsCloudEndpointHost(host string) bool {
-	h := strings.ToLower(host)
-	suffixes := []string{
-		".amazonaws.com", ".amazonaws.com.cn",
-		".googleapis.com",
-		".aliyuncs.com",
-		".myqcloud.com",
-		".myhuaweicloud.com",
-		".core.windows.net", ".core.chinacloudapi.cn",
-		".core.usgovcloudapi.net", ".core.cloudapi.de",
-	}
-	for _, s := range suffixes {
-		if strings.HasSuffix(h, s) {
-			return true
-		}
-	}
-	return false
-}
-
-// DeriveEndpoint returns the cloud endpoint for a provider/region pair, or ""
-// when it cannot be derived (empty region, unknown provider). Mirrors milvus
-// externalspec.DeriveEndpoint.
-func DeriveEndpoint(cloudProvider, region string) string {
-	cp := strings.ToLower(cloudProvider)
-	switch cp {
-	case "aws":
-		if region == "" {
-			return ""
-		}
-		if strings.HasPrefix(region, "cn-") {
-			return "https://s3." + region + ".amazonaws.com.cn"
-		}
-		return "https://s3." + region + ".amazonaws.com"
-	case "gcp":
-		return "https://storage.googleapis.com"
-	case "aliyun":
-		if region == "" {
-			return ""
-		}
-		return "https://oss-" + region + ".aliyuncs.com"
-	case "tencent":
-		if region == "" {
-			return ""
-		}
-		return "https://cos." + region + ".myqcloud.com"
-	case "huawei":
-		if region == "" {
-			return ""
-		}
-		return "https://obs." + region + ".myhuaweicloud.com"
-	case "azure":
-		r := strings.ToLower(region)
-		if r == "" {
-			return ""
-		}
-		if strings.HasPrefix(r, "china") {
-			return "core.chinacloudapi.cn"
-		}
-		if strings.HasPrefix(r, "usgov") || strings.HasPrefix(r, "usdod") {
-			return "core.usgovcloudapi.net"
-		}
-		if strings.HasPrefix(r, "germany") {
-			return "core.cloudapi.de"
-		}
-		return "core.windows.net"
-	}
-	return ""
 }
 
 // InferCloudProviderFromScheme infers the cloud provider from the URI scheme.
@@ -292,6 +376,8 @@ func InferCloudProviderFromScheme(scheme string) string {
 		return oss.CloudProviderTencent
 	case "obs":
 		return oss.CloudProviderHuawei
+	case "azure":
+		return oss.CloudProviderAzure
 	default:
 		return ""
 	}
@@ -306,12 +392,17 @@ func NewResolvedExternalObjectStore(
 	spec ExternalSourceSpec,
 	skipBucketCheck bool,
 ) (*oss.ResolvedObjectStore, ExternalSourceLocation, error) {
+	if !IsLegacyExternalSpec(spec) {
+		if err := ValidateExternalStorageSpec(source, spec); err != nil {
+			return nil, ExternalSourceLocation{}, err
+		}
+	}
 	location, err := ResolveExternalSource(source, spec)
 	if err != nil {
 		return nil, ExternalSourceLocation{}, err
 	}
 
-	provider := spec.CloudProvider
+	provider := strings.ToLower(strings.TrimSpace(spec.CloudProvider))
 	if provider == "" {
 		provider = InferCloudProviderFromScheme(location.Scheme)
 	}
@@ -335,31 +426,49 @@ func NewResolvedExternalObjectStore(
 	}
 
 	param := oss.MinioClientParam{
-		Addr:               addr,
-		UseSSL:             useSSL,
-		CloudProvider:      provider,
-		Region:             spec.Region,
-		AK:                 spec.AK,
-		SK:                 spec.SK,
-		UseIAM:             spec.UseIAM,
-		IAMEndpoint:        spec.IAMEndpoint,
-		RoleARN:            spec.RoleARN,
-		RoleSessionName:    spec.RoleSessionName,
-		ExternalID:         spec.ExternalID,
-		LoadFrequency:      spec.LoadFrequency,
-		AliyunRoleAuthMode: spec.AliyunRoleAuthMode,
-		BucketName:         bucket,
-		RootPath:           location.RootPath,
+		Addr:                         addr,
+		UseSSL:                       useSSL,
+		CloudProvider:                provider,
+		Region:                       spec.Region,
+		AK:                           spec.AccessKeyID,
+		SK:                           spec.AccessKeyValue,
+		UseIAM:                       spec.UseIAM,
+		Anonymous:                    spec.Anonymous,
+		IAMEndpoint:                  spec.IAMEndpoint,
+		UseVirtualHost:               spec.UseVirtualHost,
+		RoleARN:                      spec.RoleARN,
+		RoleSessionName:              spec.RoleSessionName,
+		ExternalID:                   spec.ExternalID,
+		LoadFrequency:                spec.LoadFrequency,
+		AliyunRoleAuthMode:           spec.AliyunRoleAuthMode,
+		AzureClientID:                spec.AzureClientID,
+		AzureTenantID:                spec.AzureTenantID,
+		AzureCredentialEndpoint:      spec.AzureCredentialEndpoint,
+		AzureRequestTimeoutMs:        3000,
+		DisableAzureConnectionString: provider == oss.CloudProviderAzure,
+		BucketName:                   bucket,
+		RootPath:                     location.RootPath,
 	}
 	if provider == oss.CloudProviderAliyun && param.RoleARN != "" && param.AliyunRoleAuthMode == "" {
 		param.AliyunRoleAuthMode = "oidc"
 	}
 	// Fallback to IAM chain when no explicit role arn / static key is present.
-	if param.RoleARN == "" && param.AK == "" && param.SK == "" && !spec.Anonymous {
+	if param.RoleARN == "" && param.AK == "" && param.SK == "" && !param.Anonymous {
 		param.UseIAM = true
 	}
 	oss.WithSkipCheckBucket(skipBucketCheck)(&param)
 
+	if provider == oss.CloudProviderAzure {
+		store, err := oss.NewAzureObjectStore(ctx, param)
+		if err != nil {
+			return nil, ExternalSourceLocation{}, err
+		}
+		return &oss.ResolvedObjectStore{
+			Store:      store,
+			BucketName: param.BucketName,
+			RootPath:   param.RootPath,
+		}, location, nil
+	}
 	client, err := oss.NewMinioClient(ctx, param)
 	if err != nil {
 		return nil, ExternalSourceLocation{}, err
@@ -554,36 +663,4 @@ func ResolveExternalObjectKey(location ExternalSourceLocation, externalFile stri
 		return path.Clean(trimmed), nil
 	}
 	return path.Join(location.RootPath, trimmed), nil
-}
-
-func ReadMapString(payload map[string]any, key string) string {
-	value, ok := payload[key]
-	if !ok || value == nil {
-		return ""
-	}
-	switch v := value.(type) {
-	case string:
-		return strings.TrimSpace(v)
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
-}
-
-func ReadMapBool(payload map[string]any, key string) (bool, bool) {
-	value, ok := payload[key]
-	if !ok || value == nil {
-		return false, false
-	}
-	switch v := value.(type) {
-	case bool:
-		return v, true
-	case string:
-		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
-		if err != nil {
-			return false, false
-		}
-		return parsed, true
-	default:
-		return false, false
-	}
 }

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -237,7 +237,7 @@ func ValidateExternalStorageSpec(source string, spec ExternalSourceSpec) error {
 	}
 	if !strings.EqualFold(u.Scheme, externalspec.SchemeAzure) ||
 		!strings.EqualFold(spec.CloudProvider, externalspec.CloudProviderAzure) {
-		return fmt.Errorf("Azure credential broker requires scheme=azure and extfs.cloud_provider=azure")
+		return fmt.Errorf("azure credential broker requires scheme=azure and extfs.cloud_provider=azure")
 	}
 	required := []struct {
 		name  string
@@ -256,7 +256,7 @@ func ValidateExternalStorageSpec(source string, spec ExternalSourceSpec) error {
 	}
 	if spec.AccessKeyValue != "" || spec.RoleARN != "" || spec.UseIAM ||
 		spec.GCPTargetServiceAccount != "" || spec.Anonymous {
-		return fmt.Errorf("Azure credential broker cannot be combined with another credential mode")
+		return fmt.Errorf("azure credential broker cannot be combined with another credential mode")
 	}
 	endpoint, err := url.Parse(spec.AzureCredentialEndpoint)
 	if err != nil || endpoint.Host == "" ||

--- a/states/ossutil/external.go
+++ b/states/ossutil/external.go
@@ -92,7 +92,10 @@ func parseExternalSpec(raw string, validateFormat bool) (ExternalSourceSpec, err
 	}
 	parsed, err := externalspec.ParseExternalSpec(normalized)
 	if err != nil {
-		return ExternalSourceSpec{}, err
+		parsed, err = parseCompatibleExternalSpec(normalized)
+		if err != nil {
+			return ExternalSourceSpec{}, err
+		}
 	}
 	if validateFormat && parsed.Format != "" && parsed.Format != externalspec.FormatParquet {
 		return ExternalSourceSpec{}, fmt.Errorf("external collection format %s is not supported", parsed.Format)
@@ -141,6 +144,43 @@ func parseExternalSpec(raw string, validateFormat bool) (ExternalSourceSpec, err
 		spec.LoadFrequency = loadFrequency
 	}
 	return spec, nil
+}
+
+// parseCompatibleExternalSpec reads persisted metadata that predates or is newer
+// than the pinned Milvus parser. Unknown extfs keys are retained; storage and
+// command-specific validation still runs after parsing.
+func parseCompatibleExternalSpec(raw string) (*externalspec.ExternalSpec, error) {
+	var payload struct {
+		Format string                     `json:"format"`
+		Extfs  map[string]json.RawMessage `json:"extfs"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse external spec: %w", err)
+	}
+	parsed := &externalspec.ExternalSpec{
+		Format: strings.ToLower(strings.TrimSpace(payload.Format)),
+		Extfs:  make(map[string]string, len(payload.Extfs)),
+	}
+	if parsed.Format == "" {
+		parsed.Format = externalspec.FormatParquet
+	}
+	for key, rawValue := range payload.Extfs {
+		var value string
+		if err := json.Unmarshal(rawValue, &value); err != nil {
+			value = string(rawValue)
+		}
+		switch key {
+		case externalspec.ExtfsKeyUseIAM, externalspec.ExtfsKeyUseSSL,
+			externalspec.ExtfsKeyUseVirtualHost, externalspec.ExtfsKeyAnonymous:
+			boolean, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return nil, fmt.Errorf("extfs.%s must be a boolean", key)
+			}
+			value = strconv.FormatBool(boolean)
+		}
+		parsed.Extfs[key] = value
+	}
+	return parsed, nil
 }
 
 type externalSpecExtensions struct {

--- a/states/ossutil/external_test.go
+++ b/states/ossutil/external_test.go
@@ -2,12 +2,34 @@ package ossutil
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/milvus-io/birdwatcher/models"
 	"github.com/milvus-io/birdwatcher/oss"
 	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 )
+
+func TestNewResolvedObjectStoreAzure(t *testing.T) {
+	accountKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", fmt.Sprintf(
+		"DefaultEndpointsProtocol=http;AccountName=test;AccountKey=%s;BlobEndpoint=http://127.0.0.1:1/test;",
+		accountKey,
+	))
+
+	resolved, err := NewResolvedObjectStore(t.Context(), oss.MinioClientParam{
+		CloudProvider: oss.CloudProviderAzure,
+		BucketName:    "container",
+		RootPath:      "root/path",
+	}, oss.WithSkipCheckBucket(true))
+	if err != nil {
+		t.Fatalf("NewResolvedObjectStore() error = %v", err)
+	}
+	if resolved.Store == nil || resolved.BucketName != "container" || resolved.RootPath != "root/path" {
+		t.Fatalf("NewResolvedObjectStore() = %#v", resolved)
+	}
+}
 
 // resolverTestStore is a minimal oss.ObjectStore stub for path-routing tests.
 // It is never opened, only passed through by ManifestPathResolver.
@@ -113,11 +135,11 @@ func TestParseExternalSpecFullKeys(t *testing.T) {
 			"external_id": "ext-123",
 			"access_key_id": "AKIA",
 			"access_key_value": "secret",
-			"use_iam": false,
+			"use_iam": "false",
 			"iam_endpoint": "https://sts.example.com",
 			"bucket_name": "override-bucket",
 			"storage_type": "remote",
-			"use_ssl": true,
+			"use_ssl": "true",
 			"load_frequency": "3600"
 		}
 	}`
@@ -144,8 +166,8 @@ func TestParseExternalSpecFullKeys(t *testing.T) {
 	if spec.ExternalID != "ext-123" {
 		t.Fatalf("unexpected external id: %s", spec.ExternalID)
 	}
-	if spec.AK != "AKIA" || spec.SK != "secret" {
-		t.Fatalf("unexpected access keys: %q/%q", spec.AK, spec.SK)
+	if spec.AccessKeyID != "AKIA" || spec.AccessKeyValue != "secret" {
+		t.Fatalf("unexpected access keys: %q/%q", spec.AccessKeyID, spec.AccessKeyValue)
 	}
 	if spec.UseIAM {
 		t.Fatalf("expected use_iam=false")
@@ -167,6 +189,76 @@ func TestParseExternalSpecFullKeys(t *testing.T) {
 	}
 }
 
+func TestNewResolvedExternalObjectStoreAzureAnonymous(t *testing.T) {
+	spec, err := ParseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"Azure",
+			"anonymous":"true"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("ParseExternalSpec() error = %v", err)
+	}
+	if spec.CloudProvider != oss.CloudProviderAzure {
+		t.Fatalf("cloud provider = %q, want %q", spec.CloudProvider, oss.CloudProviderAzure)
+	}
+
+	resolved, location, err := NewResolvedExternalObjectStore(
+		t.Context(),
+		"azure://account.blob.core.windows.net/container/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("NewResolvedExternalObjectStore() error = %v", err)
+	}
+	if resolved.Store == nil || resolved.BucketName != "container" || resolved.RootPath != "root/path" {
+		t.Fatalf("resolved store = %#v", resolved)
+	}
+	if location.Address != "account.blob.core.windows.net" || location.Bucket != "container" {
+		t.Fatalf("location = %#v", location)
+	}
+}
+
+func TestNewResolvedExternalObjectStoreAzureBroker(t *testing.T) {
+	spec, err := ParseExternalSpec(`{
+		"format":"parquet",
+		"extfs":{
+			"cloud_provider":"azure",
+			"region":"westus3",
+			"access_key_id":"storage-account",
+			"azure_client_id":"client-id",
+			"azure_tenant_id":"tenant-id",
+			"azure_credential_endpoint":"https://broker.example.com/v1/credentials/assume-role",
+			"load_frequency":"3600"
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("ParseExternalSpec() error = %v", err)
+	}
+	if spec.AzureClientID != "client-id" || spec.AzureTenantID != "tenant-id" ||
+		spec.AzureCredentialEndpoint != "https://broker.example.com/v1/credentials/assume-role" {
+		t.Fatalf("Azure broker spec = %#v", spec)
+	}
+
+	resolved, location, err := NewResolvedExternalObjectStore(
+		t.Context(),
+		"azure://core.windows.net/container/root/path",
+		spec,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("NewResolvedExternalObjectStore() error = %v", err)
+	}
+	if resolved.Store == nil || resolved.BucketName != "container" || resolved.RootPath != "root/path" {
+		t.Fatalf("resolved store = %#v", resolved)
+	}
+	if location.Address != "core.windows.net" || location.Bucket != "container" || location.RootPath != "root/path" {
+		t.Fatalf("location = %#v", location)
+	}
+}
+
 func TestParseExternalSpecEmpty(t *testing.T) {
 	spec, err := ParseExternalSpec("")
 	if err != nil {
@@ -174,6 +266,53 @@ func TestParseExternalSpecEmpty(t *testing.T) {
 	}
 	if spec.Format != "" {
 		t.Fatalf("unexpected format: %s", spec.Format)
+	}
+}
+
+func TestIsLegacyExternalSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{
+			name: "omitted extfs",
+			raw:  `{"format":"parquet"}`,
+			want: true,
+		},
+		{
+			name: "empty extfs",
+			raw:  `{"format":"parquet","extfs":{}}`,
+			want: true,
+		},
+		{
+			name: "configured extfs",
+			raw:  `{"format":"parquet","extfs":{"cloud_provider":"aws"}}`,
+			want: false,
+		},
+		{
+			name: "Azure broker extensions",
+			raw: `{
+				"format":"parquet",
+				"extfs":{
+					"azure_client_id":"client-id",
+					"azure_tenant_id":"tenant-id",
+					"azure_credential_endpoint":"https://broker.example.com/credentials"
+				}
+			}`,
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec, err := ParseExternalSpec(test.raw)
+			if err != nil {
+				t.Fatalf("ParseExternalSpec() error = %v", err)
+			}
+			if got := IsLegacyExternalSpec(spec); got != test.want {
+				t.Fatalf("IsLegacyExternalSpec() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 
@@ -269,56 +408,6 @@ func TestInferCloudProviderFromScheme(t *testing.T) {
 	}
 }
 
-func TestDeriveEndpoint(t *testing.T) {
-	tests := []struct {
-		provider string
-		region   string
-		want     string
-	}{
-		{provider: "aws", region: "us-east-1", want: "https://s3.us-east-1.amazonaws.com"},
-		{provider: "aws", region: "cn-north-1", want: "https://s3.cn-north-1.amazonaws.com.cn"},
-		{provider: "aws", region: "", want: ""},
-		{provider: "gcp", region: "", want: "https://storage.googleapis.com"},
-		{provider: "aliyun", region: "cn-hangzhou", want: "https://oss-cn-hangzhou.aliyuncs.com"},
-		{provider: "aliyun", region: "", want: ""},
-		{provider: "tencent", region: "ap-guangzhou", want: "https://cos.ap-guangzhou.myqcloud.com"},
-		{provider: "huawei", region: "cn-north-4", want: "https://obs.cn-north-4.myhuaweicloud.com"},
-		{provider: "azure", region: "public", want: "core.windows.net"},
-		{provider: "azure", region: "china", want: "core.chinacloudapi.cn"},
-		{provider: "azure", region: "", want: ""},
-		{provider: "unknown", region: "us-east-1", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.provider+"/"+tt.region, func(t *testing.T) {
-			if got := DeriveEndpoint(tt.provider, tt.region); got != tt.want {
-				t.Fatalf("DeriveEndpoint(%q, %q) = %q, want %q", tt.provider, tt.region, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestIsCloudEndpointHost(t *testing.T) {
-	tests := []struct {
-		host string
-		want bool
-	}{
-		{host: "s3.us-east-1.amazonaws.com", want: true},
-		{host: "storage.googleapis.com", want: true},
-		{host: "oss-cn-hangzhou.aliyuncs.com", want: true},
-		{host: "cos.ap-guangzhou.myqcloud.com", want: true},
-		{host: "myacct.core.windows.net", want: true},
-		{host: "my-bucket", want: false},
-		{host: "localhost:9000", want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			if got := IsCloudEndpointHost(tt.host); got != tt.want {
-				t.Fatalf("IsCloudEndpointHost(%q) = %v, want %v", tt.host, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestResolveExternalSourceAWSForm(t *testing.T) {
 	// s3://bucket/key with AWS cloud_provider + region: host is the bucket,
 	// endpoint is derived.
@@ -338,7 +427,7 @@ func TestResolveExternalSourceAWSForm(t *testing.T) {
 	if location.RootPath != "root/file" {
 		t.Fatalf("unexpected root path: %s", location.RootPath)
 	}
-	if location.Address != "https://s3.us-east-1.amazonaws.com" {
+	if location.Address != "s3.us-east-1.amazonaws.com" {
 		t.Fatalf("unexpected address: %s", location.Address)
 	}
 }
@@ -386,7 +475,7 @@ func TestResolveExternalObjectKeyAWSForm(t *testing.T) {
 		Host:     "my-bucket",
 		Bucket:   "my-bucket",
 		RootPath: "root",
-		Address:  "https://s3.us-east-1.amazonaws.com",
+		Address:  "s3.us-east-1.amazonaws.com",
 		Form:     LocationFormAWS,
 	}
 

--- a/states/ossutil/external_test.go
+++ b/states/ossutil/external_test.go
@@ -231,7 +231,9 @@ func TestNewResolvedExternalObjectStoreAzureBroker(t *testing.T) {
 			"azure_client_id":"client-id",
 			"azure_tenant_id":"tenant-id",
 			"azure_credential_endpoint":"https://broker.example.com/v1/credentials/assume-role",
-			"load_frequency":"3600"
+			"load_frequency":"3600",
+			"use_ssl":true,
+			"future_option":"enabled"
 		}
 	}`)
 	if err != nil {
@@ -516,5 +518,59 @@ func TestResolveExternalObjectKeyAWSForm(t *testing.T) {
 				t.Fatalf("ResolveExternalObjectKey() = %s, want %s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseExternalSpecCompatibleMetadata(t *testing.T) {
+	for _, raw := range []string{
+		`{"format":"parquet","extfs":{"use_iam":true,"use_ssl":false,"anonymous":false,"use_virtual_host":true,"load_frequency":3600}}`,
+		`{"format":"PARQUET","extfs":{"use_iam":"TRUE","use_ssl":"false","anonymous":"false","use_virtual_host":"true","load_frequency":"3600"}}`,
+	} {
+		spec, err := ParseExternalSpec(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if spec.Format != "parquet" || !spec.UseIAM || spec.Anonymous || spec.UseSSL == nil || *spec.UseSSL ||
+			spec.UseVirtualHost == nil || !*spec.UseVirtualHost || spec.LoadFrequency != 3600 {
+			t.Fatalf("incorrect normalized properties: %+v", spec)
+		}
+		if spec.Extfs["use_iam"] != "true" || spec.Extfs["use_ssl"] != "false" {
+			t.Fatalf("boolean properties were not normalized: %v", spec.Extfs)
+		}
+	}
+}
+
+func TestParseExternalSpecUnknownKeys(t *testing.T) {
+	spec, err := ParseExternalSpec(`{"extfs":{"cloud_provider":"aws","region":"us-east-1","use_iam":true,"future_option":"enabled","future_object":{"enabled":true}}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Format != "parquet" || spec.CloudProvider != "aws" || spec.Region != "us-east-1" ||
+		spec.Extfs["future_option"] != "enabled" || spec.Extfs["future_object"] != `{"enabled":true}` {
+		t.Fatalf("metadata was not preserved: %+v", spec)
+	}
+	if IsLegacyExternalSpec(spec) {
+		t.Fatal("configured extfs must not fall back to local storage credentials")
+	}
+	if err := ValidateExternalStorageSpec("s3://bucket/data", spec); err != nil {
+		t.Fatalf("unknown keys blocked storage validation: %v", err)
+	}
+}
+
+func TestParseExternalSpecCompatibilityValidation(t *testing.T) {
+	for _, raw := range []string{
+		`{"extfs":[]}`,
+		`{"format":12}`,
+		`{"extfs":{"use_ssl":"invalid"}}`,
+		`{"format":"lance-table","extfs":{"future_option":true}}`,
+		`{"extfs":{"load_frequency":-1,"future_option":true}}`,
+	} {
+		if _, err := ParseExternalSpec(raw); err == nil {
+			t.Fatalf("expected error for %s", raw)
+		}
+	}
+	spec, err := ParseExternalSpecLoose(`{"format":"future-format","extfs":{"future_option":true}}`)
+	if err != nil || spec.Format != "future-format" || spec.Extfs["future_option"] != "true" {
+		t.Fatalf("loose parsing failed: %+v, %v", spec, err)
 	}
 }

--- a/states/ossutil/minio_cfg.go
+++ b/states/ossutil/minio_cfg.go
@@ -94,6 +94,17 @@ func NewResolvedObjectStore(ctx context.Context, mp oss.MinioClientParam, params
 			p(&mp)
 		}
 	}
+	if strings.EqualFold(mp.CloudProvider, oss.CloudProviderAzure) {
+		store, err := oss.NewAzureObjectStore(ctx, mp)
+		if err != nil {
+			return nil, err
+		}
+		return &oss.ResolvedObjectStore{
+			Store:      store,
+			BucketName: mp.BucketName,
+			RootPath:   mp.RootPath,
+		}, nil
+	}
 	m, err := oss.NewMinioClient(ctx, mp)
 	if err != nil {
 		return nil, err

--- a/states/scan_binlog.go
+++ b/states/scan_binlog.go
@@ -25,30 +25,39 @@ import (
 )
 
 type ScanBinlogParams struct {
-	framework.ParamBase `use:"scan-binlog" desc:"scan binlog to check data"`
-	CollectionID        int64    `name:"collection" default:"0"`
-	PartitionID         int64    `name:"partition" default:"0"`
-	SegmentID           int64    `name:"segment" default:"0"`
-	Fields              []string `name:"fields"`
-	Expr                string   `name:"expr"`
-	MinioAddress        string   `name:"minioAddr"`
-	SkipBucketCheck     bool     `name:"skipBucketCheck" default:"false" desc:"skip bucket exist check due to permission issue"`
-	Action              string   `name:"action" default:"count"`
-	IgnoreDelete        bool     `name:"ignoreDelete" default:"false" desc:"ignore delete logic"`
-	IncludeUnhealthy    bool     `name:"includeUnhealthy" default:"false" desc:"also check dropped segments"`
-	WorkerNum           int64    `name:"workerNum" default:"4" desc:"worker num"`
-	OutputLimit         int64    `name:"outputLimit" default:"10" desc:"output limit"`
+	framework.DataSetParam `use:"scan-binlog" desc:"scan binlog to check data"`
+	CollectionID           int64    `name:"collection" default:"0"`
+	PartitionID            int64    `name:"partition" default:"0"`
+	SegmentID              int64    `name:"segment" default:"0"`
+	Fields                 []string `name:"fields"`
+	Expr                   string   `name:"expr"`
+	MinioAddress           string   `name:"minioAddr"`
+	SkipBucketCheck        bool     `name:"skipBucketCheck" default:"false" desc:"skip bucket exist check due to permission issue"`
+	Action                 string   `name:"action" default:"count" desc:"action to execute: count, locate, dedup, or detect-vector-nulls" values:"count,locate,dedup,detect-vector-nulls"`
+	IgnoreDelete           bool     `name:"ignoreDelete" default:"false" desc:"ignore delete logic"`
+	IncludeUnhealthy       bool     `name:"includeUnhealthy" default:"false" desc:"also check dropped segments"`
+	WorkerNum              int64    `name:"workerNum" default:"4" desc:"worker num"`
+	BatchSize              int64    `name:"batchSize" default:"1024" desc:"Arrow record batch size for detect-vector-nulls action"`
+	Exact                  bool     `name:"exact" default:"false" desc:"read every vector row and validate vector length; otherwise null-free Parquet row groups are inferred from metadata"`
+	OutputLimit            int64    `name:"outputLimit" default:"10" desc:"output limit"`
 }
 
-func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogParams) error {
+func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogParams) (*framework.PresetResultSet, error) {
 	collection, err := common.GetCollectionByIDVersion(ctx, s.client, s.basePath, p.CollectionID)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	if strings.EqualFold(p.Action, "detect-vector-nulls") {
+		report, err := s.scanExternalVectorNullSegments(ctx, collection, p)
+		if err != nil {
+			return nil, err
+		}
+		return framework.NewPresetResultSet(report, p.GetFormat()), nil
 	}
 	fmt.Println("=== Checking collection schema ===")
 	pkField, ok := collection.GetPKField()
 	if !ok {
-		return errors.New("pk field not found")
+		return nil, errors.New("pk field not found")
 	}
 	fmt.Printf("PK Field [%d] %s\n", pkField.FieldID, pkField.Name)
 
@@ -83,7 +92,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 			(p.IncludeUnhealthy || s.State != commonpb.SegmentState_Dropped)
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	params := []oss.MinioConnectParam{oss.WithSkipCheckBucket(p.SkipBucketCheck)}
@@ -94,7 +103,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	resolvedStore, err := s.GetObjectStore(ctx, params...)
 	if err != nil {
 		fmt.Println("Failed to create client,", err.Error())
-		return err
+		return nil, err
 	}
 	rootPath := resolvedStore.RootPath
 
@@ -109,7 +118,7 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 		externalStore, externalLocation, err = ossutil.NewResolvedExternalObjectStoreFromCollection(ctx, collection, p.SkipBucketCheck)
 		if err != nil {
 			fmt.Println("Failed to create external store,", err.Error())
-			return err
+			return nil, err
 		}
 		fmt.Printf("External Source: %s\n", collection.GetProto().GetSchema().GetExternalSource())
 	}
@@ -126,14 +135,14 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	case "dedup":
 		scanTask = tasks.NewDedupTask(p.OutputLimit, pkField)
 	default:
-		return errors.Newf("unknown action: %s", p.Action)
+		return nil, errors.Newf("unknown action: %s", p.Action)
 	}
 
 	var exprFilter *storage.ExprFilter
 	if p.Expr != "" {
 		exprFilter, err = storage.NewExprFilter(fields, p.Expr)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -269,10 +278,10 @@ func (s *InstanceState) ScanBinlogCommand(ctx context.Context, p *ScanBinlogPara
 	wg.Wait()
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	scanTask.Summary()
 
-	return nil
+	return nil, nil
 }

--- a/storage/binlog/v1/index_reader.go
+++ b/storage/binlog/v1/index_reader.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/samber/lo"
 
+	storagecommon "github.com/milvus-io/birdwatcher/storage/common"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 type IndexReader struct{}
 
-func NewIndexReader(f *os.File) (*IndexReader, DescriptorEvent, error) {
+func NewIndexReader(f storagecommon.ReadSeeker) (*IndexReader, DescriptorEvent, error) {
 	reader := &IndexReader{}
 	var de DescriptorEvent
 	var err error
@@ -30,31 +30,20 @@ func NewIndexReader(f *os.File) (*IndexReader, DescriptorEvent, error) {
 	return reader, de, err
 }
 
-func (reader *IndexReader) NextEventReader(f *os.File, dataType schemapb.DataType) ([][]byte, error) {
-	eventReader := NewEventReader()
-	header, err := eventReader.ReadHeader(f)
+func (reader *IndexReader) NextEventReader(f io.Reader, dataType schemapb.DataType) ([][]byte, error) {
+	data, err := readIndexEventPayload(f)
 	if err != nil {
 		return nil, err
 	}
-	ifed, err := ReadIndexFileEventData(f)
-	if err != nil {
-		return nil, err
-	}
-
-	next := header.EventLength - header.GetMemoryUsageInBytes() - ifed.GetEventDataFixPartSize()
-	data := make([]byte, next)
-	io.ReadFull(f, data)
 
 	pr, err := NewParquetPayloadReader(dataType, data)
 	if err != nil {
-		fmt.Println(err.Error())
 		return nil, err
 	}
 	switch dataType {
 	case schemapb.DataType_String:
 		result, err := pr.GetStringFromPayload(0)
 		if err != nil {
-			fmt.Println(err.Error())
 			return nil, err
 		}
 		return lo.Map(result, func(data string, _ int) []byte {
@@ -63,10 +52,40 @@ func (reader *IndexReader) NextEventReader(f *os.File, dataType schemapb.DataTyp
 	case schemapb.DataType_Int8:
 		result, err := pr.GetBytesFromPayload(0)
 		if err != nil {
-			fmt.Println(err.Error())
 			return nil, err
 		}
 		return [][]byte{result}, nil
 	}
 	return nil, errors.New("unexpected data type")
+}
+
+// NextRawEventReader returns a non-encoded index payload. Milvus stores index
+// blobs directly in the event payload when the descriptor data type is None.
+func (reader *IndexReader) NextRawEventReader(f io.Reader) ([]byte, error) {
+	return readIndexEventPayload(f)
+}
+
+func readIndexEventPayload(f io.Reader) ([]byte, error) {
+	eventReader := NewEventReader()
+	header, err := eventReader.ReadHeader(f)
+	if err != nil {
+		return nil, err
+	}
+	if header.TypeCode != IndexFileEventType {
+		return nil, fmt.Errorf("unexpected index event type %d", header.TypeCode)
+	}
+	ifed, err := ReadIndexFileEventData(f)
+	if err != nil {
+		return nil, err
+	}
+
+	next := header.EventLength - header.GetMemoryUsageInBytes() - ifed.GetEventDataFixPartSize()
+	if next < 0 {
+		return nil, fmt.Errorf("invalid index event length %d", header.EventLength)
+	}
+	data := make([]byte, next)
+	if _, err := io.ReadFull(f, data); err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/storage/binlog/v1/index_reader_test.go
+++ b/storage/binlog/v1/index_reader_test.go
@@ -1,0 +1,73 @@
+package binlogv1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func TestIndexReaderReadsRawPayload(t *testing.T) {
+	payload := []byte{1, 2, 3, 4, 5}
+	file := buildRawIndexFile(t, payload)
+	readerAtEvent := bytes.NewReader(file)
+
+	reader, descriptor, err := NewIndexReader(readerAtEvent)
+	require.NoError(t, err)
+	require.Equal(t, schemapb.DataType_None, descriptor.PayloadDataType)
+
+	actual, err := reader.NextRawEventReader(readerAtEvent)
+	require.NoError(t, err)
+	require.Equal(t, payload, actual)
+}
+
+func TestIndexReaderRejectsTruncatedRawPayload(t *testing.T) {
+	payload := []byte{1, 2, 3, 4, 5}
+	file := buildRawIndexFile(t, payload)
+	offset := descriptorFileOffset(t, file)
+
+	_, err := (&IndexReader{}).NextRawEventReader(bytes.NewReader(file[offset : len(file)-1]))
+	require.Error(t, err)
+}
+
+func buildRawIndexFile(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	descriptorData := newDescriptorEventData()
+	descriptorData.PayloadDataType = schemapb.DataType_None
+	descriptorData.Extras[originalSizeKey] = "5"
+	require.NoError(t, descriptorData.FinishExtra())
+
+	descriptorHeader := newDescriptorEventHeader()
+	descriptorHeader.EventLength = descriptorHeader.GetMemoryUsageInBytes() + descriptorData.GetMemoryUsageInBytes()
+	descriptorHeader.NextPosition = int32(binary.Size(MagicNumberV1)) + descriptorHeader.EventLength
+
+	indexData := newIndexFileEventData()
+	indexData.SetEventTimestamp(1, 1)
+	indexHeader := newEventHeader(IndexFileEventType)
+	indexHeader.EventLength = indexHeader.GetMemoryUsageInBytes() + indexData.GetEventDataFixPartSize() + int32(len(payload))
+	indexHeader.NextPosition = descriptorHeader.NextPosition + indexHeader.EventLength
+
+	var output bytes.Buffer
+	require.NoError(t, binary.Write(&output, commonEndian, MagicNumberV1))
+	require.NoError(t, descriptorHeader.Write(&output))
+	require.NoError(t, descriptorData.Write(&output))
+	require.NoError(t, indexHeader.Write(&output))
+	require.NoError(t, indexData.WriteEventData(&output))
+	_, err := output.Write(payload)
+	require.NoError(t, err)
+	return output.Bytes()
+}
+
+func descriptorFileOffset(t *testing.T, file []byte) int {
+	t.Helper()
+	reader := bytes.NewReader(file)
+	_, _, err := NewIndexReader(reader)
+	require.NoError(t, err)
+	offset, err := reader.Seek(0, 1)
+	require.NoError(t, err)
+	return int(offset)
+}


### PR DESCRIPTION
issue: #538

## What changed

- Add `inspect-vector-index` to compare logical segment rows with vector-index valid rows and optionally print only mismatches.
- Add the `detect-vector-nulls` scan action for an external vector field, with optional segment filtering and per-object counts for row-null, full-null, partial-null, and invalid-length values.
- Support Parquet and Lance external sources, including Azure credential-broker access.
- Group Lance fragment ranges by dataset, reuse reader metadata, and project only the requested vector column while preserving per-object output.

## Why

Nullable vectors can make an external collection index contain fewer valid rows than the segment logical row count. Birdwatcher needs a read-only way to locate the affected segments and trace the mismatch back to the exact external source objects.

## Behavior boundaries

- The commands are diagnostic only and do not modify Milvus metadata, source data, or index artifacts.
- External scans validate the collection and vector field before reading source objects.
- Lance support requires a binary built with the `LANCE` build tag and the compatible `milvus-storage` runtime library.

## Validation

- `go build ./...`
- `go vet ./states ./states/ossutil`
- Linux/amd64 Lance build: `go build -mod=readonly -tags LANCE ./...`
- Linux/amd64 Lance vet: `go vet -mod=readonly -tags LANCE ./states`
- `git diff --check`
- `go test` not run locally because the required reset would interrupt a Milvus instance owned by another worktree.