### PR TITLE
fix: skip etcd scan when rootPath is provided

### DIFF
--- a/framework/command.go
+++ b/framework/command.go
@@ -109,6 +109,9 @@ func parseMethodFrom(host State, receiver any, mt reflect.Method) (*cobra.Comman
 			fmt.Println(err.Error())
 			return
 		}
+		if fsa, ok := cp.(FlagSetAware); ok {
+			fsa.SetFlagSet(cmd.Flags())
+		}
 		ctx, cancel := host.Ctx()
 		defer cancel()
 

--- a/framework/param.go
+++ b/framework/param.go
@@ -1,9 +1,20 @@
 package framework
 
+import (
+	"github.com/spf13/pflag"
+)
+
 // CmdParam is the interface definition for command parameter.
 type CmdParam interface {
 	ParseArgs(args []string) error
 	Desc() (string, string)
+}
+
+// FlagSetAware is an optional interface for CmdParam implementations that need
+// access to the parsed pflag.FlagSet, e.g. to detect whether a flag was
+// explicitly set by the user.
+type FlagSetAware interface {
+	SetFlagSet(fs *pflag.FlagSet)
 }
 
 // ParamBase implmenet CmdParam when empty args parser.

--- a/states/etcd_connect.go
+++ b/states/etcd_connect.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/spf13/pflag"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/txnkv"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -102,6 +103,7 @@ func (app *ApplicationState) readEnv(cp *ConnectParams) {
 	}
 	if cp.RootPath == "by-dev" && os.Getenv("MILVUS_ROOT_PATH") != "" {
 		cp.RootPath = os.Getenv("MILVUS_ROOT_PATH")
+		cp.rootPathFromEnv = true
 		fmt.Println("using env MILVUS_ROOT_PATH,", cp.RootPath)
 	}
 }
@@ -142,7 +144,7 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 
 	cli := kv.NewEtcdKV(etcdCli)
 
-	if cp.Auto {
+	if cp.Auto && !cp.rootPathProvided() {
 		candidates, err := findMilvusInstance(ctx, cli)
 		if err != nil {
 			return err
@@ -156,6 +158,8 @@ func (app *ApplicationState) connectEtcd(ctx context.Context, cp *ConnectParams)
 			fmt.Println("failed to find rootPath candidate")
 			return nil
 		}
+	} else if cp.Auto {
+		fmt.Fprintln(os.Stderr, "rootPath provided explicitly, skip auto detection")
 	}
 
 	kvState := getKVConnectedState(app.core, cli, cp.EtcdAddr, app.config, app.extensions, app.objectStoreProvider)
@@ -207,6 +211,26 @@ type ConnectParams struct {
 	TiKVAddr      string `name:"tikv" default:"127.0.0.1:2389" desc:"the tikv endpoint to connect"`
 
 	Auto bool `name:"auto" default:"false" desc:"auto detect rootPath if possible"`
+
+	// unexported runtime state
+	flagSet         *pflag.FlagSet
+	rootPathFromEnv bool
+}
+
+// SetFlagSet implements framework.FlagSetAware to keep the parsed flagset,
+// enabling detection of whether rootPath was explicitly provided by the user.
+func (cp *ConnectParams) SetFlagSet(fs *pflag.FlagSet) {
+	cp.flagSet = fs
+}
+
+// rootPathProvided reports whether the user explicitly provided a rootPath via
+// flag or environment variable; when so, auto detection should be skipped to
+// avoid scanning the whole etcd keyspace.
+func (cp *ConnectParams) rootPathProvided() bool {
+	if cp.rootPathFromEnv {
+		return true
+	}
+	return cp.flagSet != nil && cp.flagSet.Changed("rootPath")
 }
 
 func (app *ApplicationState) getTLSConfig(cp *ConnectParams) (*tls.Config, error) {

--- a/states/etcd_connect_export_test.go
+++ b/states/etcd_connect_export_test.go
@@ -3,6 +3,7 @@ package states
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/birdwatcher/configs"
@@ -33,4 +34,34 @@ func TestExportedStateTags(t *testing.T) {
 	require.Equal(t, "tikv", TiKVTag)
 	require.Equal(t, "pulsar", PulsarTag)
 	require.Equal(t, "oss", OSSTag)
+}
+
+func TestConnectParamsRootPathProvided(t *testing.T) {
+	t.Run("flag not set", func(t *testing.T) {
+		cp := &ConnectParams{}
+		fs := pflag.NewFlagSet("connect", pflag.ContinueOnError)
+		fs.String("rootPath", "by-dev", "")
+		require.NoError(t, fs.Parse(nil))
+		cp.SetFlagSet(fs)
+		require.False(t, cp.rootPathProvided())
+	})
+
+	t.Run("flag set explicitly", func(t *testing.T) {
+		cp := &ConnectParams{}
+		fs := pflag.NewFlagSet("connect", pflag.ContinueOnError)
+		fs.String("rootPath", "by-dev", "")
+		require.NoError(t, fs.Parse([]string{"--rootPath", "tenant-a"}))
+		cp.SetFlagSet(fs)
+		require.True(t, cp.rootPathProvided())
+	})
+
+	t.Run("env provided", func(t *testing.T) {
+		cp := &ConnectParams{rootPathFromEnv: true}
+		require.True(t, cp.rootPathProvided())
+	})
+
+	t.Run("no flagset", func(t *testing.T) {
+		cp := &ConnectParams{}
+		require.False(t, cp.rootPathProvided())
+	})
 }


### PR DESCRIPTION
connect --auto always ran findMilvusInstance, scanning the entire etcd keyspace even when rootPath was already given via --rootPath or the MILVUS_ROOT_PATH env var. On a shared multi-tenant etcd with tens of millions of keys each limit-1 Range request walks the whole in-memory index while holding RLock, stalling writes for every tenant.

Short-circuit auto-detection whenever the user explicitly provides a rootPath. A new optional FlagSetAware interface plumbs the parsed pflag.FlagSet into command params so ConnectParams can detect whether the rootPath flag was actually set.